### PR TITLE
Allow searching with more than one character

### DIFF
--- a/app/views/search/_find_form.html.erb
+++ b/app/views/search/_find_form.html.erb
@@ -13,7 +13,7 @@
 
   function search() {
     search_term = encodeURI( jQuery.trim( $("#search-form").val() ) );
-    if (search_term.length > 2 ) {
+    if (search_term.length > 1 ) {
       $('#search-messages').hide();
       $('#msg').html("");
       last_search = search_term;
@@ -48,7 +48,7 @@
       })
 
     } else if (search_term.length > 0 ) {
-      $('#msg').html("<%= _("Please enter more than 2 characters") %>");
+      $('#msg').html("<%= _("Please enter more than 1 character") %>");
       $('#search-result-error').hide();
       $('#search-messages').show();
     } else {
@@ -63,7 +63,7 @@
     afterDelayedKeyup('#search-form',"search()", 500);
 
     $('#search_devel_checkbox, #search_unsupported_checkbox, #baseproject').change(function() {
-      if ($("#search-form").val().length > 2 ) {
+      if ($("#search-form").val().length > 1 ) {
         search();
       }
     });
@@ -116,4 +116,3 @@
     </p>
   </div>
 </div>
-


### PR DESCRIPTION
Previously the message "Please enter more than 2 characters" was shown and the search was not started automatically if less than 3 characters were introduce. There are packages like go whose name has less than 3 characters. It has been changed and it is only necessary to introduce 2 character.

Closes https://github.com/openSUSE/software-o-o/issues/61

I suppose I should also edit the translations, but I am not pretty sure of how to do it. Also, I think there is an error in README.i18n I'll open another PR for that.