### PR TITLE
Fetch screenshots from appdata.xml URLs instead of Debian

### DIFF
--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -68,7 +68,7 @@ module PackageHelper
     when /^openstack-/i
       screenshot_thumb = image_path "default-screenshots/openstack.png"
     else
-      screenshot_thumb = url_for :controller => :package, :action => :thumbnail, :package => pkgname
+      screenshot_thumb = image_path "default-screenshots/no_screenshot_opensuse.png"
     end
     screenshot_thumb
   end

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -17,17 +17,17 @@ class Appdata
   def self.add_appdata data, xml
     data[:apps] = Array.new unless data[:apps]
     data[:categories] = Array.new unless data[:categories]
-      xml.xpath("/applications/application").each do |app|
+      xml.xpath("/components/component").each do |app|
       appdata = Hash.new
       # Filter translated versions of name and summary out
       appdata[:name] = app.xpath('name[not(@xml:lang)]').text
       appdata[:summary] = app.xpath('summary[not(@xml:lang)]').text
       appdata[:pkgname] = app.xpath('pkgname').text
-      appdata[:categories] = app.xpath('appcategories/appcategory').map{|c| c.text}.reject{|c| c.match(/^X-/)}.uniq
+      appdata[:categories] = app.xpath('categories/category').map{|c| c.text}.reject{|c| c.match(/^X-/)}.uniq
       appdata[:homepage] = app.xpath('url').text
       data[:apps] << appdata
     end
-    data[:categories] += xml.xpath("/applications/application/appcategories/appcategory").
+    data[:categories] += xml.xpath("/components/component/categories/category").
       map{|cat| cat.text}.reject{|c| c.match(/^X-/)}.uniq
     data
   end

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -25,6 +25,7 @@ class Appdata
       appdata[:pkgname] = app.xpath('pkgname').text
       appdata[:categories] = app.xpath('categories/category').map{|c| c.text}.reject{|c| c.match(/^X-/)}.uniq
       appdata[:homepage] = app.xpath('url').text
+      appdata[:screenshots] = app.xpath('screenshots/screenshot/image').map{|s| s.text}
       data[:apps] << appdata
     end
     data[:categories] += xml.xpath("/components/component/categories/category").

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
           <a href="http://en.opensuse.org/Portal:Project">About openSUSE</a> |
           <a href="http://en.opensuse.org/Terms_of_site">Legal information</a> |
           <a href="mailto:admin@opensuse.org">Feedback</a> |
-          Screenshots from <a href="http://screenshots.debian.net/">screenshots.debian.net</a>
+          Source code available at <a href="https://github.com/openSUSE/software-o-o/">GitHub</a>
         </p>
       </div>
     </div>

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -156,7 +156,7 @@
 
           <div class="app-screenshot">
             <a title="Screenshot of <%= @pkgname %>" rel="lightbox" href="<%= @screenshot %>">
-              <img src="<%= screenshot_thumb_url( @pkgname ) %>" alt="<%= @pkgname %>" />
+              <img src="<%= @thumbnail %>" alt="<%= @pkgname %>" />
             </a>
           </div>
 

--- a/app/views/search/_find_results.html.erb
+++ b/app/views/search/_find_results.html.erb
@@ -37,6 +37,8 @@
         appdata_pkg = @appdata[:apps].select{|a| a[:pkgname] == package}
         package_name = package
         package_name = appdata_pkg.first[:name] unless ( appdata_pkg.blank? || appdata_pkg.first[:name].blank? )
+        thumb_url = screenshot_thumb_url( package )
+        thumb_url = appdata_pkg.first[:screenshots].first unless ( appdata_pkg.blank? || appdata_pkg.first[:screenshots].blank? )
       %>
 
         <% if idx % 2 == 0 %>
@@ -47,7 +49,7 @@
 
           <div class="app-screenshot-search">
             <a href="<%= url_for :controller => :package, :action => :show, :package => package %>">
-              <img src="<%= screenshot_thumb_url( package ) %>" alt="<%= package %>" />
+              <img src="<%= thumb_url %>" alt="<%= package %>" />
             </a>
           </div>
           <div class="search-result-txt">


### PR DESCRIPTION
Depends on https://github.com/openSUSE/software-o-o/pull/78.

before:
![image](https://cloud.githubusercontent.com/assets/756669/16965314/e10faec6-4dff-11e6-8c92-e988149ac3cd.png)

after:
![image](https://cloud.githubusercontent.com/assets/756669/16965320/e9b23f12-4dff-11e6-854f-c2a3ac811c38.png)

This has several benefits:
* AppData is controlled by upstream and us not some thirdparty service.
* The same screenshots are seen in the GNOME/KDE software centers.
* We always fetched the oldest versioned screenshot from Debian.
* Screenshots were often branded with Debian logos or Ubuntu widgets.
* Doesn't rely on accidental matches of Debian and SUSE package namings.