### PR TITLE
Fetch appdata directly from tumbleweed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,7 +141,7 @@ class ApplicationController < ActionController::Base
   # TODO: atm obs only offers appdata for Factory
   def prepare_appdata
     @appdata =  Rails.cache.fetch("appdata", :expires_in => 12.hours) do
-        Appdata.get "factory"
+        Appdata.get "tumbleweed"
     end
   end
 

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -32,9 +32,9 @@ class Appdata
 
 
   # Get the appdata xml for a distribution
-  def self.get_distribution dist="factory", flavour="oss"
-    if dist == "factory"
-      appdata_url = "http://download.opensuse.org/factory/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
+  def self.get_distribution dist="tumbleweed", flavour="oss"
+    if dist == "tumbleweed"
+      appdata_url = "http://download.opensuse.org/tumbleweed/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
     else
       appdata_url = "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
     end

--- a/lib/tasks/fill_search_cache.rake
+++ b/lib/tasks/fill_search_cache.rake
@@ -1,7 +1,7 @@
 
 desc "Fill cache with app data from Factory"
 task(:fill_search_cache => :environment) do
-  appdata = Appdata.get "factory"
+  appdata = Appdata.get "tumbleweed"
   pkg_list =appdata[:apps].map{|p| p[:pkgname]}.uniq
   puts "Caching data for #{pkg_list.size} apps"
   pkg_list.each_with_index do |pkg, number|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,8 +23,7 @@ class ActiveSupport::TestCase
   setup do
     # stub OBS using WebMock
     stub_remote_file("api.opensuse.org/public/distributions?", "distributions.xml")
-    stub_remote_file("download.opensuse.org/factory/repo/oss/suse/setup/descr/appdata.xml.gz?", "appdata.xml.gz")
-#    stub_remote_file("download.opensuse.org/factory/repo/non-oss/suse/setup/descr/appdata.xml.gz?", "appdata-non-oss.xml.gz")
+    stub_remote_file("download.opensuse.org/tumbleweed/repo/oss/suse/setup/descr/appdata.xml.gz?", "appdata.xml.gz")
     stub_remote_file("api.opensuse.org/search/published/binary/id?match=@name%20=%20'pidgin'%20", "pidgin.xml")
     stub_remote_file("api.opensuse.org/published/openSUSE:13.1/standard/i586/pidgin-2.10.7-4.1.3.i586.rpm?view=fileinfo", "pidgin-fileinfo.xml")
     stub_request(:get, "https://test:test@api.opensuse.org/source/openSUSE:13.1/_attribute/OBS:QualityCategory").to_return(body: "<attributes/>")


### PR DESCRIPTION
The previously used factory is redirecting to tumbleweed anyway. Which
actually failed on my dev system.