### PR TITLE
Wrong Content-Type when serving download.json as JSONP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,7 +93,7 @@ class ApplicationController < ActionController::Base
         json
       end
     end
-    render({:content_type => :js, :body => response}.merge(options))
+    render({:content_type => "application/javascript", :body => response}.merge(options))
   end
 
   def required_parameters(*parameters)


### PR DESCRIPTION
I try to load the JSONP through JavaScript, but it fails. Chrome gives an error:
> Refused to execute script from 'http://software.opensuse.org/download.json?project=home:kamilprusko&package=gnome-pomodoro&callback=_loadJSONP_callback0' because its MIME type ('js') is not executable, and strict MIME type checking is enabled.

It fails because the current Content-Type is "js" and for JSONP it should be "application/javascript".