### PR TITLE
Get rid of Pavols custom version sorting. It fails for certain distros

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,16 +82,3 @@ module ApplicationHelper
 
 
 end
-
-module Enumerable
-  def version_sort
-    sort_by { |key,val|
-      key.gsub(/_SP/, '.') \
-        .gsub(/_Factory/, '_100') \
-        .gsub(/_Tumbleweed/, '_99') \
-        .gsub(/_Snapshot/, '_98') \
-        .split(/_/) \
-        .map { |v| v =~ /\A\d+(\.\d+)?\z/ ? -(v.to_f) : v.downcase }
-    }
-  end
-end

--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -73,7 +73,7 @@ end
   <p class="soo_line" id="soo_section_toggle_ymp"><%= _("Install using One Click Install") %><span></span></p>
   <div id="soo_section_ymp">
   
-    <% @data.select {|k,v| v.has_key?(:ymp)}.version_sort.each do |k,v| %>
+    <% @data.select {|k,v| v.has_key?(:ymp)}.sort.reverse.each do |k,v| %>
       <a class="soo_ymplink soo_distro soo_distro_<%= v[:flavor] %> soo_distro_<%= k %>" href="<%= v[:ymp] %>"><%= k.gsub('_', '&nbsp;') %></a>
     <% end %>
   </div>
@@ -82,7 +82,7 @@ end
 <div id="soo_repo" class="soo_box">
   <p class="soo_line" id="soo_section_toggle_repo"><%= _("Add repository and install manually") %><span></span></p>
   <div id="soo_section_repo">
-    <% @data.select {|k,v| v.has_key?(:repo)}.version_sort.each do |k,v| %>
+    <% @data.select {|k,v| v.has_key?(:repo)}.sort.reverse.each do |k,v| %>
       <div class="soo_repoinfo soo_distro soo_distro_<%= v[:flavor] %> soo_distro_<%= k %>">
         <p><%= _("For <strong>%s</strong> run the following as <strong>root</strong>:") % k.gsub('_', '&nbsp;') %></p>
         <pre><%=
@@ -123,7 +123,7 @@ apt-key add - < Release.key  </pre>
   <p class="soo_line" id="soo_section_toggle_pkg"><%= _("Grab binary packages directly") %><span></span></p>
   <div id="soo_section_pkg">
     <table>
-      <% @data.select {|k,v| v.has_key?(:package)}.version_sort.each do |k,v| %>
+      <% @data.select {|k,v| v.has_key?(:package)}.sort.reverse.each do |k,v| %>
         <tr class="soo_pkginfo soo_distro soo_distro_<%= v[:flavor] %> soo_distro_<%= k %>">
           <td><%= _("Packages for %s:") % ["<strong>" + k.gsub('_', '&nbsp;') + "</strong>"] %></td>
           <td><ul>


### PR DESCRIPTION
With distros that start with the same string but don't end with the same type (CentOS-5/CentOS-CentOS6) this sorting fails. As the distros are user input the sorting shouldn't rely on specific formatting. Just switch to reverse alphabetical sorting produces equally good results for all cases.
