### PR TITLE
Adapt rake tasks to weblate workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@ config/database.yml
 config/secrets.yml
 
 # i18n
-locale
+locale/*/software.edit.po
+locale/*/software.po.time_stamp
 
 # Local databases
 /db/*.sqlite3

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -32,7 +32,8 @@ end
 def msgmerge_po_files
   each_po_file do |file, lang|
     print "Merging #{lang}"
-    system "msgmerge --previous --lang=#{lang} #{file} #{POT_FILE} -o #{file}.new"
+    command = "msgmerge --previous --lang=#{lang} #{file} #{POT_FILE} -o #{file}.new"
+    raise "ERROR running #{command}" unless system(command)
     system "mv #{file}.new #{file}"
   end
 end

--- a/locale/ar/software.po
+++ b/locale/ar/software.po
@@ -1,0 +1,1044 @@
+# moh <malham1@gmail.com>, 2011.
+# Mohammad Alhargan <malham1@gmail.com>, 2012.
+# Mohammad Alhargan <malham1@hotmail.com>, 2012.
+# mohammad <malham1@gmail.com>, 2012.
+# محمد الحرقان <malham1@gmail.com>, 2012, 2013, 2014.
+# malhargan <malham1@gmail.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-05-21 09:05+0300\n"
+"Last-Translator: malhargan <malham1@gmail.com>\n"
+"Language-Team: سوزي\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+"X-Generator: Virtaal 0.7.1\n"
+
+msgid " and "
+msgstr " أيضاً "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{إصدار} ليس إصدار معتمد.\""
+
+msgid "(hide)"
+msgstr "(إخفاء)"
+
+msgid "(show)"
+msgstr "(إظهار)"
+
+msgid "... and keep us informed"
+msgstr "... أبقنى على إطلاع"
+
+msgid "... get other marketing stuff"
+msgstr "... احصل على منتجات أخرى"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD 4.7 غيغابايت (مناسبة أيضا لذاكرة الفلاش USB العام)"
+
+msgid "64 Bit PC"
+msgstr "جهاز 64 بت"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">دليل تشغيل "
+"أوبن سوزي</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">ميتالينك</a> هو معيار مفتوح "
+"يقوم بتحميل الحزم بطرق مختلفة (FTP/HTTP/تورنت) للحصول على الملفات بتنسيق "
+"واحد لتسهيل عملية التحميل. وهذا جيد لتحميل ملفات Iso؛ خاصة بالنسبة للأشخاص "
+"الذين لا يمكنهم استخدام P2P بسبب قيود المفروضة من موفر خدمة إنترنت أو "
+"الجامعات. بمكن تقديم سرعات تحميل عالية جداً إذا كان العميل يدعم الاتصالات "
+"المتعددة, بمرايا متعددة، تلقائياً. وبالإضافة إلى ذلك، يمكن القيام بالكشف عن "
+"الأخطأء التلقائي وتصحيحها. وهذا يتطلب عميل خاصة بذلك."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">الرخصة</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>ملاحظات الإصدار</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>الإصدار الرسمي</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>التحديث الرسمي</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"سطح مكتب جنوم يمكنك تشغيله من %s او من فلاشة USB,<br/>ويمكن تثبيته فقط (لا "
+"توجد ترقية)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"سطح مكتب كدي يمكنك تشغيله من %s او من فلاشة USB,<br/>ويمكن تثبيته فقط (لا "
+"توجد ترقية)."
+
+msgid "Add repository and install manually"
+msgstr "إضافة المستودع والتثبيت يدويا"
+
+msgid "Add-On Downloads (optional)"
+msgstr "تحميل الإضافات (اختياري)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"بعد بنجاح بعد تنزيل صورة ISO(s)، قم بإنشاء ذاكرة فلاش USB قابلة للإقلاع أو "
+"احرق الصورة(s)على قرص DVD (أو قرص مضغوط) بحسب حجم التحميل."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"جميع البيانات يتم استخدامها فقط لإرسال مواد سوزي الترويجية\n"
+"      ولن ترسل لطراف ثالث. نقوم بتخزين البيانات إعلام المستخدمين\n"
+"      إذا كان يتوفر إصدار جديد. جميع الطلبات \n"
+"      خاضعة لنظام الحظر الأمريكي. لمزيد من المعلومات\n"
+"       حول هذا وقائمة بالبلدان في ويكيبيديا <a href='http://en.wikipedia.org/"
+"wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "متصفح التطبيقات"
+
+msgid "Available Images"
+msgstr "الصور المتاحة"
+
+msgid "BitTorrent"
+msgstr "تورنت"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"أقلع من قرص DVD او CD, في حال كان حاسوبك لايدعم الإقلاع التلقائي من هذه "
+"الأقراص. إفتح إعدادات BIOS و قم بتغيير إعدادات الإقلاع التلقائي ليقلع من هذه "
+"الأقراص."
+
+msgid "Bronze Sponsor"
+msgstr "الراعي البرونزي"
+
+msgid "Browser incompatibility"
+msgstr "المتصفُح غير متوافق"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "DVD/CD (s)حرق نسخـة"
+
+msgid "Categories"
+msgstr "الفئات"
+
+msgid "Category"
+msgstr "الفئة"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"إختر قرص تثبيت عن طريق الضغط عليه وإضغط زر التحميل لبدأ التحميل. وكخيار "
+"إضافي إختر نوع حاسوبك او طريق تحميل بديلة."
+
+msgid "Click here to display these alternative versions."
+msgstr "انقر هنا لعرض الإصدارات البديلة."
+
+msgid "Click to Download"
+msgstr "إضغط لبدء التحميل"
+
+msgid "Community"
+msgstr "المجتمع"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"يحتوي على مجموعة كبيرة من البرامج لإستعمالات سطح المكتب او للسيرفرات,<br/"
+">مناسب للتثبيت أو للترقية."
+
+msgid "Countdown"
+msgstr "العد التنازلي"
+
+msgid "Country"
+msgstr "البلد"
+
+msgid "Development"
+msgstr "التطوير"
+
+msgid "Development Version"
+msgstr "الإصدار التطويري"
+
+msgid "Development packages"
+msgstr "حزم التطوير"
+
+msgid "Development-"
+msgstr "التطوير"
+
+msgid "Direct Install"
+msgstr "تثبيت مباشر"
+
+msgid "Direct Link"
+msgstr "رابط مباشر"
+
+msgid "Documentation"
+msgstr "الوثائق"
+
+msgid "Don't show this warning the next time"
+msgstr "عدم إظهار هذا التحذير في المرة القادمة"
+
+msgid "Download"
+msgstr "تحميل"
+
+msgid "Download %s"
+msgstr "تحميل %s"
+
+msgid "Download Help"
+msgstr "مساعدة التحميل"
+
+msgid "Download Method"
+msgstr "طريقة التحميل"
+
+msgid "Download appliance from %s"
+msgstr "تحميل التطبيقات من %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "تحميل&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "تحميل&nbsp;جنوم"
+
+msgid "Download&nbsp;KDE"
+msgstr "تحميل&nbsp;كدي"
+
+msgid "Download&nbsp;Network"
+msgstr "تحميل&nbsp;الشبكة"
+
+msgid "Download&nbsp;Rescue"
+msgstr "تحميل&nbsp;إنقاذ"
+
+msgid "Downloads"
+msgstr "التحميلات"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"يقوم بتحميل قرص التثبيت وكل الحزم الضرورية من المستودعات.<br/>مناسب للتثبيت "
+"او للترقية."
+
+msgid "Expand all sections ('e')"
+msgstr "قم بتوسيع كافة المقاطع ('e')"
+
+msgid "Extra Languages"
+msgstr "اللغات الإضافية"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "اللغات الإضافية (32 بت)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "اللغات الإضافية (64 بت)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "لـ<strong>%s</strong> شغل التالي كـ <strong>جذر</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "من أجل<strong>%s</strong> شغل ما يلي:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"من أجل <strong>Arch Linux</strong>، حرر/etc/pacman.conf وأضف التالي (لاحظ أن "
+"ترتيب المستودعات في pacman.conf مهم، منذ أن أصبح pacman يقوم دوماً بتحميل "
+"الحزم التي يعثر عليها أولاً):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"الطريقة الأكثر أمانا لكي تتحقق من مَن قام بتوقيعها. ويجب ان تكون <tt>%s</tt>."
+
+msgid "Games"
+msgstr "ألعاب"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "إحصل على واحدة من التوزيعات المبنية على أوبن سوزي."
+
+msgid "Getting Help"
+msgstr "الحصول على المساعدة"
+
+msgid "Gold Sponsor"
+msgstr "الراعي الذهبي"
+
+msgid "Grab binary packages directly"
+msgstr "سحب الحزم الثنائية مباشرة"
+
+msgid "Header Logo"
+msgstr "صورة الشعار"
+
+msgid "Help on Download Method"
+msgstr "المساعدة في أسلوب التحميل"
+
+msgid "Help on Type of Computer"
+msgstr "المساعدة في نوع الحاسوب"
+
+msgid "How to Proceed"
+msgstr "كيف أبدء العمل"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"إذا أردت استخدام وصلة مباشرة ولكن تعيش في مكان يعيد توجيه التحميل بمعلومات "
+"غير كافية لإعادة توجيه التحميل لمرآة أسرع، يمكنك اختيار المرآة بنفسك."
+
+msgid "Image:"
+msgstr "صورة:"
+
+msgid "Install package %s / %s"
+msgstr "تثبيت الحزمة %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "تثبيت نمط %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "تثبيت بإستعمال التثبيت بضغطة زر واحدة"
+
+msgid "Installation Guides"
+msgstr "إرشادات التثبيت"
+
+msgid "Installation Medium"
+msgstr "قرص التثبيت"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"انضم إلى المجتمع المتنامي بسرعة، ساعد في دعم أوبن سوزي        أطلب آخر "
+"إصدار\n"
+"من أقراص DVD لمجموعتك أو منظمتك غير الربحيت أوجامعتك        \n"
+"أو للأحداث الهامة مثل اجتماعات مستخدمي لنكس        ، تثبيت.\n"
+" وإعداد سهل وسريع تساعد على زيادة الوعي والتعريف بأوبن سوزي!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"كونكيورُر لكدي 3 هو للأسف غير مدعوم ويحتوي على العديد من العلل التي تجعل من "
+"المستحيل إستعماله مع هذه الصفحة. رجاء تأكد من أن جافا سكربت معطلة عندك قبل "
+"أن <a href='%s'>تتابع</a>."
+
+msgid "Language"
+msgstr "اللغة"
+
+msgid "Legacy 32 Bit PC"
+msgstr "أجهزة الكمبيوتر القديمة 32 بت"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "أجهزة الكمبيوتر القديمة 32 بت"
+
+msgid "Live GNOME"
+msgstr "قرص جنوم الحي"
+
+msgid "Live KDE"
+msgstr "قرص كدي الحي"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"العديد من التطبيقات يمكن فحصها عن طريق رقم التحقق للتطبيق. التحقق من التحميل "
+"يفيد في التحقق من حصولك على ملف الآيزو الذي أردت تحميله وليس إصدار محطما من "
+"التوزيعة."
+
+msgid "Metalink"
+msgstr "رابط ثنائي"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "المزيد من المعلومات حول حرق ملف ISO إلى CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"المزيد من المعلومات حول إنشاء <a href='http://en.opensuse.org/"
+"Live_USB_stick'>قرص USB قابل للإقلاع</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"المزيد من المعلومات حول تحميل أوبن سوزي متوفرة في <a href=\"http://en."
+"opensuse.org/SDB:Download_help\">مساعدة التحميل</a> و <a href=\"http://en."
+"opensuse.org/SDB:Network_installation\">التثبيت من الويب</a> شاهد الصفحات في "
+"<a href=\"http://en.opensuse.org/Portal:Documentation\">ويكي الوثائق</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"معظم الحواسيب الجديدة تدعم <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (والمعروفة أيضا كـADM64 و Intel64), لكن بعض معالجات "
+"الحواسب المحمولة لاتدعمها. لذلك عليك التحقق من ويكيبيديا إذا كان حاسوبك "
+"يدعمها فعلا."
+
+msgid "Multimedia"
+msgstr "وسائط متعدّدة"
+
+msgid "Need help?"
+msgstr "تحتاج مساعدة؟"
+
+msgid "Network"
+msgstr "الشبكة"
+
+msgid "No appliance data for %s"
+msgstr "لا توجد بيانات الأداة %s"
+
+msgid "No appliances found in project %s"
+msgstr "لا توجد أدوات في المشروع %s"
+
+msgid "No data for %s / %s"
+msgstr "لا توجد بيانات %s / %s"
+
+msgid "No description found..."
+msgstr "لم يتم العثور على وصف..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "لم يتم العثور على تحميلات %s في المشروع %s"
+
+msgid "No packages found matching your search. "
+msgstr "لم يعثر على حزم تطابق بحثك. "
+
+msgid "NonOSS CD"
+msgstr "القرص غير الحر"
+
+msgid "OBS Backend not available"
+msgstr "OBS الخلفية غير متاحة"
+
+msgid "Official Manuals"
+msgstr "الكتيبات الرسمية"
+
+#, fuzzy
+#| msgid ""
+#| "Only DVD and Network medias are fully tested. Alternatives, like live or "
+#| "rescue systems, are recomended for only limited use."
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"يتم اختباره فقط الاقراص المضغوطة والشبكة بشكل كامل. البدائل، مثل النسخ الحية "
+"أو إنقاذ النظم، ينصح باستخدامها إستخداماً محدود فقط."
+
+msgid "Package %s not found..."
+msgstr "الحزمة %s غير موجودة..."
+
+msgid "Package Repositories"
+msgstr "مستودعات الحزم"
+
+msgid "Package Search"
+msgstr "البحث عن حزم"
+
+msgid "Packages for %s:"
+msgstr "حزم %s:"
+
+msgid "Pick Mirror"
+msgstr "إختيار رابط"
+
+msgid "Platinum Sponsor"
+msgstr "الراعي البلاتيني"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"نريد اخبارك بأن الحزم التالية من مستودعات غير رسمية.\n"
+"  هذا يعني أنه لم تتم مراجعتها من قبل أوبن سوزي وقد تحتوي على برامج تجريبية "
+"أو غير مستقرة."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"الرجاء إدخال سبب <b>مختصر</b> (بالانكليزية!) لماذا تحتاج أقراص DVD وقدم "
+"روابط للحدث/الغرض."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"يرجى ملاحظة أن هذا ليس أحدث إصدار openSUSE. يمكنك الحصول على أحدث نسخة <a "
+"href='/'>هنا</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"يمكن تحميل عروض دي في دي الترويجية وجميع الأعمال الفنية ذات \n"
+"        من <a href=\"http://download.opensuse.org/promodvd/\">دليل قرص "
+"التروج\n"
+"         يمكنك تجميله من المجلد %s</a>. نضع في اعتبارنا أن هذا إصدار خاص من "
+"أوبن سوزي،\n"
+"        وهي مصممة لتوزيع الترويجية."
+
+msgid "Related categories:"
+msgstr "الفئات ذات الصلة:"
+
+msgid "Released Version"
+msgstr "الإصدار المستقر"
+
+msgid "Reporting Bugs"
+msgstr "الإبلاغ عن العلل"
+
+msgid "Rescue"
+msgstr "إنقاذ"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"نظام الإنقاذ اللذي يمكنك تشغيلها من القرص المضغوط أو من وسيط تخزين USB.<br/"
+">لا يمكن أن تستخدم للتثبيت أو الترقية."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "رقم التحقق md5"
+
+msgid "Search"
+msgstr "البحث"
+
+msgid "Select Your Operating System"
+msgstr "إختر نظام التشغيل"
+
+msgid "Select the image type"
+msgstr "حدد نوع الصورة"
+
+msgid "Show"
+msgstr "إظهار"
+
+msgid "Show development, language and debug packages"
+msgstr "إظهار حزم التطوير واللغة والتصحيح"
+
+msgid "Show distribution:"
+msgstr "إظهار التوزيعة:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "إظهار المزيد من الحزم للتوزيعات غير المعتمدة"
+
+msgid "Show more..."
+msgstr "إظهار المزيد..."
+
+msgid "Show other versions"
+msgstr "إظهار الإصدارات أخرى"
+
+msgid "Show unstable packages"
+msgstr "ظهار الحزم غير المستقرة"
+
+msgid "Show unsupported packages"
+msgstr "إظهار الحزم غير المعتمدة"
+
+msgid "Silver Sponsor"
+msgstr "الراعي الفضي"
+
+#, fuzzy
+#| msgid ""
+#| "Some alternative media (eg. live and rescue systems) are also available, "
+#| "although they are less tested and recommended for only limited use."
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"بعض الوسائط البديلة (على سبيل المثال-القرص الحي وإنقاذ أنظمة) متاحة أيضا، "
+"بالرغم من أنه لم يتم إختبارها وموصى بها للاستخدام المحدود فقط."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"هذه بعض من التوزيعات المبنية على أوبن سوزي. وهم مهتمون ببناء مشتقاتهم الخاصة "
+"ويمكنك أخذ جولة في <a href=\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "المصدر"
+
+msgid "Sponsored by"
+msgstr "الرعاة"
+
+msgid "Sponsored by: AMD"
+msgstr "برعاية: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "برعاية: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "برعاية: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "برعاية: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "حزم فرعية"
+
+msgid "Support"
+msgstr "الدعم"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"عملية التثبيت متاحة بالعديد من اللغات، ولكن معظمها، لا يتم تضمين ترجمة "
+"التطبيقات في الصورة. إذا أردت أن تدعم أوبن سوزي بعض اللغات الإضافية، تحتاج "
+"إلى تحميلها من الإنترنت أثناء التثبيت أو في أي وقت لاحق. إذا كان لديك وصول "
+"سهلة إلى شبكة الإنترنت لا تحتاج هذا القرص المضغوط، ولكن إذا كنت تخطط لتثبيت "
+"أوبن سوزي على جهاز لايتصال بالإنترنت، سيوفر لك هذا القرص الوصول إلى جميع "
+"الترجمات المتاحة."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "ثم قم بتشغيل التالي <strong>كجذر</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"ليس هناك أي إصدار لأوبن سوزي في مرحلة الاختبار في الوقت الحالي.<br/> إذا كنت "
+"ترغب في استخدام البرمجيات في آخر إصداراتها. الرجاء استخدام <a href='http://"
+"en.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"يحتوي هذا القرص المدمج على برمجيات حرة موزعة تحت رخص مغلقة ولاتسمح بإضافتها "
+"إلى قرص التثبيت الرئيسي بجانب البرمجيات الحرة بالكامل. كل البرمجيات الموجودة "
+"داخل هذا القرص بالإمكان تحميلها من المستودعات المغلقة المصدر."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"هذا الإصدار يعمل على كل الحواسيب بما في ذلك الحواسيب التي تدعم 64 بت,إذا كان "
+"عندك أكثر من 3جيجابايت من الرام فمن لمستحسن ان تستعمل الإصدار 64 بت. أوبن "
+"سوزي لاتدعم المعالجات قبل Pentium الأقراص الحية لاتدعم أيضا إلا بنية ,i686 "
+"(Pentium Pro وأعلى)."
+
+msgid "Type of Computer"
+msgstr "نوع الحاسوب"
+
+msgid "Unsupported distributions:"
+msgstr "توزيعات غير معتمدة:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"ويتوفر دليل المستخدم في <a href=\"http://activedoc.opensuse.org\">activedoc."
+"opensuse.org</a>، على سبيل المثال <a href=\"http://activedoc.opensuse.org/"
+"book/opensuse-start-up/\">دليل بدء التشغيل الرسمي</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"يستحسن استخدام <a href=\"http://en.opensuse.org/SDB:BitTorrent\">تورنت</a> "
+"للروابط البطيئة، خاصة عند تحميل صورة DVD. التورنت له فوائد عدة، كالحماية من "
+"فقد البيانات والمساعدة في تخفيف الحمل على الخادم بمشاركة التحميل - إذا قام "
+"ما يكفي من الناس بالمشاركة سيكون التحميل أسرع للجميع من استخدام خادم مركزي. "
+"يضاً، ويسمح لك بإيقاف التحميل في أي وقت واستئنافه في وقت لاحق."
+
+msgid "Verify your download before use"
+msgstr "تحقق من التحميل قبل استخدامه"
+
+msgid "Version"
+msgstr "الإصدار"
+
+msgid "We offer three different checksums:"
+msgstr "نحن نعرض ثلاثة أرقام مختلفة للتحقق:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"نود أن تبقينا على إطلاع بنتائج تجربتك واستخدامك لأقراص أوبن سوزي. نستطيع\n"
+"        يمكننا أن نساعدك في دعم مدرستك أو منظمتك أو جامعتك في\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>صفحة "
+"الأخبار</a>\n"
+"        أو المصادر الأخرى. (ملاحظة! نحن نحب الصور كثيراً الرجاء ارسال الكثير "
+"منها). إتصل بنا على\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        لبحث ومناقشة طرق أخرى لمساعدتك."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"عند تنزيل صور آخر غير القرص المضغوط للتثبيت عبر شبكة الاتصال، يوصى<i>بشدة</"
+"i> باستخدام مدير تحميل للتقليل من خطر تلف البيانات."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"يمكنك إضافة مفتاح المستودع. ضع في اعتبارك أن مالك المفتاح قد يوفر التحديثات "
+"والحزم والمستودعات والتي سيقوم النظام بالثقة بها (<a href=\"%s\">مزيد من "
+"المعلومات</a>). لإضافة المفتاح، قم بتشغيل:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"حاول توسيع نطاق البحث لتطوير الحزم أو البحث عبر قاعدة توزيعة أخرى (حاليا)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"يمكنك فحص الملف أثناء عملية التحميل,كمثال التحقق من رقم (SHA256) سيتم "
+"تلقائيا إذا إخترت <a href='http://en.opensuse.org/SDB:Metalink'>الرابط "
+"الثنائي</a> في الحقل أعلاه وإستعملت إضافة Downthemall! في <a href='http://en."
+"opensuse.org/Firefox'>فيرفكس</a>."
+
+msgid "gpg signature"
+msgstr "توقع gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"ماتزال الطريقة الأكثر إستعمال للتحقق من التحميلات. العديد من برامج حرق ملفات "
+"الآيزو تعرضها قبل بدأ الحرق."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "وهي الطريقة الأقل إنتشارا لكن أكثر أمانا من رقم md5."
+
+msgid "md5 checksum"
+msgstr "رقم التحقق md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"الطريقة الأكثر أمانا لكي تتحقق من مَن قام بتوقيعها. ويجب ان تكون <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "العد التنازلي لأوبن سوزي"
+
+msgid "openSUSE Derivatives"
+msgstr "مشتقات أوبن سوزي"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"أوبن سوزي تتوفر عبر http (وصلة مباشرة) أو تورنت. القرص المضغوط للتثبيت عبر "
+"شبكة اتصال متوفر عبر http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "أوبن سوزي تدعم فقط حواسيب 32 و 64 بت."
+
+msgid "see Derivatives on wiki"
+msgstr "مشاهدة المشتقات على الويكي"
+
+msgid "sha1 checksum"
+msgstr "رقم sha1"
+
+msgid "switch to"
+msgstr "تحويل إلى"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "حدث خطأ داخلي:-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "يرجى إدخال أكثر من حرفين 2"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "عمليات البحث الأخيرة:"
+
+#~ msgid "Statistics"
+#~ msgstr "الإحصائيات"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "أكثر 1-نقرة تحميلا:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "الأكثر بحثا من دون النقر:"
+
+#~ msgid "Top searches:"
+#~ msgstr "الأكثر بحثا:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "حاليا لا يوجد فرع لتطوير لقطة أكثر حداثة من نسختنا الأخيرة من أوبن سوزي. "
+#~ "<br/>رجاءا تحقق من<a href='http://en.opensuse.org/Portal:Factory'>http://"
+#~ "en.opensuse.org/Portal:Factory</a> للمزيد من المعلومات."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "يمكنك إضافة مفتاح المستودع لملائمة مثل هذا: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "ديفيدي 4.7 جيجا"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "الأقرص الحية تحتوي فقط على أربع لغات (الإنكليزية, الألمانية, الروسية و "
+#~ "الإيطالية). إذا كنت تريد الحصول على دعم كامل لباقي اللغات فعليك تحميلها "
+#~ "من الويب أثناء التثبيت أو في أي وقت لاحق. إذا كان لديك وصول سهل للويب او "
+#~ "كنت تستعمل DVD يحتوي على كل اللغات ,فلن تحتاج لهذا القرص."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "بعد تحميل ملفات(s) الآيزو بشكل صحيح إحرق النسخة(s), بواسطة برنامجك المفضل "
+#~ "على قرص ديفيدي او سيدي رجاءا <em>لا</em> تحرق الملفات على شكل بيانات. لكن "
+#~ "إستعمل خيار الحرق بشكل ملفات ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "سطح مكتب جنوم يمكنك تشغيله من قرص السيدي او من فلاشة USB,<br/>ويمكن "
+#~ "تثبيته فقط (لا توجد ترقية)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "سطح مكتب كدي يمكنك تشغيله من قرص السيدي او من فلاشة USB,<br/>ويمكن تثبيته "
+#~ "فقط (لا توجد ترقية)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "قد تحاول توسيع نطاق البحث إلى مجموعات غير معتمدة أو البحث على قاعدة "
+#~ "توزيعة أخرى (حاليا)."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "رجاءا إستعمل دوال البحث على الأقل حرفان 2"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "تم التحويل إلى التطابق التام نتيجة لعدد النقرات الكثيرة على دوال البحث "
+#~ "الفرعية."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "رجاءا كن أكثر دقة في بحثك, تم الوصول إلى أقصى حد للبحث."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "لم يُتمكن من تنفيذ البحث: "
+
+#~ msgid "Popular Software"
+#~ msgstr "البرامج الأكثر شيوعا"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "شراء أوبن سوزي"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-ضغطة واحدة للتثبيت"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "تحميل الحزم يدويا"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "إذهب إلى مشروع OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[مجموعة البرامج]"
+
+#~ msgid "Search Results"
+#~ msgstr "نتائج البحث"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "لم يتم العثور على نتائج تطابق ماتبحث عنه في خدمة بناء أوبن سوزي."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d مجموعات و %d حزم ثنائية من %d حزم المصدر"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "لقطة للشاشة  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "إحصائيات البحث:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "إحصائيات التحميل:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "البحث وتثبيت حزم البرامج من <a href=\"http://build.opensuse.org\">خدمة "
+#~ "بناء أوبن سوزي</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "خيارات البحث"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "تضمين المستخدمين' مشاريع المنزل"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "إستثناء حزم التنقيح"

--- a/locale/bg/software.po
+++ b/locale/bg/software.po
@@ -1,0 +1,1149 @@
+# translation of software-opensuse-org.po to Bulgarian
+# Borislav Mitev <morbid_viper@tkzs.org>, 2009.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2009-10-21 16:39+0300\n"
+"Last-Translator: Borislav Mitev <morbid_viper@tkzs.org>\n"
+"Language-Team: Bulgarian <kde-i18n-doc@kde.org>\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.0\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr ""
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "64-битов"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://en.opensuse.org/OpenSUSE_EULA\">Лиценз</a> (Лицензионно "
+"споразумение с крайния потребител)"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+
+#, fuzzy
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr ""
+"<a href=\"http://en.opensuse.org/OpenSUSE_EULA\">Лиценз</a> (Лицензионно "
+"споразумение с крайния потребител)"
+
+#, fuzzy
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Бележки по изданието</a> (последна информация)"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "Официални ръководства"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "Официални ръководства"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+
+msgid "Add repository and install manually"
+msgstr ""
+
+msgid "Add-On Downloads (optional)"
+msgstr "Сваляне на добавки (незадължително)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+#, fuzzy
+msgid "App Browser"
+msgstr "Мрежов браузър"
+
+#, fuzzy
+msgid "Available Images"
+msgstr "Налични кръпки"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Заредете от DVD/CD. В случай, че компютърът не зареди автоматично от това "
+"устройство, отворете BIOS и разрешете зареждането от там."
+
+#, fuzzy
+msgid "Bronze Sponsor"
+msgstr "Златен спонсор"
+
+msgid "Browser incompatibility"
+msgstr ""
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Запис на образ(и) CD/DVD"
+
+msgid "Categories"
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+#, fuzzy
+msgid "Click to Download"
+msgstr "Сваляне"
+
+#, fuzzy
+msgid "Community"
+msgstr "Поддръжка от общността"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+
+msgid "Countdown"
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Development"
+msgstr "Разработка"
+
+#, fuzzy
+msgid "Development Version"
+msgstr "Последна версия в разработка"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "Последна версия в разработка"
+
+#, fuzzy
+msgid "Development-"
+msgstr "Разработка"
+
+#, fuzzy
+msgid "Direct Install"
+msgstr "Инсталиране"
+
+msgid "Direct Link"
+msgstr "Директна връзка"
+
+#, fuzzy
+msgid "Documentation"
+msgstr "Документ"
+
+#, fuzzy
+msgid "Don't show this warning the next time"
+msgstr "Без повторно показване на това съобщение."
+
+msgid "Download"
+msgstr "Сваляне"
+
+msgid "Download %s"
+msgstr "Сваляне на %s"
+
+msgid "Download Help"
+msgstr "Помощ за свалянето"
+
+msgid "Download Method"
+msgstr "Методи на сваляне"
+
+msgid "Download appliance from %s"
+msgstr ""
+
+#, fuzzy
+msgid "Download&nbsp;DVD"
+msgstr "Сваляне на %s"
+
+#, fuzzy
+msgid "Download&nbsp;GNOME"
+msgstr "Сваляне на %s"
+
+#, fuzzy
+msgid "Download&nbsp;KDE"
+msgstr "Сваляне на %s"
+
+#, fuzzy
+msgid "Download&nbsp;Network"
+msgstr "Методи на сваляне"
+
+#, fuzzy
+msgid "Download&nbsp;Rescue"
+msgstr "Сваляне на %s"
+
+#, fuzzy
+msgid "Downloads"
+msgstr "Сваляне"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+# label for language selection
+msgid "Extra Languages"
+msgstr "Допълнителни езици"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Допълнителни езици (32-бита)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Допълнителни езици (64-бита)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be"
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"предлага най-добро ниво на сигурност, тъй като може да се удостовери и кой е "
+"подписал файла. То трябва да бъде"
+
+msgid "Games"
+msgstr "Игри"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+
+msgid "Getting Help"
+msgstr "Получаване на помощ"
+
+msgid "Gold Sponsor"
+msgstr "Златен спонсор"
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr ""
+
+#, fuzzy
+msgid "Help on Download Method"
+msgstr "Изскачащ прозорец: Помощ за методите на сваляне"
+
+#, fuzzy
+msgid "Help on Type of Computer"
+msgstr "Тип на компютъра"
+
+msgid "How to Proceed"
+msgstr "Как да се продължи"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+
+msgid "Image:"
+msgstr ""
+
+#, fuzzy
+msgid "Install package %s / %s"
+msgstr "Инсталиране на пакета с YaST"
+
+#, fuzzy
+msgid "Install pattern %s / %s"
+msgstr "Инсталиране на %s"
+
+msgid "Install using One Click Install"
+msgstr ""
+
+msgid "Installation Guides"
+msgstr "Напътствия за инсталиране"
+
+#, fuzzy
+msgid "Installation Medium"
+msgstr "Изберете носител на инсталация"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+
+# label for language selection
+msgid "Language"
+msgstr "Език"
+
+#, fuzzy
+msgid "Legacy 32 Bit PC"
+msgstr "64-битов"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32-битов"
+
+msgid "Live GNOME"
+msgstr ""
+
+msgid "Live KDE"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Много приложения могат да удостоверят сумата за проверка на сваленото. Това "
+"може да бъде важно, тъй като показва дали наистина имате файла, който сте "
+"искали да свалите или сте получили някоя счупена версия. Ние предлагаме три "
+"различни суми за проверка:"
+
+msgid "Metalink"
+msgstr "Мета-връзка"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"В случай на проблеми със свалянето се обърнете към <a href=\"http://en."
+"opensuse.org/Download_Help\">Помощта при сваляне</a>."
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+
+msgid "Multimedia"
+msgstr "Мултимедия"
+
+msgid "Need help?"
+msgstr "Нужна ли ви е помощ?"
+
+msgid "Network"
+msgstr "Мрежа"
+
+msgid "No appliance data for %s"
+msgstr ""
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+msgid "No data for %s / %s"
+msgstr ""
+
+#, fuzzy
+msgid "No description found..."
+msgstr "Не са открити хранилища."
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+msgid "No packages found matching your search. "
+msgstr ""
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "SCPM не е налично"
+
+msgid "Official Manuals"
+msgstr "Официални ръководства"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+#, fuzzy
+msgid "Package %s not found..."
+msgstr "Хостът %s не бе открит."
+
+msgid "Package Repositories"
+msgstr "Хранилища с пакети"
+
+msgid "Package Search"
+msgstr "Търсене на пакети"
+
+#, fuzzy
+msgid "Packages for %s:"
+msgstr "Опаковчик: %1\n"
+
+msgid "Pick Mirror"
+msgstr "Избор на огледало"
+
+#, fuzzy
+msgid "Platinum Sponsor"
+msgstr "Златен спонсор"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+msgid "Related categories:"
+msgstr ""
+
+#, fuzzy
+msgid "Released Version"
+msgstr "Нова версия"
+
+#, fuzzy
+msgid "Reporting Bugs"
+msgstr "Импортиране на модул"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "Спасяване на системата"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "Сума за проверка MD5"
+
+msgid "Search"
+msgstr "Търсене"
+
+msgid "Select Your Operating System"
+msgstr ""
+
+#, fuzzy
+msgid "Select the image type"
+msgstr "Избор на типа на монитора."
+
+msgid "Show"
+msgstr ""
+
+msgid "Show development, language and debug packages"
+msgstr ""
+
+#, fuzzy
+msgid "Show distribution:"
+msgstr "Дистрибуция: %1\n"
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+msgid "Show more..."
+msgstr ""
+
+#, fuzzy
+msgid "Show other versions"
+msgstr "Други версии"
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "пакет"
+
+msgid "Show unsupported packages"
+msgstr ""
+
+msgid "Silver Sponsor"
+msgstr "Сребърен спонсор"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+
+msgid "Source"
+msgstr "Източник"
+
+msgid "Sponsored by"
+msgstr "Спонсорирано от"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "Спонсорирано от AMD"
+
+#, fuzzy
+msgid "Sponsored by: B1 Systems"
+msgstr "Спонсорирано от"
+
+#, fuzzy
+msgid "Sponsored by: Heinlein"
+msgstr "Спонсорирано от"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Спонсорирано от: IP Exchange"
+
+#, fuzzy
+msgid "Sub-Packages"
+msgstr "пакет"
+
+#, fuzzy
+msgid "Support"
+msgstr "%1 (3D поддръжка)"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+
+msgid "Type of Computer"
+msgstr "Тип на компютъра"
+
+msgid "Unsupported distributions:"
+msgstr ""
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "Удостоверяване на сваленото (незадължително)"
+
+msgid "Version"
+msgstr "Версия"
+
+msgid "We offer three different checksums:"
+msgstr ""
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+
+msgid "gpg signature"
+msgstr "Подпис GPG"
+
+#, fuzzy
+msgid "http://doc.opensuse.org/"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/INSTALL_Local"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://en.opensuse.org/INSTALL_Local"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"все още е една от най-често използваните суми. Доста софтуери за записване я "
+"показват точно преди запис."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "е по-малко известна, но по-сигурна сума от MD5."
+
+msgid "md5 checksum"
+msgstr "Сума за проверка MD5"
+
+#, fuzzy
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"предлага най-добро ниво на сигурност, тъй като може да се удостовери и кой е "
+"подписал файла. То трябва да бъде"
+
+#, fuzzy
+msgid "openSUSE Countdown"
+msgstr "openSUSE.org"
+
+#, fuzzy
+msgid "openSUSE Derivatives"
+msgstr "Проект openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr ""
+
+#, fuzzy
+msgid "see Derivatives on wiki"
+msgstr "Проект openSUSE"
+
+msgid "sha1 checksum"
+msgstr "Сума за проверка SHA1"
+
+#, fuzzy
+msgid "switch to"
+msgstr "Превключване към профил"
+
+#, fuzzy
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Паролата е прекалено къса (трябва да има поне 8 символа)."
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#, fuzzy
+#~ msgid "Statistics"
+#~ msgstr "Статус"
+
+#, fuzzy
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Сваляне"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "След като сте свалили успешно ISO образите ги изпечете с любимия ви "
+#~ "софтуер за записване на DVD или CD, според необходимостта. Моля, <em>НЕ</"
+#~ "em> записвайте като DVD/CD с данни, а изберете записването на ISO образ."
+
+#, fuzzy
+#~| msgid "Password is too short (must have at least 8 characters)."
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Паролата е прекалено къса (трябва да има поне 8 символа)."
+
+#, fuzzy
+#~| msgid "Could not stat %1"
+#~ msgid "Could not perform search: "
+#~ msgstr "Не може да се види състоянието %1"
+
+#, fuzzy
+#~| msgid "Build Software"
+#~ msgid "Popular Software"
+#~ msgstr "Изграждане на софтуер"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Купете openSUSE!"
+
+#, fuzzy
+#~| msgid "Install"
+#~ msgid "1-Click Install"
+#~ msgstr "Инсталиране"
+
+#, fuzzy
+#~| msgid "openSUSE Project"
+#~ msgid "Go to OBS Project"
+#~ msgstr "Проект openSUSE"
+
+#, fuzzy
+#~| msgid "Software Search"
+#~ msgid "[Software collection]"
+#~ msgstr "Търсене на софтуер"
+
+#, fuzzy
+#~| msgid "Connect Result"
+#~ msgid "Search Results"
+#~ msgstr "Резултат от свързването"
+
+#, fuzzy
+#~| msgid "Connect Result"
+#~ msgid "Search Statistics:"
+#~ msgstr "Резултат от свързването"
+
+#, fuzzy
+#~| msgid "Download %s"
+#~ msgid "Download Statistics:"
+#~ msgstr "Сваляне на %s"
+
+#, fuzzy
+#~| msgid ""
+#~| "Search for and install additional software packages from the openSUSE "
+#~| "Build Service."
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Търсене и инсталиране на допълнителни пакети от Услугата за изграждане на "
+#~ "openSUSE"
+
+# button label for other/more options
+#, fuzzy
+#~| msgid "Expert options"
+#~ msgid "Search options"
+#~ msgstr "Експертни настройки"
+
+#~ msgid "Additional Information"
+#~ msgstr "Допълнителна информация"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.1"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Купете openSUSE 11.1!"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.1"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Купете openSUSE 11.1!"
+
+#, fuzzy
+#~| msgid ""
+#~| "In case of problems with the download, please <a href=\"http://en."
+#~| "opensuse.org/Download_Help\">refer to the Download Help</a>."
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "В случай на проблеми със свалянето се обърнете към <a href=\"http://en."
+#~ "opensuse.org/Download_Help\">Помощта при сваляне</a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Инструкциите са налични както следва:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Инсталиране от DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Официално Начално напътствие на %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Напътствие за инсталиране стъпка по стъпка"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Мрежова инсталация"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Инсталиране от Интернет"
+
+#~ msgid "More information"
+#~ msgstr "Повече информация"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Търсене на софтуер"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "User Directory"
+#~ msgstr "Потребителска директория"
+
+#~ msgid "Features"
+#~ msgstr "Характеристики"
+
+#~ msgid "News"
+#~ msgstr "Новини"
+
+#~ msgid "Forums"
+#~ msgstr "Форуми"
+
+#~ msgid "Shop"
+#~ msgstr "Магазин"
+
+#~ msgid "Software"
+#~ msgstr "Софтуер"
+
+#~ msgid "Software Search"
+#~ msgstr "Търсене на софтуер"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Хранилища с обновления"
+
+#~ msgid "Source Repository"
+#~ msgstr "Хранилища с изходен код"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Други параметри"
+
+#~ msgid "Mirrors"
+#~ msgstr "Огледала"
+
+#, fuzzy
+#~| msgid "Select the language."
+#~ msgid "In other languages"
+#~ msgstr "Изборете на език."
+
+#~ msgid "Get it"
+#~ msgstr "Вземи го!"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Търсене в услугата за изграждане"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Търсене и инсталиране на допълнителни пакети от Услугата за изграждане на "
+#~ "openSUSE"
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Вземете openSUSE!"
+
+#, fuzzy
+#~| msgid ""
+#~| "Search for and install additional software packages from the openSUSE "
+#~| "Build Service."
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr ""
+#~ "Търсене и инсталиране на допълнителни пакети от Услугата за изграждане на "
+#~ "openSUSE"
+
+#, fuzzy
+#~| msgid "Search"
+#~ msgid "Searching"
+#~ msgstr "Търсене"
+
+#~ msgid "Metalinks"
+#~ msgstr "Мета-връзки"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.1!"
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Купете openSUSE 11.1!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "За новаците в Линукс може би най-добрият избор е версията на openSUSE с "
+#~ "поддръжка – получавате пълната потребителска документация, инсталационни "
+#~ "носители с 32 и 64-битовите версии на системата и 90 дена потребителска "
+#~ "поддръжка при инсталацията."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 е налична в няколко <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">онлайн</a> магазина, както и при доста локални "
+#~ "разпространители."
+
+# button label for other/more options
+#~ msgid "Expert view"
+#~ msgstr "Експертен изглед"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Компютри с процесори, например,  AMD&reg; Sempron или Intel&reg; "
+#~ "Celeron&trade;. Това са почти всички компютри произведени до 2004. Тази "
+#~ "версия също работи и с 64-битови компютри."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: Повечето нови компютри с процесори, например,  AMD&reg;: "
+#~ "Opteron&trade;, Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: "
+#~ "Core&trade;2, Pentium&reg; 4 6xx, Pentium&reg; D."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "За да свалите носител, изберете някой от методите, евентуално сменете "
+#~ "архитектурата и изберете „Запис на файл“."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Изскачащ прозорец: Помощ за свалянето на носител"
+
+#~ msgid "Help"
+#~ msgstr "Помощ"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "За повечето хора DVD е носителят по подразбиране"
+
+#~| msgid "GNOME Desktop"
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Живо CD с работна среда GNOME"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Живо CD с работна среда KDE"
+
+#~| msgid "Start Installation or Update"
+#~ msgid "Network installation for experts"
+#~ msgstr "Мрежова инсталация за експерти"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "все още е една от най-често използваните суми. Доста софтуери за "
+#~ "записване я показват точно преди запис."
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr "е по-малко известна, но по-сигурна сума от MD5."

--- a/locale/ca/software.po
+++ b/locale/ca/software.po
@@ -1,0 +1,917 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-04 09:21+0100\n"
+"Last-Translator: David Medina <opensusecatala@gmail.com>\n"
+"Language-Team: Catalan\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.6.10\n"
+
+msgid " and "
+msgstr " i "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} no és una versió amb suport.\""
+
+msgid "(hide)"
+msgstr "(amaga)"
+
+msgid "(show)"
+msgstr "(mostra)"
+
+msgid "... and keep us informed"
+msgstr "... i mantingueu-nos informats"
+
+msgid "... get other marketing stuff"
+msgstr "... obtingueu més coses de màrqueting"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD de 4.7 GB (també adient per a memòries usb)"
+
+msgid "64 Bit PC"
+msgstr "PC de 64 bits"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Guia "
+"d'inici d'openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Un metaenllaç</a> és un "
+"estàndard obert que combina les diferents maneres (FTP/HTTP/BitTorrent) "
+"d'obtenir fitxers en un sol format per a descàrregues més fàcils. Va bé per "
+"a descàrregues d'ISO, particularment per a gent que no pot utilitzar P2P a "
+"causa de restriccions d'ISP o de la universitat. Pot oferir baixades molt "
+"ràpides ja que molts dels clients tenen suport per a connexions múltiples, a "
+"múltiples miralls, automàticament. A més, pot fer una detecció automàtica "
+"d'errors i correccions. Ara bé, per fer-ho necessita un client especial."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Llicència</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notes de la versió</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>versió oficial</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>actualització oficial</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un escriptori GNOME que podeu fer servir des de %s o des d'una memòria USB."
+"<br/>Es pot instal·lar tal com és (no per actualitzar)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un escriptori KDE que podeu fer servir des de %s o des d'una memòria USB.<br/"
+">Es pot instal·lar tal com és (no per actualitzar)."
+
+msgid "Add repository and install manually"
+msgstr "Afegiu el repositori i instal·leu manualment"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Descàrregues complementàries (opcional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Després d'haver descarregat correctament una imatge ISO, creeu una memòria "
+"USB d'arrencada o graveu la imatge en un DVD (o CD si la imatge escollida hi "
+"cap)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Les dades només s'utilitzen per enviar material promocional d'openSUSE\n"
+"      i no s'escamparan a terceres parts. Desem les dades per\n"
+"      informar els usuaris de les noves versions disponibles. Totes les "
+"peticions\n"
+"      han d'escanejar-se per complir l'US export embargo. Més informació\n"
+"      sobre l'embargo i una llista de països a la Viquipèdia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Navegador de l'aplicació"
+
+msgid "Available Images"
+msgstr "Imatges disponibles"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Arrenqueu des d'un DVD, CD o memòria USB. En cas que l'ordinador no arrenqui "
+"automàticament des del mitjà escollit, entreu a la configuració de la BIOS "
+"per permetre-ho."
+
+msgid "Bronze Sponsor"
+msgstr "Patrocinadors de bronze"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilitat de navegador"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Graveu una imatge de CD/DVD"
+
+msgid "Categories"
+msgstr "Categories"
+
+msgid "Category"
+msgstr "Categoria"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Escolliu un mitjà d'instal·lació clicant-hi i després premeu el botó de "
+"descàrrega per iniciar la baixada. Opcionalment, trieu el tipus d'ordinador "
+"o un mètode de descàrrega alternatiu."
+
+msgid "Click here to display these alternative versions."
+msgstr "Cliqueu aquí per veure aquestes versions alternatives."
+
+msgid "Click to Download"
+msgstr "Cliqueu per descarregar"
+
+msgid "Community"
+msgstr "Comunitat"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Conté una gran col·lecció de programari per a ús d'escriptori o de servidor."
+"<br/>Adient per a una instal·lació o actualització."
+
+msgid "Countdown"
+msgstr "Compte enrere"
+
+msgid "Country"
+msgstr "País"
+
+msgid "Development"
+msgstr "Desenvolupament"
+
+msgid "Development Version"
+msgstr "Versió de desenvolupament"
+
+msgid "Development packages"
+msgstr "Paquets de desenvolupament"
+
+msgid "Development-"
+msgstr "Desenvolupament-"
+
+msgid "Direct Install"
+msgstr "Instal·lació directa"
+
+msgid "Direct Link"
+msgstr "Enllaç directe"
+
+msgid "Documentation"
+msgstr "Documentació"
+
+msgid "Don't show this warning the next time"
+msgstr "No tornis a mostrar aquest missatge la propera vegada."
+
+msgid "Download"
+msgstr "Descàrrega"
+
+msgid "Download %s"
+msgstr "Descarregueu l'%s"
+
+msgid "Download Help"
+msgstr "Ajuda sobre la baixada"
+
+msgid "Download Method"
+msgstr "Mètode de descàrrega"
+
+msgid "Download appliance from %s"
+msgstr "Descarregueu l'aparell des de %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Descarregueu el&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Descarregueu&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Descarregueu&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Descarregueu&nbsp;Xarxa"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Descarregueu&nbsp;Rescat"
+
+msgid "Downloads"
+msgstr "Descàrregues"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Descarrega el sistema d'instal·lació i tots els paquets des dels repositoris "
+"en línia.<br/>Adient per a una instal·lació o actualització."
+
+msgid "Expand all sections ('e')"
+msgstr "Expandeix totes les seccions ('e')"
+
+msgid "Extra Languages"
+msgstr "Més llengües"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Més llengües (32 bits)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Més llengües (64 bits)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Per a <strong>%s</strong> executeu el següent com a <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Per a <strong>%s</strong> executeu el següent:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Per a<strong>Arch Linux</strong>, editeu /etc/pacman.conf i afegiu-hi el "
+"següent (noteu que l'ordre dels repositoris dins de pacman.conf és "
+"important, ja que el Pacman sempre baixa el primer paquet que troba):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Per a cada ISO, oferim un fitxer de suma de verificació amb la suma SHA256 "
+"corresponent."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Per a més seguretat, podeu usar GPG per verificar qui ha signat aquests "
+"fitxers .sha256. Hauria de ser <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Jocs"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Obtingueu una de les distribucions especialitzades construïdes a partir "
+"d'openSUSE."
+
+msgid "Getting Help"
+msgstr "Obtingueu ajuda"
+
+msgid "Gold Sponsor"
+msgstr "Patrocinadors d'or"
+
+msgid "Grab binary packages directly"
+msgstr "Agafeu paquets binaris directament"
+
+msgid "Header Logo"
+msgstr "Logo de la capçalera"
+
+msgid "Help on Download Method"
+msgstr "Ajuda sobre el mètode de baixada"
+
+msgid "Help on Type of Computer"
+msgstr "Ajuda sobre el tipus d'ordinador"
+
+msgid "How to Proceed"
+msgstr "Com procedir"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Si voleu fer servir un enllaç directe però viviu en un lloc del planeta on "
+"el nostre redirector de descàrregues no té prou informació per redireccionar-"
+"vos al mirall més ràpid, podeu escollir vosaltres mateixos el mirall."
+
+msgid "Image:"
+msgstr "Imatge:"
+
+msgid "Install package %s / %s"
+msgstr "Instal·la el paquet %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Patró d'instal·lació %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instal·la amb la instal·lació d'1-clic"
+
+msgid "Installation Guides"
+msgstr "Guies d'instal·lació"
+
+msgid "Installation Medium"
+msgstr "Mitjà d'instal·lació"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Uniu-vos a la comunitat creixent, poseu l'openSUSE a mans de més persones\n"
+"        obtenint l'últim PromoDVD per al vostre grup, organizació sense ànim "
+"de lucre,\n"
+"        escola, universitat o esdeveniment com ara trobades LUG, festes "
+"d'instal·lació i conferències.\n"
+"        Els PromoDVD ajuden a augmentar el coneixement i la visibilitat "
+"d'openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"El Konqueror del KDE 3 ja no té suport i no és mantingut i la seva "
+"implementació java conté errors que el fan impossible d'utilitzar amb "
+"aquesta pàgina. Si us plau, assegureu-vos de desactivar el javascript abans "
+"de <a href='%s'>continuar</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Legacy 32 Bit PC"
+msgstr "PC de 32 bits (llegat)"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Llegat de 32&nbsp;bits&nbsp"
+
+msgid "Live GNOME"
+msgstr "GNOME imatge viva"
+
+msgid "Live KDE"
+msgstr "KDE imatge viva"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Diverses aplicacions permeten verificar la suma d'una descàrrega. Verificar-"
+"la pot ser important ja que comprova que tingueu la imatge ISO que voleu i "
+"no una versió trencada o incorrecta. "
+
+msgid "Metalink"
+msgstr "Metaenllaç"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Més informació sobre gravació d'una imatge ISO en un CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Més informació sobre la creació d'una <a href='http://en.opensuse.org/"
+"Live_USB_stick'>memòria USB d'arrencada</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Més informació sobre la descàrrega d'openSUSE està disponible a <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Ajuda sobre la baixada</a> i a "
+"les pàgines de la <a href=\"http://en.opensuse.org/SDB:Network_installation"
+"\">Instal·lació per xarxa</a> de la <a href=\"http://en.opensuse.org/Portal:"
+"Documentation\">Wiki de documentació</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"La mojoria d'ordinadors nous tenen suport per a <a href=\"http://en."
+"wikipedia.org/wiki/X86-64\">x86-64</a> (també conegut com a AMD64 i "
+"Intel64), però alguns processadors de portàtils o netbooks no en tenen "
+"suport. Podeu consultar la Viquipèdia per saber si el vostre en té."
+
+msgid "Multimedia"
+msgstr "Multimèdia"
+
+msgid "Need help?"
+msgstr "Necessiteu ajuda?"
+
+msgid "Network"
+msgstr "Xarxa"
+
+msgid "No appliance data for %s"
+msgstr "No dades d'aparell per a %s"
+
+msgid "No appliances found in project %s"
+msgstr "No s'han trobat aparells al projecte %s"
+
+msgid "No data for %s / %s"
+msgstr "No hi ha dades per a %s / %s"
+
+msgid "No description found..."
+msgstr "No s'ha trobat cap descripció..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "No hi ha descàrregues per a %s al projecte %s"
+
+msgid "No packages found matching your search. "
+msgstr "No hi ha paquets que coincideixin amb la cerca."
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS "
+
+msgid "OBS Backend not available"
+msgstr "Rerefons OBS no disponible"
+
+msgid "Official Manuals"
+msgstr "Manuals oficials"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Només s'han provat completament els mitjans de DVD i de xarxa. Els "
+"alternatius, com ara els sistemes vius o de rescat, són recomanats només per "
+"a un ús limitat."
+
+msgid "Package %s not found..."
+msgstr "No s'ha trobat el paquet %s"
+
+msgid "Package Repositories"
+msgstr "Repositoris de paquets"
+
+msgid "Package Search"
+msgstr "Cerca de paquets"
+
+msgid "Packages for %s:"
+msgstr "Paquets per %s:"
+
+msgid "Pick Mirror"
+msgstr "Trieu un mirall"
+
+msgid "Platinum Sponsor"
+msgstr "Patrocinadors de platí"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Si us plau, tingueu present que els paquets següents són de repositoris no "
+"oficials.\n"
+"   Això significa que no estan revisats per openSUSE i que poden contenir "
+"programari no estable o experimental. "
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Si us plau, introduïu una raó <b>breu</b> (en anglès!) de per què necessiteu "
+"els DVD i proporcioneu un enllaç de l'esdeveniment/propòsit."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Si us plau, noteu que aquesta no és l'última versió estable d'openSUSE. "
+"Podeu obtenir-ne l'última <a href='/'>aquí</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"PromoDVD i tot l'art relacionat -etiquetes i caràtules- es pot descarregar\n"
+"        de <a href=\"http://download.opensuse.org/promodvd/\">promodvd\n"
+"        directori de baixada %s</a>. Tingueu present que aquesta és una "
+"verisó especial d'openSUSE,\n"
+"        dissenyada per a una distribució promocional."
+
+msgid "Related categories:"
+msgstr "Categories relacionades:"
+
+msgid "Released Version"
+msgstr "Versió publicada"
+
+msgid "Reporting Bugs"
+msgstr "Informeu d'errors"
+
+msgid "Rescue"
+msgstr "Rescat"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Sistema de rescat que podeu executar des d'un CD o d'una memòria USB.<br/>No "
+"es pot fer servir per a instal·lacions o actualitzacions."
+
+msgid "SHA256 checksum"
+msgstr "La suma SHA256"
+
+msgid "Search"
+msgstr "Cerca"
+
+msgid "Select Your Operating System"
+msgstr "Seleccioneu el sistema operatiu"
+
+msgid "Select the image type"
+msgstr "Seleccioneu el tipus d'imatge"
+
+msgid "Show"
+msgstr "Mostra"
+
+msgid "Show development, language and debug packages"
+msgstr "Mostra els paquets de desenvolupament, llengua i depuració"
+
+msgid "Show distribution:"
+msgstr "Mostra la distribució:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Mostra més paquets per a distribucions sense suport"
+
+msgid "Show more..."
+msgstr "Mostra'n més"
+
+msgid "Show other versions"
+msgstr "Mostra'n altres versions"
+
+msgid "Show unstable packages"
+msgstr "Mostra els paquets inestables"
+
+msgid "Show unsupported packages"
+msgstr "Mostra paquets sense suport"
+
+msgid "Silver Sponsor"
+msgstr "Patrocinadors de plata"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"També hi ha disponibles alguns mitjans alternatius (per exemple, sistemes "
+"vius o de rescat), tot i que s'han provat menys i es recomanen només per a "
+"un ús limitat."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Algunes de les distribucions vives basades en openSUSE. Tothom que estigui "
+"interessat a construir-ne un derivat propi pot fer un cop d'ull a <a href="
+"\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Font"
+
+msgid "Sponsored by"
+msgstr "Patrocinat per"
+
+msgid "Sponsored by: AMD"
+msgstr "Patrocinat per AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Patrocinat per B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Patrocinat per Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Patrocinat per IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Subpaquets"
+
+msgid "Support"
+msgstr "Suport"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"El procés d'instal·lació està disponible en moltes llengües però, per a la "
+"majoria, la traducció de les aplicacions no s'inclou a la imatge. Si voleu "
+"que el vostre sistema openSUSE tingui suport d'una llengua addicional, l'heu "
+"de baixar d'Internet durant la instal·lació o després. Si teniu accés fàcil "
+"a Internet no necessiteu aquest CD, que és només per a màquines sense "
+"connexió. Si voleu tenir l'openSUSE en català l'opció més fàcil és "
+"instal·lar-lo per xarxa, així ja el tindreu en català des del primer moment "
+"i no us caldrà acabar d'instal·lar després els paquets de llengua."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Llavors executeu el següent com a <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Ara no hi ha versió d'openSUSE en fase de proves. <br/> Si voleu fer servir "
+"programari d'última generació; si us plau, utilitzeu <a href='http://en."
+"opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Aquest CD conté programari gratuït distribuït sota llicència privada que no "
+"permet incloure'l al mitjà d'instal·lació principal conjuntament amb el "
+"programari lliure de codi obert. Tot el programari d'aquest CD es pot "
+"descarregar des del repositori NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Aquesta versió funciona en tots els PC, fins i tot amb els de 64 bits. Si "
+"teniu més de 3 GB de RAM, hauríeu de preferir la versió de 64 bits. OpenSUSE "
+"no té suport per a processadors més antics que els Pentium - els CD vius "
+"fins i tot per a i686 (Pentium Pro i posteriors)."
+
+msgid "Type of Computer"
+msgstr "Tipus d'ordinador"
+
+msgid "Unsupported distributions:"
+msgstr "Distribucions sense suport:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Els manuals d'usuari estan disponibles a <a href=\"http://activedoc.opensuse."
+"org\">activedoc.opensuse.org</a>, per exemple <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">la Guia oficial d'inici</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Usar <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> és "
+"recomanable per a enllaços lents, especialment per a la descàrrega del DVD. "
+"Les baixades de BitTorrent tenen alguns beneficis: els clients protegeixen "
+"contra la corrupció de dades i alhora ajudeu a alleujar la càrrega dels "
+"servidors participant també a la pujada -si hi participa prou gent serà fins "
+"i tot més ràpid que els servidors centralitzats- per a tothom. Sobretot us "
+"permet aturar la descàrrega i continuar-la més tard."
+
+msgid "Verify your download before use"
+msgstr "Verifiqueu la descàrrega abans de fer-la servir"
+
+msgid "Version"
+msgstr "Versió"
+
+msgid "We offer three different checksums:"
+msgstr "Oferim tres tipus de sumes de verificació:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Ens agradaria que ens mantinguéssiu informats de l'ús que feu del DVD, per "
+"tal que puguem\n"
+"        ajudar-vos a  promocionar la vostra organització, esdeveniment o "
+"escola a la nostra\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>pàgina "
+"de notícies</a>\n"
+"        o altres recursos. (Pista! Ens agraden les fotos! Feu-ne moltes!). "
+"Si us plau, contacteu amb nosaltes a\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        per parlar de la promoció o d'altres maneres en què us puguem "
+"assistir."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Quan descarregueu imatges diferents del CD d'instal·lació per xarxa, és "
+"<i>molt</i> recomanable que feu servir un gestor de descàrregues adient per "
+"reduir el risc de corrupció de dades. "
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Podeu afegir la clau del repositori a apt. Tingueu present que el propietari "
+"de la clau pot distribuir actualitzacions, paquets i repositoris en què el "
+"vostre sistema confiarà. (<a href=\"%s\">Més informació</a>). Per afegir la "
+"clau, executeu:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Podeu provar d'ampliar la cerca als paquets de desenvolupament o cercar en "
+"una altra distribució de base (vigent)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Podeu verificar el fitxer durant el procés de baixada. Per exemple, es farà "
+"servir automàticament una suma de verificació (SHA256) si escolliu <a "
+"href='http://en.opensuse.org/SDB:Metalink'>Metaenllaç</a> al camp anterior i "
+"useu el complement DownThemAll! al <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "signatura gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"és encara la suma de verificació més usada. Molts gravadors d'ISO la mostren "
+"abans d'enregistrar-les."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "és menys coneguda però més segura que la suma md5."
+
+msgid "md5 checksum"
+msgstr "La suma md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"ofereix la màxima seguretat ja que podeu verificar qui ho ha siginat. Hauria "
+"de ser <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Compte enrere d'openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivats d'openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"L'openSUSE està disponible a través d'http (enllaç directe) o BitTorrent. El "
+"CD d'instal·lació per xarxa només està disponible per http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "L'openSUSE només ofereix suport per a 32 i 64 bits."
+
+msgid "see Derivatives on wiki"
+msgstr "Vegeu-ne els Derivats a la wiki"
+
+msgid "sha1 checksum"
+msgstr "La suma sha1"
+
+msgid "switch to"
+msgstr "Canvieu a"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Hi ha hagut un error intern."
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Si us plau, introduïu més de 2 caràcters"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Últimes cerques:"
+
+#~ msgid "Statistics"
+#~ msgstr "Estadístiques"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Baixades d'1-clic més usuals:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Cerques més usades sense coincidència:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Cerques més usuals:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"

--- a/locale/cs/software.po
+++ b/locale/cs/software.po
@@ -1,0 +1,1259 @@
+# Vojtěch Zeisek <vojta.sc@seznam.cz>, 2009.
+# Vojtěch Zeisek <Vojtech.Zeisek@opensuse.org>, 2010, 2015.
+# Vít Pelčák <vit@pelcak.org>, 2011.
+# Jan Papež <honyczek@centrum.cz>, 2011, 2012, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-05 22:14+0100\n"
+"Last-Translator: Jan Papez (honyczek) <honyczek@centrum.cz>\n"
+"Language-Team: Czech <opensuse-translation@opensuse.org>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 2.0\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+msgid " and "
+msgstr " a "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} není podporované vydání.\""
+
+msgid "(hide)"
+msgstr "(skrýt)"
+
+msgid "(show)"
+msgstr "(zobrazit)"
+
+msgid "... and keep us informed"
+msgstr "... a dejte nám vědět"
+
+msgid "... get other marketing stuff"
+msgstr "... získat další marketingové věci"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (též vhodné pro USB flash disk)"
+
+msgid "64 Bit PC"
+msgstr "64 bitové PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Startovní "
+"průvodce openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">Metalink</a> je otevřený "
+"standard, který spojuje různé cesty (FTP/HTTP/BitTorrent) tak, aby dostal "
+"soubory do jediného formátu pro snadnější stahování. To je dobré ke "
+"stahování ISO obrazů; částečně pro lidi, kteří nemohou využít P2P spojení z "
+"důvodů omezení od poskytovatele nebo univerzity. Může dosáhnout velmi vysoké "
+"rychlosti stahování, protože většina klientů automaticky podporuje "
+"vícenásobná spojení k více zrcadlům. Navíc má automatickou detekci chyb. Je "
+"k&nbsp;tomu však potřeba speciální klient."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://cs.opensuse.org/openSUSE:Licence\">Licence</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Poznámky k vydání</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>oficiální vydání</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>oficiální aktualizace</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Pracovní prostředí GNOME, které můžete spustit z %s nebo z USB flash disku."
+"<br />Může být nainstalováno tak, jak je (bez povýšení)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Pracovní prostředí KDE, které můžete spustit z %s nebo z USB flash disku."
+"<br />Může být nainstalováno tak, jak je (bez povýšení)."
+
+msgid "Add repository and install manually"
+msgstr "Přidat repozitář a instalovat ručně"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Doplňky ke stažení (volitelné)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Poté co si úspěšně stáhnete ISO obraz(y), vytvořte startovací USB flash disk "
+"nebo je vypalte na DVD (popř. na CD, pokud vybraný obraz vyhovuje velikostí)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Všechna data jsou použita pouze pro odeslání propagačních materiálů "
+"openSUSE\n"
+"       a nebudou rozšiřována třetím stranám. Tato data ukládáme k tomu,\n"
+"       abychom informovali uživatele, zda je k dispozici nová verze. Všechny "
+"požadavky\n"
+"       musí být promítány, aby bylo vyhověno exportnímu embargu Spojených "
+"států amerických. Více informací\n"
+"       o embargu a seznam zemí na Wikipedii <a href='http://en.wikipedia.org/"
+"wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Prohlížeč aplikací"
+
+msgid "Available Images"
+msgstr "Dostupné obrazy"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Nastartujte z DVD, CD nebo USB flash disku. Pokud váš počítač automaticky "
+"nestartuje z vybraného zařízení, upravte patřičné nastavení v BIOSu."
+
+msgid "Bronze Sponsor"
+msgstr "Bronzový sponzor"
+
+msgid "Browser incompatibility"
+msgstr "Nekompatibilita prohlížečů"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Vypálit obrazy CD/DVD"
+
+msgid "Categories"
+msgstr "Kategorie"
+
+msgid "Category"
+msgstr "Kategorie"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Kliknutím vyberte instalační médium a stiskněte tlačítko stahování. Případně "
+"můžete zvolit typ vašeho počítače a jinou metodu stahování."
+
+msgid "Click here to display these alternative versions."
+msgstr "Pro zobrazení alternativních verzí klepněte sem."
+
+msgid "Click to Download"
+msgstr "Klikněte a stáhněte"
+
+msgid "Community"
+msgstr "Komunita"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Obsahuje obrovskou sbírku software pro použití na osobních počítačích i "
+"serverech.<br/>Vhodné pro instalaci nebo upgrade."
+
+msgid "Countdown"
+msgstr "Odpočítávání"
+
+msgid "Country"
+msgstr "Země"
+
+msgid "Development"
+msgstr "Vývoj"
+
+msgid "Development Version"
+msgstr "Vývojová verze"
+
+msgid "Development packages"
+msgstr "Vývojové balíčky"
+
+msgid "Development-"
+msgstr "Vývoj-"
+
+msgid "Direct Install"
+msgstr "Přímá instalace"
+
+msgid "Direct Link"
+msgstr "Přímý odkaz"
+
+msgid "Documentation"
+msgstr "Dokumentace"
+
+msgid "Don't show this warning the next time"
+msgstr "Příště toto upozornění nezobrazovat"
+
+msgid "Download"
+msgstr "Stáhnout"
+
+msgid "Download %s"
+msgstr "Stáhnout %s"
+
+msgid "Download Help"
+msgstr "Nápověda ke stahování"
+
+msgid "Download Method"
+msgstr "Metoda stažení"
+
+msgid "Download appliance from %s"
+msgstr "Stáhnout předpřipravený systém z %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Stáhnout&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Stáhnout&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Stáhnout&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Stáhnout&nbsp;Síťové"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Stáhnout&nbsp;Záchranné"
+
+msgid "Downloads"
+msgstr "Stažení"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Stahuje instalační systém a všechny balíčky z on-line repozitáře.<br/>Vhodné "
+"k instalaci nebo upgrade."
+
+msgid "Expand all sections ('e')"
+msgstr "Rozbalit všechny oddíly ('e')"
+
+msgid "Extra Languages"
+msgstr "Další jazyky"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Další jazyky (32 bitů)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Další jazyky (64 bitů)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Pro <strong>%s</strong> spusťte jako <strong>root</strong> následující:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Pro <strong>%s</strong> spusťte následující:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"V <strong>Arch Linuxu</strong> upravte /etc/pacman.conf a přidejte "
+"následující (pozor, pořadí repozitářů v souboru pacman.conf je důležité, "
+"protože pacman vždy stahuje první nalezený balíček):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Pro každé ISO nabízíme soubor s kontrolním součtem s odpovídajícím SHA256 "
+"součtem."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Pro větší bezpečnost můžete pomocí GPG ověřit, kdo podepsal tyto .sha256 "
+"soubory. Měl by to být %s."
+
+msgid "Games"
+msgstr "Hry"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Získejte jednu ze specializovaných distribucí založených na openSUSE."
+
+msgid "Getting Help"
+msgstr "Získání nápovědy"
+
+msgid "Gold Sponsor"
+msgstr "Zlatý sponzor"
+
+msgid "Grab binary packages directly"
+msgstr "Získat binární balíčky přímo"
+
+msgid "Header Logo"
+msgstr "Logo hlavičky"
+
+msgid "Help on Download Method"
+msgstr "Pomoc s metodou stažení"
+
+msgid "Help on Type of Computer"
+msgstr "Nápověda k typům počítačů"
+
+msgid "How to Proceed"
+msgstr "Jak postupovat"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Pokud chcete použít přímý odkaz, ale žijete v místě, kde přesměrovávač "
+"stahování nemá dostatek informací k tomu, aby vás přesměroval na rychlejší "
+"zrcadlo, můžete si nejbližší zrcadlo vybrat sami."
+
+msgid "Image:"
+msgstr "Obraz:"
+
+msgid "Install package %s / %s"
+msgstr "Nainstalovat balíček %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Nainstalovat šablonu %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instalovat pomocí Instalace jedním klepnutím"
+
+msgid "Installation Guides"
+msgstr "Instalační příručky"
+
+msgid "Installation Medium"
+msgstr "Instalační médium"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Přidejte se k rychle rostoucí komunitě. Předejte openSUSE do dalších\n"
+"        rukou. Získáním nejnovějšího PromoDVD pro vaši skupinu přátel,\n"
+"        neziskovou organizaci, školu, univerzitu nebo na akci jako jsou\n"
+"        setkání uživatelů Linuxu (LUG), installfesty a konference.\n"
+"        Propagační DVD pomáhají zvyšovat povědomí openSUSE a zviditelňují je!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror z KDE 3 je naneštěstí neudržovaný a jeho implementace JavaScriptu "
+"obsahuje chyby, které jeho použití na této stránce činí nemožným. Prosíme, "
+"ujistěte se, že máte vypnutý javascript a pak <a href='%s'>pokračujte</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Jazyk"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Staré 32 bitové PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Staré&nbsp;32&nbsp;bitové&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Živé GNOME"
+
+msgid "Live KDE"
+msgstr "Živé KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Mnoho aplikací může ověřit kontrolní součet stažených dat. Ověření stažených "
+"dat může být důležité, protože se ujistíte, že jste skutečně stáhli soubor "
+"ISO, který jste chtěli a ne nějakou poškozenou verzi."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Více informací k&nbsp;vypalování ISO souboru na CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Více informací k&nbsp;vytváření <a href='http://en.opensuse.org/SDB:"
+"Live_USB_stick'>spustitelného USB flashdisku</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Více informací ke stahování openSUSE je k dispozici v&nbsp;\n"
+"<a href=\"http://en.opensuse.org/SDB:Download_help\">Nápovědě ke stahování</"
+"a> a <a href=\"http://en.opensuse.org/SDB:Network_installation\">Síťové "
+"instalaci</a>,\n"
+"které naleznete v&nbsp;<a href=\"http://cs.opensuse.org/Portal:Dokumentace"
+"\">Dokumentační Wiki</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Většina nových počítačů podporuje <a href=\"http://cs.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (také známé jako AMD64 a Intel64), ale některé procesory "
+"notebooků a netbooků to nepodporují. Pokud si nejste jisti, jestli váš "
+"počítač podporuje 64 bitů, obraťte se na Wikipedii nebo na stránky výrobce."
+
+msgid "Multimedia"
+msgstr "Multimédia"
+
+msgid "Need help?"
+msgstr "Potřebujete pomoci?"
+
+msgid "Network"
+msgstr "Síť"
+
+msgid "No appliance data for %s"
+msgstr "Žádná data předpřipraveného systému pro %s"
+
+msgid "No appliances found in project %s"
+msgstr "V projektu %s nebyly nalezeny žádné předpřipravené systémy"
+
+msgid "No data for %s / %s"
+msgstr "Žádná data pro %s / %s"
+
+msgid "No description found..."
+msgstr "Nebyl nalezen popis..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Pro %s v projektu %s nebylo nalezeno nic ke stažení "
+
+msgid "No packages found matching your search. "
+msgstr "Nebyly nalezeny žádné balíčky vyhovující vašemu hledání. "
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+msgid "OBS Backend not available"
+msgstr "Výkonná část OBS není dostupná"
+
+msgid "Official Manuals"
+msgstr "Oficiální manuály"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Plně testované jsou pouze média DVD a Síť. Alternativy jako živé nebo "
+"záchranné systémy jsou doporučeny jen pro omezené používání."
+
+msgid "Package %s not found..."
+msgstr "Balíček %s nebyl nalezen..."
+
+msgid "Package Repositories"
+msgstr "Repozitáře softwaru"
+
+msgid "Package Search"
+msgstr "Vyhledávání balíčků"
+
+msgid "Packages for %s:"
+msgstr "Balíčky pro %s:"
+
+msgid "Pick Mirror"
+msgstr "Vyberte zrcadlo"
+
+msgid "Platinum Sponsor"
+msgstr "Platinový sponzor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Buďte si prosím vědomi, že následující balíčky jsou z neoficiálních "
+"repozitářů.\n"
+"  To znamená, že nebyly openSUSE prohlédnuty a mohou obsahovat nestabilní "
+"nebo experimentální software."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Zadejte prosím <b>stručný</b> důvod (anglicky), nač chcete použít DVD, a "
+"přiložte odkaz na událost/účel."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Vezměte na vědomí, že toto není nejposlednější vydání openSUSE. Poslední "
+"vydání můžete obdržet <a href='/'>zde</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"PromoDVD a všechny příbuzné propagační materiály - štítky a obal - můžete\n"
+"stáhnout z <a href=\"http://download.opensuse.org/promodvd/\">adresáře\n"
+"pro stažení promodvd %s</a>. Nezapomeňte, že toto je speciální verze\n"
+"openSUSE, navržená především pro propagační šíření."
+
+msgid "Related categories:"
+msgstr "Příbuzné kategorie:"
+
+msgid "Released Version"
+msgstr "Aktuální verze"
+
+msgid "Reporting Bugs"
+msgstr "Hlášení chyb"
+
+msgid "Rescue"
+msgstr "Záchrana"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Záchranný systém, který můžete spustit z CD nebo z USB flash disku.<br /"
+">Nemůže být použit pro instalaci ani povýšení verze distribuce."
+
+msgid "SHA256 checksum"
+msgstr "kontrolní součet SHA256"
+
+msgid "Search"
+msgstr "Najít"
+
+msgid "Select Your Operating System"
+msgstr "Vyberte váš operační systém"
+
+msgid "Select the image type"
+msgstr "Zvolte typ obrazu"
+
+msgid "Show"
+msgstr "Zobrazit"
+
+msgid "Show development, language and debug packages"
+msgstr "Zobrazit vývojové, jazykové a ladící balíčky"
+
+msgid "Show distribution:"
+msgstr "Zobrazit distribuci:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Zobrazit více balíčků pro nepodporované distribuce"
+
+msgid "Show more..."
+msgstr "Zobrazit více..."
+
+msgid "Show other versions"
+msgstr "Zobrazit jiné verze"
+
+msgid "Show unstable packages"
+msgstr "Zobrazit nestabilní balíčky"
+
+msgid "Show unsupported packages"
+msgstr "Zobrazit nepodporované balíčky"
+
+msgid "Silver Sponsor"
+msgstr "Stříbrný sponzor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Též jsou dostupná některá alternativní média (jako živé a záchranné "
+"systémy), avšak ty jsou o něco méně testovaná a jsou doporučena spíše pro "
+"omezené používání."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Některé živé distribuce založené na openSUSE. Ti, co by měli zájem o tvorbu "
+"své vlastní odvozeniny, se mohou podívat na <a href=\"http://susestudio.com/"
+"\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Zdroj"
+
+msgid "Sponsored by"
+msgstr "Sponzorováno"
+
+msgid "Sponsored by: AMD"
+msgstr "Sponzor: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponzor: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponzor: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponzor: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Podbalíčky"
+
+msgid "Support"
+msgstr "Podpora"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Instalační proces je dostupný v mnoha jazycích, ale pro většinu z nich není "
+"překlad aplikací zahrnutý v obrazu. Pokud chcete, aby váš systém openSUSE "
+"podporoval další jazyk, budete jej muset stáhnout z internetu během "
+"instalace nebo kdykoliv později. Toto CD nepotřebujete, pokud máte snadný "
+"přístup k internetu, ale pokud se chystáte instalovat openSUSE na nějaký "
+"stroj bez internetového připojení, máte na tomto CD možnost si vybrat z "
+"dostupných překladů."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Potom jako <strong>root</strong> spusťte následující:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"V současnosti nemáme žádné vydání openSUSE v této fázi. <br/> Pokud chcete "
+"používat krajní verze softwaru, použijte prosím <a href='http://cs.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Toto CD obsahuje software dostupný zdarma, ale pod proprietární licencí, "
+"která neumožňuje jeho zařazení na hlavní média dohromady se svobodným open-"
+"source software. Veškerý software z tohoto CD může být stažen z NON-OSS "
+"repozitáře."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Tato verze funguje na všech typech PC včetně těch podporujících 64 bitů. "
+"Pokud máte více jak 3 GB RAM, měli byste dát raději přednost 64 bitové "
+"verzi. openSUSE nepodporuje procesory starší než Pentium - živá CD podporují "
+"pouze i686 (Pentium Pro a novější)."
+
+msgid "Type of Computer"
+msgstr "Typ počítače"
+
+msgid "Unsupported distributions:"
+msgstr "Nepodporované distribuce:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Uživatelské příručky jsou dostupné na <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, například <a href=\"http://activedoc.opensuse."
+"org/book/opensuse-start-up/\">Oficiální Startovní průvodce</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Použití <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrentu</a> je "
+"doporučeno na pomalých linkách, zvláště stahujete-li obraz DVD. Stahování "
+"přes BitTorrent má řadu výhod, klient je chráněn před poškozením dat a "
+"zároveň pomáháte odlehčit zátěž centrálním serverům podílem na uploadu - "
+"pokud se na stahování podílí hodně lidí, je to také pro všechny rychlejší "
+"než stahování z jednoho serveru. Navíc máte možnost kdykoliv přerušit "
+"stahování a obnovit jej později."
+
+msgid "Verify your download before use"
+msgstr "Před použitím ověřte vaše stažené soubory"
+
+msgid "Version"
+msgstr "Verze"
+
+msgid "We offer three different checksums:"
+msgstr "Nabízíme tři různé kontrolní součty:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Byli bychom rádi, kdybyste nás informovali o využívání získaných DVD.\n"
+"        Můžeme vám takto pomoci propagovat vaši organizaci, událost nebo "
+"školu na\n"
+"        naší <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>stránce s&nbsp;novinkami</a> nebo dalšími prostředky.\n"
+"        (Rada: Máme rádi fotografie. Vyfoťte jich hodně!)\n"
+"        Kontaktujte nás prosím (anglicky) na adrese <a href='mailto:opensuse-"
+"marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>, abychom\n"
+"        prodiskutovali propagaci a/nebo další způsoby, jak vám můžeme pomoci."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Pokud stahujete jiné obrazy než CD pro síťovou instalaci, je <i>důrazně</i> "
+"doporučeno použití kvalitního správce stahování, abyste minimalizovali "
+"riziko poškození dat během přenosu."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Klíč repozitáře můžete do aptu přidat. Vezměte v úvahu, že vlastník klíče "
+"může distribuovat aktualizace, balíčky a repozitáře, kterým pak bude váš "
+"systém důvěřovat (<a href=\"%s\">více informací</a>). Pro přidání klíče "
+"spusťte:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Zkuste rozšířit vyhledávání na vývojové balíčky nebo hledat v jiné základní "
+"distribuce (aktuálně)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Ověřit soubor můžete i&nbsp;v&nbsp;průběhu stahování. Pokud například v&nbsp;"
+"políčku výše vyberete <a href='http://en.opensuse.org/SDB:"
+"Metalink'>Metalink</a> a ve <a href='http://cs.opensuse.org/"
+"Firefox'>Firefoxu</a> použijete rozšíření DownThemAll!, pak se automaticky "
+"zpracuje kontrolní součet (SHA256)."
+
+msgid "gpg signature"
+msgstr "GPG podpis"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES.cs."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/RELEASE-NOTES.cs."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/RELEASE-NOTES.cs."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/RELEASE-NOTES.cs."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES.cs."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.cs.html"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.cs.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"je stále nejpoužívanějším kontrolním součtem. Mnoho nástrojů vypalujících "
+"ISO jej před vypálením zobrazí."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "jde o méně známý kontrolní součet než MD5, ale je bezpečnější."
+
+msgid "md5 checksum"
+msgstr "kontrolní součet MD5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"nabízí nejvíc bezpečnosti, protože můžete ověřit, kdo to podepsal. Mělo by "
+"to být <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Odpočítávání openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Odvozeniny openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE je dostupné přes HTTP (přímý odkaz) nebo BitTorrent. CD pro síťovou "
+"instalaci je dostupné pouze přes HTTP."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE podporuje pouze 32 a 64 bitové počítače."
+
+msgid "see Derivatives on wiki"
+msgstr "Podívejte se na odvozeniny na wiki"
+
+msgid "sha1 checksum"
+msgstr "kontrolní součet SHA1"
+
+msgid "switch to"
+msgstr "přepnout na"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Došlo k interní chybě :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Zadejte prosím více než 2 znaky"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES."
+#~ "cs.html"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES."
+#~ "cs.html"
+
+#~ msgid "Last searches:"
+#~ msgstr "Nedávná vyhledávání:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistika"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Nejstahovanější balíčky Jedním klepnutím:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Nejvyhledávanější bez výsledku:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Nejvyhledávanější:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES."
+#~ "cs.html"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "V&nbsp;současné době nemáme tovární snímek,\n"
+#~ "který by byl aktuálnější než nejnovější vydání openSUSE.<br />\n"
+#~ "Pro více informací sledujte stránku <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a>."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Můžete do aptu přidat klíč repozitáře následujícím způsobem: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4,7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD obsahuje pouze čtyři jazyky (angličtinu, němčinu, ruštinu a "
+#~ "italštinu). Pokud chcete mát podporu pro zbývající jazyky, musíte si ji "
+#~ "stáhnout z internetu během instalace nebo kdykoliv potom. Pokud máte "
+#~ "snadný přístup k internetu nebo pokud používáte DVD obsahující podporu "
+#~ "pro všechny jazyky, toto CD nepotřebujete."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Poté, co stáhnete ISO obraz(y), vypalte je pomocí vaší oblíbené aplikace "
+#~ "vypalující CD nebo DVD. Prosíme, <em>nevypalujte</em> datová CD, ale "
+#~ "zvolte možnost vypálit ISO obraz."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Můžete spustit pracovní prostředí GNOME z CD nebo USB paměti.<br/>Může "
+#~ "být použito k instalaci, ale ne k aktualizaci."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Můžete spustit pracovní prostředí KDE z CD nebo USB paměti.<br/>Může být "
+#~ "použito k instalaci, ale ne k aktualizaci."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "Zkuste rozšířit vaše vyhledávání na nepodporované balíčky nebo "
+#~ "prohledávat jinou základní distribuci (v současnosti )."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.cs.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.cs.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Jako řetězec pro vyhledávání použijte prosím nejméně 2 znaky"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Z důvodu velkého množství nálezů podřetězcového hledání bylo přepnuto na "
+#~ "přesnou shodu."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Prosíme, buďte ve svém vyhledávání přesnější. Bylo dosaženo limitů "
+#~ "hledání."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Nešlo provést vyhledávání: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Populární software"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Kupte openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Nainstalovat 1 kliknutím"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Ruční stažení balíčku"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Jděte do openSUSE Building Projectu"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Softwarová kolekce]"
+
+#~ msgid "Search Results"
+#~ msgstr "Vyhledat podrobnosti"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "V&nbsp;openSUSE Build Service nebyly nalezeny žádné balíčky odpovídající "
+#~ "vašemu dotazu."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d kolekce a %d binární balíčky ze %d zdrojových balíčků"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Snímek z  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Vyhledat statistiku:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Statistika stahování:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Hledejte a instalujte balíčky z <a href=\"http://build.opensuse.org"
+#~ "\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Volby vyhledávání"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Zahrnout uživatelské domácí projekty"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Vyloučit debugovací balíčky"
+
+#~ msgid "Additional Information"
+#~ msgstr "Další informace"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Kupte openSUSE 11.2"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2!"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Kupte openSUSE 11.2!"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Více informací o stahování openSUSE je dostupných na stránce <a href="
+#~ "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Následující instrukce jsou dostupné:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Instalace z CD/DVD"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Oficiální %s základní příručka"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Instalační příručka krok za krokem"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Síťová instalace"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Derivatives"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Instalace přes internet"
+
+#~ msgid "More information"
+#~ msgstr "Více informací"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Získejte software"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Vytvořte software"
+
+#~ msgid "User Directory"
+#~ msgstr "Uživatelský adresář"
+
+#~ msgid "Features"
+#~ msgstr "Vlastnosti"
+
+#~ msgid "News"
+#~ msgstr "Novinky"
+
+#~ msgid "Forums"
+#~ msgstr "Fórum"
+
+#~ msgid "Shop"
+#~ msgstr "Obchod"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Vyhledat software"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Aktualizační repozitáře"
+
+#~ msgid "Source Repository"
+#~ msgstr "Zdrojový repozitář"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Další volby"
+
+#~ msgid "Mirrors"
+#~ msgstr "Zrcadla"
+
+#~ msgid "In other languages"
+#~ msgstr "V jiných jazycích"
+
+#~ msgid "Get it"
+#~ msgstr "Získejte to"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Prohledat Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Hledejte a instalujte další balíčky software pomocí openSUSE Build "
+#~ "Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Získejte openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Trvalý odkaz na tento výsledek"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nic nenalezeno"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Získejte software z openSUSE Build Service"
+
+#~ msgid "Searching"
+#~ msgstr "Vyhledávání"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Obsahuje obrovskou sbírku software pro použití na osobních počítačích i "
+#~ "serverech. Vhodné pro instalaci nebo upgrade."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Můžete spustit pracovní prostředí GNOME z CD nebo USB paměti. Může být "
+#~ "použito k instalaci, ale ne k aktualizaci."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Můžete spustit pracovní prostředí KDE z CD nebo USB paměti. Může být "
+#~ "použito k instalaci, ale ne k aktualizaci."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Stahuje instalační systém a všechny balíčky z on-line repozitáře. Vhodné "
+#~ "k instalaci nebo upgrade."
+
+#, fuzzy
+#~| msgid "Italian"
+#~ msgid "Metalinks"
+#~ msgstr "Italština"
+
+#, fuzzy
+#~| msgid "openSUSE 11"
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "openSUSE 11"
+
+#, fuzzy
+#~| msgid "Expert options"
+#~ msgid "Expert view"
+#~ msgstr "Expertní volby"
+
+#~ msgid "Help"
+#~ msgstr "Nápověda"
+
+#, fuzzy
+#~| msgid "GNOME desktop"
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Prostředí GNOME"
+
+#, fuzzy
+#~| msgid "KDE desktop"
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Prostředí KDE"

--- a/locale/da/software.po
+++ b/locale/da/software.po
@@ -1,0 +1,974 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Martin Schlander <mschlander@opensuse.org>, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: version 0.0.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-04 08:10+0100\n"
+"Last-Translator: Martin Schlander <mschlander@opensuse.org>\n"
+"Language-Team: Danish <opensuse-translation@opensuse.org>\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.5\n"
+
+msgid " and "
+msgstr " og "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} er ikke en supporteret udgivelse.\""
+
+msgid "(hide)"
+msgstr "(skjul)"
+
+msgid "(show)"
+msgstr "(vis)"
+
+msgid "... and keep us informed"
+msgstr "... og hold os informeret"
+
+msgid "... get other marketing stuff"
+msgstr "... få andet marketinghalløj"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB dvd (kan også bruges som USB-pen)"
+
+msgid "64 Bit PC"
+msgstr "64-bit pc"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"Start-Up Guide</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> er en åben "
+"standard der sammenkobler de forskellige måder (FTP/HTTP/BitTorrent) at få "
+"filer på i ét format for nemmere downloads. Det gør det velegnet til "
+"download af ISO-filer, især for personer der ikke kan bruge P2P på grund af "
+"restriktioner fra deres internetudbyder eller universitet. Det kan levere "
+"meget høje hastigheder, da de fleste klienter understøtter flere "
+"forbindelser til flere mirrors, automatisk. Desuden kan det udføre "
+"automatisk detektion og rettelse af fejl. Det kræver dog et særligt  "
+"klientprogram til at håndtere det."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licens</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Udgivelsesnoter</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>officiel udgivelse</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>officiel opdatering</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Et GNOME-skrivebordsmiljø du kan køre fra %s eller usb-pen.<br/>Kan "
+"installeres som den er (ikke til  opgradering)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Et KDE-skrivebordsmiljø du kan køre fra %s eller usb-pen.<br/>Kan "
+"installeres som den er (ikke til opgradering)."
+
+msgid "Add repository and install manually"
+msgstr "Tilføj softwarekilde og installér manuelt"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Download af tillæg (valgfrit)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Efter gennemført download af ISO-imagefil, kan du oprette en bootbar USB-pen "
+"eller brænde imagefilerne til en dvd (eller en cd, hvis der er plads til det "
+"valgte image)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Al data bruges kun til at sende openSUSE promoveringsmateriale\n"
+"          og vil ikke blive videregivet til tredjeparter. Vi gemmer data for "
+"at\n"
+"          informere brugere når en ny version er tilgængelig. Alle "
+"forespørgsler skal\n"
+"          screenes for at opfylde USA's eksportembargo. Mere information\n"
+"          om embargoen og en liste over lande findes på wikipedia <a "
+"href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://en."
+"wikipedia.org/wiki/United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Gennemse programmer"
+
+msgid "Available Images"
+msgstr "Tilgængelige image-filer"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Boot fra dvd, cd eller USB-pen. HVis din computer ikke automatisk booter fra "
+"den valgte enhed, så gå til BIOS-opsætningen og tillad boot fra enheden."
+
+msgid "Bronze Sponsor"
+msgstr "Bronzesponsor"
+
+msgid "Browser incompatibility"
+msgstr "Browser-inkompatibilitet"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Brænd cd-/dvd-imagefil"
+
+msgid "Categories"
+msgstr "Kategorier"
+
+msgid "Category"
+msgstr "Kategori"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Vælg et installationsmedie ved at klikke på det og tryk på download-knappen "
+"for at starte downloadet. Vælg eventuelt din computertype eller en "
+"alternativ downloadmetode."
+
+msgid "Click here to display these alternative versions."
+msgstr "Klik her for at få vist disse alternative versioner."
+
+msgid "Click to Download"
+msgstr "Klik for at downloade"
+
+msgid "Community"
+msgstr "Community"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Indeholder en stor samling af software til desktop- eller serverbrug.<br/"
+">Egnet til installation eller opgradering."
+
+msgid "Countdown"
+msgstr "Nedtælling"
+
+msgid "Country"
+msgstr "Land"
+
+msgid "Development"
+msgstr "Udvikling"
+
+msgid "Development Version"
+msgstr "Udviklingsversion"
+
+msgid "Development packages"
+msgstr "Udviklingspakker"
+
+msgid "Development-"
+msgstr "Udvikling-"
+
+msgid "Direct Install"
+msgstr "Direkte installation"
+
+msgid "Direct Link"
+msgstr "Direkte link"
+
+msgid "Documentation"
+msgstr "Dokumentation"
+
+msgid "Don't show this warning the next time"
+msgstr "Vis ikke denne advarsel næste gang"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Download %s"
+msgstr "Download %s"
+
+msgid "Download Help"
+msgstr "Hjælp til download"
+
+msgid "Download Method"
+msgstr "Downloadmetode"
+
+msgid "Download appliance from %s"
+msgstr "Downloader anordning fra %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Download&nbsp;dvd"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Download&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Download&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Download&nbsp;netværk"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Download&nbsp;Redningssystem"
+
+msgid "Downloads"
+msgstr "Downloads"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Downloader installationssystemet og alle pakker fra online-softwarekilder."
+"<br/>Egnet til installation eller opgradering."
+
+msgid "Expand all sections ('e')"
+msgstr "Fold alle sektioner ud (\"e\")"
+
+msgid "Extra Languages"
+msgstr "Ekstra sprog"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Ekstra sprog (32-bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Ekstra sprog (64-bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "For <strong>%s</strong> kør følgende som <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "For <strong>%s</strong> kør følgende:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"På <strong>Arch Linux</strong>, redigér /etc/pacman.conf og tilføj følgende "
+"(bemærk at rækkefølgen af softwarekilder i pacman.conf er vigtig, da pacman "
+"altid downloader den først fundne pakke):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "Vi tilbyder en tjeksum-fil med den tilhørende SHA256-sum til hver ISO."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Som ekstra sikkerhed kan du bruge GPG til at verificere hvem der har "
+"signeret .sha256-filerne. Det bør være %s."
+
+msgid "Games"
+msgstr "Spil"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Hent en af de specialiserede distributioner baseret på openSUSE."
+
+msgid "Getting Help"
+msgstr "Få hjælp"
+
+msgid "Gold Sponsor"
+msgstr "Guldsponsor"
+
+msgid "Grab binary packages directly"
+msgstr "Hent binære pakker direkte"
+
+msgid "Header Logo"
+msgstr "Logo i sidehoved"
+
+msgid "Help on Download Method"
+msgstr "Hjælp til downloadmetode"
+
+msgid "Help on Type of Computer"
+msgstr "Hjælp til computertype"
+
+msgid "How to Proceed"
+msgstr "Hvordan du fortsætter"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Hvis du vil bruge et direkte link, men lever et sted i verden hvor vores "
+"download-omdirigering ikke har nok information til at omdirigere til det "
+"hurtigste mirror, kan du vælge et mirror selv."
+
+msgid "Image:"
+msgstr "Image-fil:"
+
+msgid "Install package %s / %s"
+msgstr "Installér pakken %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Installér mønstret %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Installér med 1-klik-installation"
+
+msgid "Installation Guides"
+msgstr "Installationsguides"
+
+msgid "Installation Medium"
+msgstr "Installationsmedie"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Bliv en del af det hurtigt voksende fællesskab, få openSUSE i fingrene på "
+"flere ved at\n"
+"        få den seneste promo-dvd til din gruppe, non-profit-organisation, "
+"skole\n"
+"        universitet eller events såsom LUG-møder, installparties og "
+"konferencer.\n"
+"        Promo-dvd'er hjælper med at forøge kendskabet til og synligheden af "
+"openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror fra KDE 3 bliver desværre ikke vedligeholdt og dens JavaScript-"
+"implementation indeholder fejl der gør den umulig at benytte til denne side. "
+"Sørg for at du har deaktiveret JavaScript før du <a href='%s'>fortsætter</a>."
+
+msgid "Language"
+msgstr "Sprog"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Legacy 32-bit pc"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Legacy 32-bit&nbsp;pc"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Mange programmer kan verificere tjeksummen for et download. Verifikation af "
+"dit download kan være vigtigt, da det sikrer at du faktisk har fået den ISO-"
+"fil du ønskede at downloade og ikke en defekt fil."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Mere information om at brænde ISO-filen til cd/dvd"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Mere information om at oprette en <a href='http://en.opensuse.org/"
+"Live_USB_stick'>USB-pen som kan boote</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Mere information om download af openSUSE kan findes på siderne <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Hjælp til download</a> og <a "
+"href=\"http://en.opensuse.org/SDB:Network_installation"
+"\">Netværksinstallation</a> i vores<a href=\"http://en.opensuse.org/Portal:"
+"Documentation\">Wiki med dokumentation</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"De fleste nye computere understøtter <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (også kendt som AMD64 og Intel64), men nogle processorer "
+"i bærbare computere og netbooks, understøtter det ikke. Så du er nødt til at "
+"tjekke Wikipedia hvis du vil være sikker på at din computer understøtter det."
+
+msgid "Multimedia"
+msgstr "Multimedie"
+
+msgid "Need help?"
+msgstr "Brug for hjælp?"
+
+msgid "Network"
+msgstr "Netværk"
+
+msgid "No appliance data for %s"
+msgstr "Ingen anordningsdata for %s"
+
+msgid "No appliances found in project %s"
+msgstr "Ingen anordninger fundet i projektet %s"
+
+msgid "No data for %s / %s"
+msgstr "Ingen data for %s / %s"
+
+msgid "No description found..."
+msgstr "Ingen beskrivelse fundet..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Ingen downloads til %s fundet i projektet %s"
+
+msgid "No packages found matching your search. "
+msgstr "Der blev ikke fundet nogen pakker som matcher din søgning. "
+
+msgid "NonOSS CD"
+msgstr "Ikke-OSS-cd"
+
+msgid "OBS Backend not available"
+msgstr "OBS-backenden er ikke tilgængelig"
+
+msgid "Official Manuals"
+msgstr "Officielle manualer"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Kun dvd- og netværksmedierne er grundigt testede. Alternative medier såsom "
+"live- eller redningssystemer anbefales kun til begrænset brug."
+
+msgid "Package %s not found..."
+msgstr "Pakken %s blev ikke fundet..."
+
+msgid "Package Repositories"
+msgstr "Softwarekilder"
+
+msgid "Package Search"
+msgstr "Pakkesøgning"
+
+msgid "Packages for %s:"
+msgstr "Pakker til %s:"
+
+msgid "Pick Mirror"
+msgstr "Vælg mirror"
+
+msgid "Platinum Sponsor"
+msgstr "Platinsponsor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Vær opmærksom på at følgende pakker kommer fra uofficielle softwarekilder.\n"
+"  Det betyder at de ikke er efterset af openSUSE og kan indeholde ustabil "
+"eller eksperimentel software."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Angiv en <b>kort</b> begrundelse (på engelsk!) af hvorfor du har brug for "
+"dvd'erne og give et link til begivenheden/formålet."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Bemærk at dette ikke er den seneste udgivelse af openSUSE. Du kan få den "
+"seneste version <a href='/'>her</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo-dvd'er og alt det relaterede grafik - etiketter og omslag - kan \n"
+"        downloades fra <a href=\"http://download.opensuse.org/promodvd/"
+"\">promo-dvd\n"
+"        download-mappen %s</a>. Bemærk at det er en særlig version af "
+"openSUSE,\n"
+"        specielt designet til markedsføringsformål."
+
+msgid "Related categories:"
+msgstr "Relaterede kategorier:"
+
+msgid "Released Version"
+msgstr "Udgivet version"
+
+msgid "Reporting Bugs"
+msgstr "Rapportering af programfejl"
+
+msgid "Rescue"
+msgstr "Redningssystem"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Et redningssystem som du kan køre fra cd eller en usb-pen.<br/>Kan hverken "
+"bruges til installation eller opgradering."
+
+msgid "SHA256 checksum"
+msgstr "SHA256-tjeksum"
+
+msgid "Search"
+msgstr "Søg"
+
+msgid "Select Your Operating System"
+msgstr "Vælg dit operativsystem"
+
+msgid "Select the image type"
+msgstr "Vælg type af image-fil"
+
+msgid "Show"
+msgstr "Vis"
+
+msgid "Show development, language and debug packages"
+msgstr "Vis pakker til udvikling, sprog og fejlsøgning"
+
+msgid "Show distribution:"
+msgstr "Vis distribution:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Vis flere pakker til ikke-supporterede distributioner"
+
+msgid "Show more..."
+msgstr "Vis flere..."
+
+msgid "Show other versions"
+msgstr "Vis andre versioner"
+
+msgid "Show unstable packages"
+msgstr "Vis ustabile pakker"
+
+msgid "Show unsupported packages"
+msgstr "Vis ikke-supporterede pakker"
+
+msgid "Silver Sponsor"
+msgstr "Sølvsponsor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Der er også nogle alternative medier tilgængelige (f.eks. live- og "
+"redningssystemer), men de er mindre testede og anbefales kun til begrænset "
+"brug."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Nogle af de live-distributioner som er baseret på openSUSE. Dem der er "
+"interesserede i at prøve at bygge deres egne specialversioner kan kaste et "
+"blik på  <a href=\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Kilde"
+
+msgid "Sponsored by"
+msgstr "Sponseret af"
+
+msgid "Sponsored by: AMD"
+msgstr "Sponseret af: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponseret af: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponseret af: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponseret af: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Underpakker"
+
+msgid "Support"
+msgstr "Support"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Installationsprocessen er tilgængelig på mange sprog, men for de fleste af "
+"dem er oversættelserne til programmer ikke inkluderet i imagefilerne. Hvis "
+"du vil have dit openSUSE-system til at understøtte yderligere sprog, skal du "
+"downloade det fra internettet under installationen eller på et senere "
+"tidspunkt. Hvis du har nem internetadgang, behøver du ikke denne cd, men "
+"hvis du påtænker at installere openSUSE på en maskine uden "
+"internetforbindelse, vil den give dig adgang til alle tilgængelige "
+"oversættelser."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Kør så følgende som <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Der er ikke nogen openSUSE-udgivelse under test i øjeblikket. <br/> Hvis du "
+"vil være på forkant med din software, så brug evt. <a href='http://en."
+"opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Denne cd indeholder gratis software distribueret under proprietære licenser, "
+"som ikke muliggør inkludering af det på hovedinstallationsmedierne med fri/"
+"open source software. Al software fra denne cd kan også downloades fra "
+"softwarekilden NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Denne version kører på alle pc'er inklusiv dem der understøtter 64-bit. Hvis "
+"du har mere end 3 GB ram bør du dog vælge 64-bit-versionen. openSUSE "
+"understøtter ikke processorer ældre end Pentium - live-cd'erne understøtter "
+"endda kun i686 (Pentium Pro og nyere)."
+
+msgid "Type of Computer"
+msgstr "Computertype"
+
+msgid "Unsupported distributions:"
+msgstr "Ikke-supporterede distributioner:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Brugermanualer kan findes på <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for eksempel <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">officiel Start-Up Guide</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Brug af <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> "
+"anbefales for langsomme forbindelser, især ved download af dvd-imagefilen. "
+"BitTorrent-downloads har flere fordele. Klienten beskytter mod "
+"datakorruption og du hjælper med at aflaste serverne ved at deltage i upload "
+"- hvis nok folk deltager er det også hurtigere end centrale servere - for "
+"alle. Ydermere giver det dig mulighed for at stoppe downloadet når som helst "
+"og genoptage det senere."
+
+msgid "Verify your download before use"
+msgstr "Verificér dit download før brug"
+
+msgid "Version"
+msgstr "Version"
+
+msgid "We offer three different checksums:"
+msgstr "Vi tilbyder tre forskellige tjeksummer:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Vi vil gerne have at du holder os informeret om din brug af dvd'erne, så vi\n"
+"        kan hjælpe med at promovere din organisation, event eller skole på "
+"vores\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>nyhedsside</a>\n"
+"        eller andre ressourcer. (Tip! Vi elsker fotos. Tag mange af dem!). "
+"Kontakt os på\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        for at tale om promovering og andre måder vi kan hjælpe dig på."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Ved download af imagefiler, udover cd'en til netværksinstallation, anbefales "
+"det <i>kraftigt</i> at bruge en rigtig download-manager for at reducere "
+"risikoen for defekte data."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Du kan tilføje softwarekilde-nøglen til apt. Vær opmærksom på at ejeren af "
+"nøglen kan distribuere opdateringer, pakker og softwarekilder, som dit "
+"system vil have tillid til (<a href=\"%s\">mere information</a>). For at "
+"tilføje nøglen, kør:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Du kan prøve at udvide din søgning til udviklingspakker eller søge efter en "
+"anden basisdistribution (aktuelt )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Du kan verificere filen under download. For eksempel vil en tjeksum (SHA256) "
+"automatisk blive brugt hvis du vælger <a href='http://en.opensuse.org/SDB:"
+"Metalink'>Metalink</a> i feltet ovenfor og bruger tilføjelsen DownThemAll! i "
+"<a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "gpg-signatur"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"er stadig den mest anvendte tjeksum. Mange ISO-brændere viser den før "
+"brænding."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "er en mindre kendt, men mere sikker tjeksum end md5."
+
+msgid "md5 checksum"
+msgstr "md5-tjeksum"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"tilbyder den højeste sikkerhed da du kan verificere hvem der signerede den. "
+"Det bør være <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Nedtælling til openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Specialversioner af openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE er tilgængelig via http (direkte link) eller BitTorrent. Cd'en til "
+"netværksinstallation er kun tilgængelig via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE understøtter kun pc'er med 32- og 64-bit."
+
+msgid "see Derivatives on wiki"
+msgstr "Se specialversioner på wiki'en"
+
+msgid "sha1 checksum"
+msgstr "sha1-tjeksum"
+
+msgid "switch to"
+msgstr "skift til"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Der opstod en intern fejl :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Indtast venligst mere end to tegn"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Seneste søgninger:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistik"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Top 1-klik-downloads:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Topsøgninger uden fund:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Topsøgninger:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Vi har i øjeblikket ikke et Factory-snapshot der er nyere end den seneste "
+#~ "udgivelse af openSUSE. <br/>Se <a href='http://en.opensuse.org/Portal:"
+#~ "Factory'>http://en.opensuse.org/Portal:Factory</a> for mere information."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Du kan føje softwarekilde-nøglen til apt på denne måde: "
+
+#~ msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.3"
+#~ msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.3"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB dvd"
+
+#, fuzzy
+#~| msgid ""
+#~| "Live images contain only four languages (English, German, Russian and "
+#~| "Italian). If you want to have support for remaining languages you need "
+#~| "to download it from the Internet during the installation or any time "
+#~| "after it. If you have easy access to the Internet or if you use DVD "
+#~| "containing all languages, you do not need this CD."
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live-imagefiler indeholder kun fire sprog (engelsk, tysk, russisk og "
+#~ "italiensk). Hvis du vil have understøttelse for andre sprog skal du hente "
+#~ "dem fra internettet under installationen eller nårsomhelst efter "
+#~ "installation. Hvis du har god internetadgang eller hvis du bruger dvd'en "
+#~ "som indeholder alle sprog, så behøver du ikke denne cd."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Efter korrekt download af ISO-imagefil(er), så brænd imagefil(erne) til "
+#~ "en dvd eller cd med dit foretrukne brænderprogram. Brænd <em>ikke</em> en "
+#~ "data-dvd/-cd, men vælg i stedet muligheden for at brænde en ISO-imagefil."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from USB stick.<br/>Can be installed as is "
+#~ "(no upgrade)."
+#~ msgstr ""
+#~ "Et GNOME-skrivebordsmiljø du kan køre fra usb-pen.<br/>Kan installeres "
+#~ "som den er (ikke til  opgradering)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from USB stick.<br/>Can be installed as is (no "
+#~ "upgrade)."
+#~ msgstr ""
+#~ "Et KDE-skrivebordsmiljø du kan køre fra usb-pen.<br/>Kan installeres som "
+#~ "den er (ikke til opgradering)."

--- a/locale/de/software.po
+++ b/locale/de/software.po
@@ -1,0 +1,1349 @@
+# Stephan Kulow <coolo@suse.de>, 2009, 2011.
+# Hermann-Josef Beckers <hj.beckers@onlinehome.de>, 2009.
+# Thomas Schmidt <tom@opensuse.org>, 2010, 2011.
+# Sebastian Gödecke <simpsonetti@googlemail.de>, 2012.
+# Michael Skiba <trans@michael-skiba.de>, 2012, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2014-11-01 23:36+0100\n"
+"Last-Translator: Michael Skiba <trans@michael-skiba.de>\n"
+"Language-Team: German <opensuse-translation-de@opensuse.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.5\n"
+
+msgid " and "
+msgstr " und "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} ist keine unterstützte Veröffentlichung.\""
+
+msgid "(hide)"
+msgstr "(ausblenden)"
+
+msgid "(show)"
+msgstr "(anzeigen)"
+
+msgid "... and keep us informed"
+msgstr "... und halten Sie uns auf dem Laufenden"
+
+msgid "... get other marketing stuff"
+msgstr "... weiteres Marketingmaterial"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (auch für USB-Stick geeignet)"
+
+msgid "64 Bit PC"
+msgstr "64-Bit-PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/de/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">Metalink</a> ist ein offener "
+"Standard, der verschiedene Wege (FTP/HTTP/BitTorrent) bündelt, um Dateien in "
+"ein Format zu bringen, das Downloads erleichtert. Dies macht es besonders "
+"geeignet für das Abrufen von ISO-Dateien, besonders für Menschen, die "
+"aufgrund von Beschränkungen durch ihre ISPs oder Universitäten keine P2P-"
+"Verfahren nutzen können. Es kann sehr schnelle Abrufzeiten bieten, da viele "
+"Clients automatisch Mehrfach-Verbindungen zu mehreren Spiegelservern  "
+"unterstützen. Zusätzlich bietet es automatische Fehler-Erkennung und -"
+"Korrektur. Es ist jedoch ein spezieller Client erforderlich."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Lizenz</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Veröffentlichungshinweise</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>Offizielle Veröffentlichung</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>Offizielle Aktualisierung</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Ein von %s oder USB-Stick lauffähiger GNOME-Desktop.<br/>Kann auch wie er "
+"ist installiert werden (kein Upgrade)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Ein von %s oder USB-Stick lauffähiger KDE-Desktop.<br/>Kann auch wie er ist "
+"installiert werden (kein Upgrade)."
+
+msgid "Add repository and install manually"
+msgstr "Das Repository hinzufügen und manuell installieren"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Herunterladen von weiteren Medien (optional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Nachdem Sie die ISO-Datei(en) erfolgreich heruntergeladen haben, erstellen "
+"Sie einen bootfähigen USB-Stick oder brennen das/die Abbild(er) auf eine DVD "
+"(oder eine CD, falls das Abbild von seiner Größe her darauf passt)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Alle Daten werden ausschließlich für den Versand von openSUSE-Promo-Material "
+"verwendet\n"
+"      und werden nicht an Dritte weitergegeben. Wir speichern die Daten um\n"
+"      Sie über neue Versionen zu Informieren. Alle Anfragen müssen\n"
+"      gesichtet werden um den Anforderungen US-Export-Embargo zu "
+"entsprechen.\n"
+"      Weitere Informationen und eine Liste der betroffenen Länder finden Sie "
+"bei Wikipedia <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+# App für Application?
+msgid "App Browser"
+msgstr "Anwendungsbrowser"
+
+msgid "Available Images"
+msgstr "Verfügbare Abbilder"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Booten Sie von der DVD, CD oder dem USB-Stick. Wenn ihr Computer nicht "
+"automatisch vom ausgewählten Medium bootet, öffnen Sie das BIOS-Setup und "
+"erlauben dort das Booten vom entsprechenden Medium."
+
+msgid "Bronze Sponsor"
+msgstr "Bronze-Sponsor"
+
+msgid "Browser incompatibility"
+msgstr "Browser-Inkompatibilität"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "CD/DVD-Abbild(er) brennen"
+
+msgid "Categories"
+msgstr "Kategorien"
+
+msgid "Category"
+msgstr "Kategorie"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Wählen Sie ein Installationsmedium durch Klick darauf und klicken Sie auf "
+"die Download-Schaltfläche, um das Herunterladen zu starten. Optional können "
+"Sie Ihren Computertyp oder eine andere Download-Methode wählen."
+
+msgid "Click here to display these alternative versions."
+msgstr "Klicken Sie hier, um diese alternativen Versionen anzuzeigen."
+
+msgid "Click to Download"
+msgstr "Klicken zum Herunterladen"
+
+msgid "Community"
+msgstr "Community"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Enthält eine große Sammlung von Software für Desktop- und Server-Systeme.<br/"
+">Geeignet zur Installation oder zum Upgrade."
+
+msgid "Countdown"
+msgstr "Countdown"
+
+msgid "Country"
+msgstr "Land"
+
+msgid "Development"
+msgstr "Entwicklung"
+
+msgid "Development Version"
+msgstr "Entwicklungsversion"
+
+msgid "Development packages"
+msgstr "Entwicklungspakete"
+
+msgid "Development-"
+msgstr "Entwicklung-"
+
+msgid "Direct Install"
+msgstr "Direkte Installation"
+
+msgid "Direct Link"
+msgstr "Direkter Link"
+
+msgid "Documentation"
+msgstr "Dokumentation"
+
+msgid "Don't show this warning the next time"
+msgstr "Diese Meldung beim nächsten Mal nicht mehr anzeigen."
+
+msgid "Download"
+msgstr "Herunterladen"
+
+msgid "Download %s"
+msgstr "%s herunterladen"
+
+msgid "Download Help"
+msgstr "Hilfe zum Herunterladen"
+
+msgid "Download Method"
+msgstr "Download-Methode"
+
+msgid "Download appliance from %s"
+msgstr "Lade Appliance von %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "DVD&nbsp;herunterladen"
+
+msgid "Download&nbsp;GNOME"
+msgstr "GNOME&nbsp;herunterladen"
+
+msgid "Download&nbsp;KDE"
+msgstr "KDE&nbsp;herunterladen"
+
+msgid "Download&nbsp;Network"
+msgstr "Netzwerk&nbsp;herunterladen"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Rettung&nbsp;herunterladen"
+
+msgid "Downloads"
+msgstr "Downloads"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Lädt das Installationssystem und alle Pakete aus Onlinequellen.<br/>Kann zur "
+"Neuinstallation oder zum Upgrade verwendet werden."
+
+msgid "Expand all sections ('e')"
+msgstr "Alle Abschnitte erweitern ('e')"
+
+msgid "Extra Languages"
+msgstr "Weitere Sprachen"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Weitere Sprachen (32 Bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Weitere Sprachen (64 Bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Führen Sie für <strong>%s</strong>  das folgende als <strong>root</strong> "
+"aus:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Führen Sie für <strong>%s</strong>  folgendes aus:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Für <strong>Arch Linux</strong>, bearbeiten Sie /etc/pacman.conf und fügen "
+"Sie folgendes hinzu (bitte beachten Sie, dass die Reihenfolge der "
+"Repositories in pacman.conf wichtig ist, weil pacman immer das zuerst "
+"gefundene Paket herunterlädt) :"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"bietet die höchste Sicherheit, da man verifizieren kann, wer die Checksumme "
+"erstellt hat. Es sollte sich um <tt>%s</tt> handeln."
+
+msgid "Games"
+msgstr "Spiele"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Holen Sie sich eine der spezialisierten Distributionen basierend auf "
+"openSUSE."
+
+msgid "Getting Help"
+msgstr "Hilfe bekommen"
+
+msgid "Gold Sponsor"
+msgstr "Gold-Sponsor"
+
+msgid "Grab binary packages directly"
+msgstr "Binärpakete direkt herunterladen"
+
+msgid "Header Logo"
+msgstr "Kopfzeilen Logo"
+
+msgid "Help on Download Method"
+msgstr "Hilfe zur Download-Methode"
+
+msgid "Help on Type of Computer"
+msgstr "Hilfe zu Typ des Computers"
+
+msgid "How to Proceed"
+msgstr "Wie es weitergeht"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Wenn Sie einen direkten Link verwenden möchten, aber in einem Teil der Welt "
+"leben, zu dem unsere Download-Umleitung nicht über genug Informationen "
+"verfügt, um zum schnellsten Spiegel-Server zu verweisen. können Sie selbst "
+"einen Spiegel-Server wählen."
+
+msgid "Image:"
+msgstr "Abbild:"
+
+msgid "Install package %s / %s"
+msgstr "Installiere Paket %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Installiere Schema %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Mit 1-Klick-Installation installieren"
+
+msgid "Installation Guides"
+msgstr "Hilfe zur Installation"
+
+msgid "Installation Medium"
+msgstr "Installationsmedium"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Treten Sie der schnell wachsenden Gemeinschaft bei und bringen Sie\n"
+"        openSUSE unter die Leute, indem Sie sich die aktuelle Promo-DVD\n"
+"        für Ihre Freunde, gemeinnützige Organisation, Schule, Universität\n"
+"        Konferenz oder für das nächste Treffen Ihrer LUG organisieren\n"
+"        Promo-DVDs helfen die Wahrnehmung und Sichtbarkeit von openSUSE zu "
+"verbessern!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror aus KDE 3 wird leider nicht mehr gepflegt und die Javascript-"
+"Implementierung enthält Fehler, die eine Benutzung mit dieser Seite "
+"unmöglich machen. Bitte stellen Sie sicher, dass Sie Javascript deaktiviert "
+"haben, bevor Sie  <a href='%s'>fortfahren</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Sprache"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Herkömmlicher 32 Bit PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Herkömmlicher 32&nbsp;Bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "GNOME Live"
+
+msgid "Live KDE"
+msgstr "KDE Live"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Viele Anwendungen können die Checksumme eines Downloads überprüfen. Eine "
+"Überprüfung des Downloads kann wichtig sein, um sicherzustellen dass das "
+"Medium nicht beschädigt heruntergeladen wurde. Wir bieten drei verschiedene "
+"Checksummen an:"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Weitere Informationen zum brennen der ISO-Datei auf CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Weitere Informationen zum Erstellen eines <a href='http://de.opensuse.org/"
+"SDB:Live_USB_Stick'>bootfähigen USB Sticks</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Weitere Informationen zum Herunterladen von openSUSE sind auf den Seiten <a "
+"href=\"http://de.opensuse.org/Download-Hilfe\">Download-</a> und <a href="
+"\"http://de.opensuse.org/SDB:Netzwerk_Installation\">Netzwerkinstallation</"
+"a> im <a href=\"http://de.opensuse.org/Portal:Dokumentation\">Dokumentations-"
+"Wiki</a> verfügbar."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Viele neue Computer unterstützen <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (auch als AMD64 und Intel64 bekannt), aber einige "
+"Laptop- und Netbook-Prozessoren unterstützen es nicht. Daher müssen Sie in "
+"der Wikipedia nachsehen, was Ihr Computer unterstützt."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Benötigen Sie Hilfe?"
+
+msgid "Network"
+msgstr "Netzwerk"
+
+msgid "No appliance data for %s"
+msgstr "Keine Appliance-Daten für %s"
+
+msgid "No appliances found in project %s"
+msgstr "Für das Projekt %s wurden keine Appliance gefunden"
+
+msgid "No data for %s / %s"
+msgstr "Keine Daten für %s / %s"
+
+msgid "No description found..."
+msgstr "Keine Beschreibung gefunden ..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Es gibt keine Downloads für %s im Projekt %s"
+
+msgid "No packages found matching your search. "
+msgstr "Es wurden keine Pakete gefunden, die Ihrer Suchanfrage entsprechen."
+
+msgid "NonOSS CD"
+msgstr "NonOSS-CD"
+
+msgid "OBS Backend not available"
+msgstr "OBS-Backend steht nicht zur Verfügung"
+
+msgid "Official Manuals"
+msgstr "Offizielle Handbücher"
+
+#, fuzzy
+#| msgid ""
+#| "Only DVD and Network medias are fully tested. Alternatives, like live or "
+#| "rescue systems, are recomended for only limited use."
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Nur DVD und Netzwerkmedien sind voll getestet. Alternativen, wie Live- oder "
+"Rettungssysteme, werden nur für begrenzte Einsatzzwecke empfohlen."
+
+msgid "Package %s not found..."
+msgstr "Paket %s wurde nicht gefunden ..."
+
+msgid "Package Repositories"
+msgstr "Paketrepositories"
+
+msgid "Package Search"
+msgstr "Paketsuche"
+
+msgid "Packages for %s:"
+msgstr "Pakete für %s:"
+
+msgid "Pick Mirror"
+msgstr "Server wählen"
+
+msgid "Platinum Sponsor"
+msgstr "Platin-Sponsor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Bitte seien Sie sich bewusst, dass die folgenden Pakete aus nicht "
+"offiziellen Installationsquellen stammen.\n"
+"  Das bedeutet, dass diese nicht von openSUSE begutachtet wurden und "
+"instabile oder experimentelle Software beinhalten könnten. "
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Bitte geben Sie uns eine <b>kurze</b> Begründung (in Englisch!) warum Sie "
+"die DVDs benötigen und geben Sie uns einen Link von Ihrem Event/"
+"Verwendungszweck."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Bitte beachten Sie das dies nicht die aktuelle openSUSE-Version ist. Sie "
+"können die aktuelle Version <a href='/'>hier</a> beziehen."
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo-DVDs und das dazugehörige Artwork - Labels und Hülle - kann\n"
+"        aus dem <a href=\"http://download.opensuse.org/promodvd/\">promodvd "
+"Downloadverzeichnis\n"
+"        %s</a> heruntergeladen werden. Beachten Sie dabei, dass es sich um "
+"eine spezielle Version\n"
+"        von openSUSE handelt, die speziell für Promotion-Zwecke gestaltet "
+"wurde."
+
+msgid "Related categories:"
+msgstr "Verwandte Kategorien:"
+
+msgid "Released Version"
+msgstr "Veröffentlichte Version"
+
+msgid "Reporting Bugs"
+msgstr "Fehler melden"
+
+msgid "Rescue"
+msgstr "Rettung"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Ein Rettungssystem, das von CD oder USB-Stick aus gestartet werden kann.<br/"
+">Kann weder zur Installation noch zum Upgraden genutzt werden."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "md5-Checksumme"
+
+msgid "Search"
+msgstr "Suche"
+
+msgid "Select Your Operating System"
+msgstr "Wählen Sie ihr Betriebssystem"
+
+msgid "Select the image type"
+msgstr "Wählen Sie den Typ des Abbildes"
+
+msgid "Show"
+msgstr "Anzeigen"
+
+msgid "Show development, language and debug packages"
+msgstr "Zeige Entwicklungs-, Sprach- und Debugpakete"
+
+msgid "Show distribution:"
+msgstr "Zeige Distribution:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Weitere Pakete für nicht unterstützte Distributionen anzeigen"
+
+msgid "Show more..."
+msgstr "Mehr anzeigen ..."
+
+msgid "Show other versions"
+msgstr "Zeige andere Versionen"
+
+msgid "Show unstable packages"
+msgstr "Möglicherweise Instabile Pakete anzeigen"
+
+msgid "Show unsupported packages"
+msgstr "Zeige nicht unterstützte Pakete"
+
+msgid "Silver Sponsor"
+msgstr "Silber-Sponsor"
+
+#, fuzzy
+#| msgid ""
+#| "Some alternative media (eg. live and rescue systems) are also available, "
+#| "although they are less tested and recommended for only limited use."
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Einige alternative Medien (z.B. Live- und Rettungssysteme) sind auch "
+"verfügbar, allerdings weniger getestet und nur für begrenzte Einsatzzwecke "
+"empfohlen."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Einige Live-Distributionen auf Basis von openSUSE. Wenn Sie interessiert "
+"sind  eigene Derivate zu basteln, werfen Sie einen Blick auf<a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Quelle"
+
+msgid "Sponsored by"
+msgstr "Gesponsert von"
+
+msgid "Sponsored by: AMD"
+msgstr "Gesponsert von: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Gesponsert von B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Gesponsert von: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Gesponsert von IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Unterpakete:"
+
+msgid "Support"
+msgstr "Support"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Der Installationsprozess ist in vielen Sprachen verfügbar, aber die meisten "
+"sind nicht im Abbild enthalten. Wenn Sie wollen, dass Ihr openSUSE-System "
+"weitere Sprachen unterstützt, müssen Sie diese während der Installation oder "
+"zu einem späteren Zeitpunkt aus dem Internet herunterladen. Wenn Sie während "
+"der Installation problemlos Internetzugang haben, dann benötigen Sie diese "
+"CD nicht. Wenn Sie jedoch vorhaben openSUSE auf einer Maschine ohne "
+"Internetverbindung zu installieren, ermöglicht diese CD Ihnen Zugang zu "
+"allen verfügbaren Sprachen."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Führen Sie anschließend das folgende als <strong>root</strong> aus"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Zur Zeit befindet sich keine openSUSE-Version in der Testphase. <br/> Falls "
+"Sie die neuste („bleeding edge“) Software nutzen wollen, benutzen Sie bitte "
+"<a href='http://de.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Diese CD enthält freie Software mit einer proprietären Lizenz die es nicht "
+"erlaubt sie zusammen mit anderer freier Software auszuliefern. Alle "
+"Softwarepakete dieser CD können auch aus dem NON-OSS Repository "
+"heruntergeladen werden."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Diese Version läuft auf allen PCs einschließlich derjenigen, die 64 Bit "
+"unterstützen. Wenn Sie über mehr als 3 GB verfügen, sollten Sie die 64 Bit-"
+"Version bevorzugen. openSUSE unterstützt keine Prozessoren vor Pentium - die "
+"Live-CDs unterstützen nur i686 (Pentium Pro und neuer)."
+
+msgid "Type of Computer"
+msgstr "Typ des Computers"
+
+msgid "Unsupported distributions:"
+msgstr "Nicht unterstützte Distributionen:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Benutzerhandbücher sind verfügbar auf <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, zum Beispiel der <a href=\"http://activedoc."
+"opensuse.org/de/book/opensuse-start-up\">offizielle Start-Up Guide</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"BitTorrent wird für langsame Verbindungen empfohlen, besonders wenn das DVD-"
+"Abbild heruntergeladen wird. BitTorrent-Downloads bieten mehrere Vorteile, "
+"die Clients schützen gegen Datenfehler und Sie helfen die Last auf den "
+"Servern zu mindern, indem Sie am Upload teilnehmen - wenn sich genügend "
+"Leute beteiligen, ist es auch schneller als die zentralen Server. Darüber "
+"hinaus können Sie den Abruf jederzeit stoppen und später wieder aufnehmen. "
+"Weitere Informationen finden Sie unter <a href=\"http://de.opensuse.org/"
+"BitTorrent\">BitTorrent and openSUSE</a>."
+
+msgid "Verify your download before use"
+msgstr "Überprüfen Sie vor der Benutzung Ihre heruntergeladenen Daten"
+
+msgid "Version"
+msgstr "Version"
+
+msgid "We offer three different checksums:"
+msgstr "Wir bieten 3 verschiedene Checksummen an: "
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Wir fänden es schön, wenn Sie uns auf dem Laufenden halten, was Ihre Nutzung "
+"der\n"
+"       DVDs anbelangt, damit wir Ihnen helfen können Ihre Organisation, "
+"Veranstaltung oder\n"
+"       Schule über unsere <a href='http://news.opensuse.org' title='news."
+"opensuse.org'>Neuigkeitenseite</a> \n"
+"       oder andere Ressourcen bekannt zu machen (Tipp: Wir lieben Fotos. "
+"Machen Sie viele davon!). Bitte\n"
+"       kontaktieren Sie uns unter <a href='mailto:opensuse-"
+"marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>\n"
+"       um Ihre Veranstaltung zu besprechen und/oder wie wir Ihnen dabei "
+"helfen können."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Wenn Sie andere Abbilder als die Netzwerk-Installations-CD herunterladen, "
+"wird es <i>sehr</i> empfohlen, ein geeignetes Download-Verwaltungsprogramm "
+"zu verwenden, um das Risiko korrupter Dateien zu reduzieren."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Sie können den Schlüssel des Repositories zu apt hinzufügen. Denken Sie "
+"jedoch daran, dass der Besitzer des Schlüssels Aktualisierungen, Pakete und "
+"Repositories verteilen kann, denen Ihr System vertrauen wird (<a href=\"%s"
+"\">weitere Informationen</a>). Um den Schlüssel hinzuzufügen, führen Sie "
+"folgenden Befehl aus:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Sie können versuchen Ihre Suchanfrage zu erweitern, indem Sie "
+"Entwicklungspakete einbeziehen oder eine andere Basisdistribution wählen "
+"(aktuell )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Die Datei kann während des Herunterladens verifiziert werden, wenn Sie im "
+"obigen Feld <a href='http://en.opensuse.org/SDB:Metalink'>Metalink</"
+"a>(englisch) auswählen und die Erweiterung DownThemAll! in <a href='http://"
+"de.opensuse.org/Mozilla_Firefox'>Firefox</a> verwendet wird, diese kann "
+"automatisch gegen eine Checksumme (SHA256) prüfen. "
+
+msgid "gpg signature"
+msgstr "gpg-Signatur"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://de.opensuse.org/Derivate"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://de.opensuse.org/Paket_Repositorys"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://de.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://de.opensuse.org/Download-Hilfe"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://de.opensuse.org/index.php?title=SDB:Download-Hilfe#Brennen"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://de.opensuse.org/Fehler_berichten"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"ist nach wie vor die verbreitetste Checksumme. Viele Brennprogramme zeigen "
+"diese Checksumme vor dem Brennen an."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "ist die weniger bekannte, aber sichere als md5."
+
+msgid "md5 checksum"
+msgstr "md5-Checksumme"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"bietet die höchste Sicherheit, da man verifizieren kann, wer die Checksumme "
+"erstellt hat. Es sollte sich um <tt>%s</tt> handeln."
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE  Countdown"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE Derivative"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE ist über http (direkter Link) oder BitTorrent verfügbar. Die CD für "
+"die Netzwerk-Installation ist nur über http verfügbar."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE unterstützt nur PCs mit 32 Bit und 64 Bit."
+
+msgid "see Derivatives on wiki"
+msgstr "siehe Derivate im Wiki"
+
+msgid "sha1 checksum"
+msgstr "sha1-Checksumme"
+
+msgid "switch to"
+msgstr "wechsle zu"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Ein interner Fehler ist aufgetreten :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Bitte einen Suchbegriff mit mindestens 2 Zeichen verwenden"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Letzte Suchanfragen:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistiken"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Die beliebtesten 1-Klick-Downloads: "
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Top-Suchen ohne Treffer:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Am meisten gesucht: "
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Es gibt derzeit keine Veröffentlichung von Factory, die neuer wäre als "
+#~ "das letzte openSUSE. <br>Bitte besuchen Sie <a href='http://en.opensuse."
+#~ "org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> für mehr "
+#~ "Informationen. (nur englisch)"
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Sie können den Repository-Schlüssel wie folgt zur apt hinzufügen: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CDs enthalten nur 4 Sprachen (Englisch, Deutsch, Russisch und "
+#~ "Italienisch). Falls Sie unterstuetzung fuer weitere Sprachen benoetigen "
+#~ "koennen diese waehrend der Installation oder danach heruntergeladen "
+#~ "werden. Falls Sie einfachen Internetzugriff oder die DVD mit allen "
+#~ "Sprachen haben benoetigen Sie diese CD nicht."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Nachdem die ISO-Datei erfolgreich heruntergeladen wurde, brennen Sie die "
+#~ "Datei mit ihrem bevorzugten Brenn-Programm auf eine DVD oder CD. Bitte "
+#~ "brennen Sie <em>keine</em> Daten-CD, sondern wählen sie eine Option aus, "
+#~ "die es erlaubt ein fertiges ISO-Abbild zu brennen."
+
+#~ msgid ""
+#~ "Please be aware that the following packages are from unofficial "
+#~ "repositories.\\n  That means they are not reviewed by openSUSE and may "
+#~ "contain unstable or experimental software."
+#~ msgstr ""
+#~ "Bitte seien Sie sich bewusst, dass die folgenden Pakete aus nicht "
+#~ "offiziellen Installationsquellen stammen. \\n Das bedeutet, dass diese "
+#~ "nicht von openSUSE begutachtet wurden und instabile oder experimentelle "
+#~ "Software beinhalten könnten. "
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Ein von CD oder USB Stick lauffaehiger GNOME Desktop.<br/>Kann auch "
+#~ "direkt installiert werden (kein Upgrade)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Ein von CD oder USB Stick lauffaehiger KDE Desktop.<br/>Kann auch direkt "
+#~ "installiert werden (kein Upgrade)."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.de.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.de.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.de.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/12.2/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.2/RELEASE-NOTES.de.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Bitte einen Suchbegriff mit mindestens 2 Zeichen verwenden"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "Automatischer Wechsel zur exakten Suche wegen zu vieler Treffer. "
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Bitte genaueren Suchbegriff verwenden, das Suchlimit wurde erreicht."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Konnte Suche nicht ausfuehren: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Beliebte Software"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "openSUSE kaufen"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://de.opensuse.org/OpenSUSE_kaufen"
+
+#~ msgid "Sponsored by AMD"
+#~ msgstr "Sponsored von AMD"
+
+#~ msgid "Verify your download (optional, for experts)"
+#~ msgstr "Überprüfen des Downloads (optional, für Experten)"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Klick-Installation"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Manueller Paket-Download"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Zum OBS-Projekt"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Software-Kollektion]"
+
+#~ msgid "Development packages:"
+#~ msgstr "Entwicklungspakete:"
+
+#~ msgid "Sub-packages:"
+#~ msgstr "Unterpakete:"
+
+#~ msgid "Search Results"
+#~ msgstr "Suchergebnisse"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "Keine Pakete fuer diese Suchanfrage gefunden."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d Kollektionen und %d Binärprogramme aus %d Quellpaketen"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Bildschirmfoto von"
+
+#~ msgid "official release"
+#~ msgstr "Offizielle Veröffentlichung"
+
+#~ msgid "official update"
+#~ msgstr "Offizielle Aktualisierung"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Such Statistiken:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Download Statistiken: "
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Suche und installiere weitere Softwarepakete aus dem <a href=\"http://"
+#~ "build.opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Such-Optionen"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Suche auch in 'Home'-Projekten"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Keine Debug Pakete"
+
+#~ msgid "Additional Information"
+#~ msgstr "Weitere Informationen"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "openSUSE 11.3 kaufen"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "openSUSE 11.3 kaufen"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Weitergehenden Hilfe zum openSUSE-Download  auf <a href=\"http://de."
+#~ "opensuse.org/Downloadhilfe\">Download-Hilfe </a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Weiterführende Informationen sind hier erhältlich:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Installation von DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Offizieller %s Startup"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Schritt für Schritt Installationsanleitung"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Netzwerkinstallation"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Internet-Installation"
+
+#~ msgid "More information"
+#~ msgstr "Weitere Informationen"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Maybe you want to extend your search using the "
+#~ msgstr ""
+#~ "Sie haben die Moeglichkeit die Suche mit Hilfe der Optionen zu erweitern."
+
+#~ msgid "Get Software"
+#~ msgstr "Software herunterladen"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Software erstellen"
+
+#~ msgid "User Directory"
+#~ msgstr "Benutzerverzeichnis"
+
+#~ msgid "Features"
+#~ msgstr "Features"
+
+#~ msgid "News"
+#~ msgstr "Nachrichten"
+
+#~ msgid "Forums"
+#~ msgstr "Foren"
+
+#~ msgid "Shop"
+#~ msgstr "Shop"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Software-Suche"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Aktualisierungs-Repository"
+
+#~ msgid "Source Repository"
+#~ msgstr "Quell-Repository"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Weitere Optionen"
+
+#~ msgid "Mirrors"
+#~ msgstr "Spiegelserver"
+
+#, fuzzy
+#~| msgid "Select the language."
+#~ msgid "In other languages"
+#~ msgstr "Wählen Sie die Sprache"
+
+#~ msgid "Get it"
+#~ msgstr "Get it"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Suche im Build Service"
+
+#~ msgid "Get openSUSE"
+#~ msgstr "openSUSE herunterladen"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Permanenter Verweis auf dieses Ergebnis"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nichts gefunden"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Software aus dem openSUSE Build Service herunterladen"
+
+#~ msgid "Searching"
+#~ msgstr "Suche"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Enthält eine große Anzahl an Software für Desktop- oder Server-Benutzung. "
+#~ "Für Installation oder Aktualisierung geeignet."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Der GNOME Desktop kann direkt von CD oder einem USB-Stick laufen und dann "
+#~ "installiert werden (keine Aktualisierung möglich)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Der KDE Desktop kann direkt von CD oder einem USB-Stick laufen und dann "
+#~ "installiert werden (keine Aktualisierung möglich)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Lädt das Installationssystem und alle Pakete aus Online-Repositories "
+#~ "herunter. Geeignet für Installation oder Aktualisierung."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinks"
+
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "openSUSE 11.2 kaufen!<br />"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Für neue Linux-Benutzer mag die openSUSE-Version mit Installationssupport "
+#~ "die beste Alternative sein. Sie enthält das komplette Handbuch und "
+#~ "Installationsmedium für 32bit und 64bit und 90 Tage Installationssupport."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 ist verfügbar in mehrerenl <a href=\"http://de.opensuse.org/"
+#~ "OpenSUSE_kaufen\">Onlineshops</a> und einigen Eltromärkten."
+
+#~ msgid "Expert view"
+#~ msgstr "Experten-Ansicht"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Computer mit z.B. AMD&reg; Sempron oder Intel&reg; Celeron&trade;, "
+#~ "fast alle Computer von 2004 und davor. Diese Version läuft auch auf 64 "
+#~ "Bit PCs."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: Die meisten neuen Computer mit z.B. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, oder Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr ""
+#~ "Das kleinste Medium (nur 100MB) lädt das Installationssystem und die "
+#~ "Pakete aus dem Online-Repository."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "Um ein Medium herunterzuladen, wählen Sie eins aus und ändern "
+#~ "möglicherweise die Architektur und die Download-Methode und wählen sie "
+#~ "\"Datei speichern\", wenn der Browser danach fragt."
+
+#~ msgid ""
+#~ "This CD contains a live session of the GNOME desktop. It can be installed "
+#~ "as is and also works when deployed on an USB stick."
+#~ msgstr ""
+#~ "Diese CD enthält eine Live-Sitzung des GNOME Desktops. Sie kann "
+#~ "unverändert installiert werden und funktioniert auch auf USB-Sticks."
+
+#~ msgid "Help"
+#~ msgstr "Hilfe"
+
+#, fuzzy
+#~| msgid "GNOME desktop"
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "GNOME-Desktop"
+
+#, fuzzy
+#~| msgid "KDE desktop"
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "KDE-Desktop"
+
+#, fuzzy
+#~| msgid "No installation source was defined."
+#~ msgid "Network installation for experts"
+#~ msgstr "Es wurde keine Installationsquelle definiert."

--- a/locale/el/software.po
+++ b/locale/el/software.po
@@ -1,0 +1,1208 @@
+# Robert Krambovitis <rkrambovitis@gmail.com>, 2011.
+# Efstathios Agrapidis <stathisagrapidis@gmail.com>, 2014.
+# Efstathios Iosifidis <iosifidis@opensuse.org>, 2011, 2012, 2013, 2014, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-03 23:26+0200\n"
+"Last-Translator: Efstathios Iosifidis <iosifidis@opensuse.org>\n"
+"Language-Team: Ελληνικά <opensuse-translation-el@opensuse.org>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Gtranslator 2.91.7\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid " and "
+msgstr " και "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"Η #{release} δεν είναι υποστηριζόμενη έκδοση.\""
+
+msgid "(hide)"
+msgstr "(απόκρυψη)"
+
+msgid "(show)"
+msgstr "(εμφάνιση)"
+
+msgid "... and keep us informed"
+msgstr "...και κρατήστε μας ενήμερυς"
+
+msgid "... get other marketing stuff"
+msgstr "...πάρτε άλλα υλικά μάρκετινγκ"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (κατάλληλο επίσης για USB stick)"
+
+msgid "64 Bit PC"
+msgstr "64 Bit Η/Υ"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Οδηγός "
+"εκκίνησης openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> είναι ένα "
+"ανοιχτό πρότυπο που τυλίγει τους διάφορους τρόπους (FTP/HTTP/BitTorrent) "
+"μεταφόρτωσης αρχείων σε μία μορφή, για πιο εύκολο κατέβασμα. Αυτό το καθιστά "
+"καλό για την μεταφόρτωση ISO, ειδικά για άτομα που δεν μπορούν να "
+"χρησιμοποιήσουν P2P λόγω περιορισμών από τον πάροχο ή την σχολή τους. "
+"Μπορείτε να επιτύχετε πολύ γρήγορες ταχύτητες μεταφόρτωσης αφού οι "
+"περισσότεροι πελάτες υποστηρίζουν πολλαπλές συνδέσεις, σε πολλαπλούς "
+"διακομιστές αυτόματα. Επίσης, μπορεί να εντοπίζει και να διορθώνει λάθη. "
+"Χρειάζεται όμως ειδική εφαρμογή για να το χειριστεί."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Άδεια χρήσης</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Σημειώσεις έκδοσης</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>επίσημη έκδοση</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>επίσημη ενημέρωση</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Μία επιφάνεια εργασίας GNOME που μπορείτε να εκτελέσετε από %s ή από στικάκι "
+"USB.<br/>Μπορεί να εγκατασταθεί ως έχει (χωρίς αναβάθμιση)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Μία επιφάνεια εργασίας KDE που μπορείτε να εκτελέσετε από %s ή από στικάκι "
+"USB.<br/>Μπορεί να εγκατασταθεί ως έχει (χωρίς αναβάθμιση)."
+
+msgid "Add repository and install manually"
+msgstr "Προσθέσετε αποθετήριο και εγκαταστήσετε με το χέρι"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Επιπρόσθετες μεταφορτώσεις (προαιρετικό)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Μόλις κατεβάσετε επιτυχώς τα ISO, δημιουργήστε ένα εκκινήσιμο USB stick ή "
+"εγγράψτε το ISO σε ένα DVD (ή σε CD εάν το ISO χωράει)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Όλα τα δεδομένα χρησιμοποιούνται μόνο για αποστολή του προωθητικού υλικού "
+"του openSUSE\n"
+"          και δεν θα διαμοιραστεί σε τρίτους. Αποθηκεύουμε τα δεδομένα\n"
+"          ώστε να ενημερώνουμε τους χρήστες εάν είναι διαθέσιμη νέα έκδοση. "
+"Όλα τα αιτήματα\n"
+"          πρέπει να ελεγχθούν για την εκπλήρωση του εμπορικού αποκλεισμού "
+"εξαγωγών στις ΗΠΑ. Περισσότερες πληροφορίες\n"
+"          σχετικά με τον εμπορικό αποκλεισμό για την λίστα με τς χώρες θα "
+"βρείτε στην <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Εφαρμογή Πλοηγού"
+
+msgid "Available Images"
+msgstr "Διαθέσιμες Εικόνες"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Εκκινήστε τον υπολογιστή σας από το DVD, CD ή το USB stick. Σε περίπτωση που "
+"ο υπολογιστής σας δεν εκκινήσει αυτόματα από την επιλεγμένη συσκευή, ανοίξτε "
+"τις ρυθμίσεις BIOS και επιτρέψτε την εκκίνηση από αυτή."
+
+msgid "Bronze Sponsor"
+msgstr "Χάλκινος Χορηγός"
+
+msgid "Browser incompatibility"
+msgstr "Ασυμβατότητα περιηγητή"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Εγγραφή εικόνας(ων) CD/DVD"
+
+msgid "Categories"
+msgstr "Κατηγορίες"
+
+msgid "Category"
+msgstr "Κατηγορία"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Επιλέξτε μέσο εγκατάστασης με το να το κάνετε κλικ και πατήσετε το κουμπί "
+"Μεταφόρτωση για να ξεκινήσει η μεταφόρτωσή του. Προαιρετικά επιλέξτε το "
+"είδος του υπολογιστή σας ή κάποια εναλλακτική μέθοδο μεταφόρτωσης."
+
+msgid "Click here to display these alternative versions."
+msgstr "Κάντε κλίκ εδώ για εμφάνιση αυτών των εναλλακτικών εκδόσεων."
+
+msgid "Click to Download"
+msgstr "Κάντε κλικ για Λήψη"
+
+msgid "Community"
+msgstr "Κοινότητα"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Περιέχει μεγάλη συλλογή εφαρμογών για χρήση σε desktop ή διακομιστή. <br/> "
+"Κατάλληλο για εγκατάσταση ή αναβάθμιση."
+
+msgid "Countdown"
+msgstr "Αντίστροφη Μέτρηση"
+
+msgid "Country"
+msgstr "Χώρα"
+
+msgid "Development"
+msgstr "Ανάπτυξη"
+
+msgid "Development Version"
+msgstr "Έκδοση υπό ανάπτυξη"
+
+msgid "Development packages"
+msgstr "Πακέτα υπό ανάπτυξη"
+
+msgid "Development-"
+msgstr "Ανάπτυξη-"
+
+msgid "Direct Install"
+msgstr "Άμεση Εγκατάσταση"
+
+msgid "Direct Link"
+msgstr "Απευθείας σύνδεσμος"
+
+msgid "Documentation"
+msgstr "Τεκμηρίωση"
+
+msgid "Don't show this warning the next time"
+msgstr "Να μην εμφανιστεί την επόμενη φορά αυτή η προειδοποίηση."
+
+msgid "Download"
+msgstr "Λήψη"
+
+msgid "Download %s"
+msgstr "Λήψη %s"
+
+msgid "Download Help"
+msgstr "Λήψη Βοήθειας"
+
+msgid "Download Method"
+msgstr "Μέθοδος Λήψης"
+
+msgid "Download appliance from %s"
+msgstr "Λήψη μεταφόρτωσης από %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Λήψη&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Λήψη&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Λήψη&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Λήψη&nbsp;Δικτυακού"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Λήψη&nbsp;Συστήματος&nbsp;Διάσωσης"
+
+msgid "Downloads"
+msgstr "Λήψεις"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Κατεβάζει το σύστημα εγκατάστασης και όλα τα πακέτα από διαδικτυακά "
+"αποθετήρια. <br/>Κατάλληλο για εγκατάσταση ή αναβάθμιση."
+
+msgid "Expand all sections ('e')"
+msgstr "Ανάπτυξη όλων των τμημάτων ('e')"
+
+msgid "Extra Languages"
+msgstr "Πρόσθετες γλώσσες"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Πρόσθετες γλώσσες (32 Bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Πρόσθετες γλώσσες (64 bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "Εκτελέστε το <strong>%s</strong> ως χρήστης <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Για <strong>%s</strong> εκτελέστε το παρακάτω:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Για <strong>Arch Linux</strong>, επεξεργαστείτε το αρχείο /etc/pacman.conf "
+"και προσθέστε το παρακάτω (σημειώστε ότι η σειρά των αποθετηρίων στο pacman."
+"conf είναι σημαντική, διότι ο pacman κατεβάζει πάντα το πρώτο πακέτο που "
+"βρίσκει):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "Για κάθε ISO, παρέχουμε ένα αρχείο checksum με το SHA256 sum."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Για περισσότερη ασφάλεια, μπορείτε να χρησιμοποιήσετε το κλειδί GPG για να "
+"επιβεβαιώσετε ποιος υπέγραψε τα αρχεία sha256. Πρέπει να είναι %s."
+
+msgid "Games"
+msgstr "Παιγνίδια"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Λάβετε μία από τις ειδικευμένες διανομές που χτίστηκαν πάνω στο openSUSE."
+
+msgid "Getting Help"
+msgstr "Λήψη Βοήθειας"
+
+msgid "Gold Sponsor"
+msgstr "Χρυσός Χορηγός"
+
+msgid "Grab binary packages directly"
+msgstr "Πάρτε τα εκτελέσιμα πακέτα απευθείας"
+
+msgid "Header Logo"
+msgstr "Λογότυπο Επικεφαλίδας"
+
+msgid "Help on Download Method"
+msgstr "Βοήθεια στην μέθοδο λήψης"
+
+msgid "Help on Type of Computer"
+msgstr "Βοήθεια στο είδος υπολογιστή"
+
+msgid "How to Proceed"
+msgstr "Πως να προχωρήσετε"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Αν θέλετε να χρησιμοποιήσετε απευθείας σύνδεσμο αλλά ζείτε σε μέρος όπου ο "
+"ανακατευθυντής μεταφορτώσεων δεν έχει αρκετές πληροφορίες να σας "
+"ανακατευθύνει στον ταχύτερο διακομιστή, μπορείτε να επιλέξετε μόνοι σας "
+"διακομιστή."
+
+msgid "Image:"
+msgstr "Εικόνα:"
+
+msgid "Install package %s / %s"
+msgstr "Εγκατάσταση πακέτου %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Εγκατάσταση προτύπου %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Εγκατάσταση με χρήση ενός κλικ"
+
+msgid "Installation Guides"
+msgstr "Οδηγοί Εγκατάστασης"
+
+msgid "Installation Medium"
+msgstr "Μέσο Eγκατάστασης"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Συμμετέχετε στην γρήγορα αναπτυσσόμενη κοινότητα, δώστε το openSUSE σε "
+"περισσότερα χέρια\n"
+"        παραγγέλλοντας το τελευταίο PromoDVD για την ομάδα σας, τον μη "
+"κερδοσκοπικό οργανισμό, το σχολείο\n"
+"        πανεπιστήμιο ή εκδήλωση όπως συναντήσεις LUG, installfests, και "
+"συνέδρια.\n"
+"        Τα Promo DVDs βοηθούν στην γνωριμία με το openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Το Konqueror του KDE 3 δυστυχώς δεν υποστηρίζεται πλέον και η υλοποίησή του "
+"σε javascript περιέχει σφάλματα που το καθιστούν αδύνατο να χρησιμοποιηθεί "
+"με αυτή την σελίδα. Παρακαλώ επιβεβαιώσετε ότι έχετε απενεργοποιήσει το "
+"javascript προτού <a href='%s'>συνεχίσετε</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Γλώσσα"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Παλαιοί 32 Bit Η/Υ"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Παλαιοί 32&nbsp;Bit&nbsp;Η/Υ"
+
+msgid "Live GNOME"
+msgstr "Live Gnome"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Πολλές εφαρμογές μπορούν να επαληθεύσουν το ελεγκτικό άθροισμα μιας "
+"μεταφόρτωσης. Το να επαληθεύσετε την μεταφόρτωσή σας μπορεί να είναι "
+"σημαντικό, καθώς επιβεβαιώνει ότι πραγματικά έχετε το αρχείο ISO που θέλατε "
+"να μεταφορτώσετε και όχι κάποια χαλασμένη έκδοση."
+
+msgid "Metalink"
+msgstr "Σύνδεσμος"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Περισσότερες πληροφορίες για την εγγραφή του αρχείου ISO σε CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Περισσότερες πληροφορίες για την δημιουργία <a href='http://en.opensuse.org/"
+"Live_USB_stick'>USB στικ εκκίνησης</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Περισσότερες πληροφορίες για την μεταφόρτωση του openSUSE είναι διαθέσιμες "
+"στις σελίδες <a href=\"http://en.opensuse.org/SDB:Download_help\">Βοήθεια "
+"Μεταφόρτωσης</a> και <a href=\"http://en.opensuse.org/SDB:"
+"Network_installation\">Δικτυακή Εγκατάσταση </a> στο <a href=\"http://en."
+"opensuse.org/Portal:Documentation\">Wiki Τεκμηρίωσης</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Οι περισσότεροι υπολογιστές υποστηρίζουν <a href=\"http://en.wikipedia.org/"
+"wiki/X86-64\">x86-64</a> (γνωστό και ως AMD64 και Intel64), αλλά κάποιοι "
+"επεξεργαστές laptop και netbook  δεν το υποστηρίζουν. Οπότε πρέπει να "
+"ελέγξετε αν θέλετε να είστε σίγουροι ότι ο υπολογιστής σας το υποστηρίζει."
+
+msgid "Multimedia"
+msgstr "Πολυμέσα"
+
+msgid "Need help?"
+msgstr "Χρειάζεστε βοήθεια;"
+
+msgid "Network"
+msgstr "Δίκτυο"
+
+msgid "No appliance data for %s"
+msgstr "Δεν υπάρχουν δεδομένα μεταφορτώσεων για %s"
+
+msgid "No appliances found in project %s"
+msgstr "Δεν βρέθηκαν μεταφορτώσεις στο έργο %s"
+
+msgid "No data for %s / %s"
+msgstr "Δεν υπάρχουν στοιχεία για %s / %s"
+
+msgid "No description found..."
+msgstr "Δεν βρέθηκε περιγραφή..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Δεν βρέθηκαν μεταφορτώσεις για %s στο έργο %s"
+
+msgid "No packages found matching your search. "
+msgstr "Δεν βρέθηκαν πακέτα που να ταιριάζουν στην αναζήτησή σας."
+
+msgid "NonOSS CD"
+msgstr "CD λογισμικού που δεν είναι ανοιχτού κώδικα (NON-OSS)"
+
+msgid "OBS Backend not available"
+msgstr "Δεν είναι διαθέσιμο το σύστημα υποστήριξης OBS"
+
+msgid "Official Manuals"
+msgstr "Επίσημα Εγχειρίδια Οδηγιών"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Μόνο τα μέσα DVD και Εγκατάσταση από το Δίκτυο είναι πλήρως δοκιμασμένα. Τα "
+"εναλλακτικά, όπως το live και το σύστημα διάσωσης, συνιστώνται μόνο για "
+"περιορισμένη χρήση."
+
+msgid "Package %s not found..."
+msgstr "Δεν βρέθηκε το πακέτο %s..."
+
+msgid "Package Repositories"
+msgstr "Αποθετήρια Πακέτων"
+
+msgid "Package Search"
+msgstr "Αναζήτηση Πακέτων"
+
+msgid "Packages for %s:"
+msgstr "Πακέτα για το %s:"
+
+msgid "Pick Mirror"
+msgstr "Επιλογή πηγής"
+
+msgid "Platinum Sponsor"
+msgstr "Πλατινένιος Χορηγός"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Σημειώστε ότι τα παρακάτω πακέτα είναι από ανεπίσημα αποθετήρια.\n"
+"  Αυτό σημαίνει ότι δεν έχουν αναθεωρηθεί από την openSUSE και μπορεί να "
+"περιέχουν μη σταθερό ή πειραματικό λογισμικό."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Παρακαλώ εισάγετε ένα <b>συνοπτικό</b> λόγο (στα Αγγλικά) γιατί χρειάζεστε "
+"τα DVDs και παρέχετε ένα σύνδεσμο για την εκδήλωση/σκοπό."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Σημειώστε ότι αυτή δεν είναι η τελευταία έκδοση openSUSE. Μπορείτε να λάβετε "
+"την τελευταία έκδοση από <a href='/'>εδώ</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Τα Promo DVDs και όλη τη σχετική καλλιτεχνική επιμέλεια -ετικέτες και "
+"εξώφυλλα- μπορείτε\n"
+"        να τα κατεβάσετε από τον <a href=\"http://download.opensuse.org/"
+"promodvd/\">κατάλογο\n"
+"        λήψεων promodvd %s</a>. Να έχετε υπόψιν σας ότι αυτή είναι ειδική "
+"έκδοση του openSUSE,\n"
+"        που προορίζεται για προώθηση της διανομής."
+
+msgid "Related categories:"
+msgstr "Σχετικές κατηγορίες:"
+
+msgid "Released Version"
+msgstr "Έκδοση σε Κυκλοφορία"
+
+msgid "Reporting Bugs"
+msgstr "Αναφορά Σφαλμάτων"
+
+msgid "Rescue"
+msgstr "Σύστημα Διάσωσης"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Το σύστημα διάσωσης μπορείτε να το εκτελέσετε από το CD ή από το στικάκι USB."
+"<br/>Δεν μπορεί να χρησιμοποιηθεί για εγκατάσταση ούτε αναβάθμιση."
+
+msgid "SHA256 checksum"
+msgstr "SHA256 checksum"
+
+msgid "Search"
+msgstr "Αναζήτηση"
+
+msgid "Select Your Operating System"
+msgstr "Επιλογή Λειτουργικού Συστήματος"
+
+msgid "Select the image type"
+msgstr "Επιλέξτε τον τύπο εικόνας"
+
+msgid "Show"
+msgstr "Προβολή"
+
+msgid "Show development, language and debug packages"
+msgstr "Εμφάνιση πακέτων ανάπτυξης, γλώσσας και αποσφαλμάτωσης"
+
+msgid "Show distribution:"
+msgstr "Εμφάνιση διανομής:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Εμφάνιση περισσότερων πακέτων για μη υποστηριζόμενες διανομές"
+
+msgid "Show more..."
+msgstr "Εμφάνιση περισσότερων..."
+
+msgid "Show other versions"
+msgstr "Εμφάνιση άλλων εκδόσεων"
+
+msgid "Show unstable packages"
+msgstr "Εμφάνιση μη σταθερών πακέτων"
+
+msgid "Show unsupported packages"
+msgstr "Εμφάνιση μη υποστηριζόμενων πακέτων"
+
+msgid "Silver Sponsor"
+msgstr "Ασημένιος Χορηγός"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Μερικά εναλλακτικά μέσα (πχ live και συστήματα διάσωσης) είναι επίσης "
+"διαθέσιμα, αν και είναι λιγότερο δοκιμασμένα και συνιστώνται για "
+"περιορισμένη χρήση."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Κάποιες από τις live διανομές με βάση το openSUSE. Όσοι ενδιαφέρονται να "
+"δοκιμάσουν να φτιάξουν το δικό τους παράγωγο μπορούν να κοιτάξουν στο <a "
+"href=\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Πηγή"
+
+msgid "Sponsored by"
+msgstr "Χορηγήθηκε από"
+
+msgid "Sponsored by: AMD"
+msgstr "Χορηγός: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Χορηγός: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Χορηγός: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Χορηγός: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Υπό-πακέτα"
+
+msgid "Support"
+msgstr "Υποστήριξη"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Η διαδικασία εγκατάστασης είναι διαθέσιμη σε πολλές γλώσσες αλλά, για τις "
+"περισσότερες από αυτές, δεν συμπεριλαμβάνεται η μετάφραση των εφαρμογών στο "
+"στιγμιότυπο. Εάν θέλετε το σύστημα openSUSE να υποστηρίζει επιπρόσθετες "
+"γλώσσες, πρέπει να τις κατεβάσετε από το Internet κατά την διάρκεια της "
+"εγκατάστασης ή οποιαδήποτε στιγμή αργότερα. Εάν έχετε εύκολη πρόσβαση στο "
+"Internet δεν χρειάζεστε αυτό το CD, αλλά εάν έχετε σκοπό να εγκαταστήσετε το "
+"openSUSE σε κάποιο μηχάνημα χωρίς σύνδεση στο Internet, θα έχετε πρόσβαση σε "
+"όλες τις διαθέσιμες μεταφράσεις."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Μετά εκτελέστε την παρακάτω ως χρήστης <strong>root</strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Προς το παρόν δεν υπάρχει έκδοση openSUSE σε δοκιμαστική φάση. <br/> Εάν "
+"επιθυμείτε να έχετε τελευταίες εκδόσεις λογισμικού, παρακαλώ χρησιμοποιήστε "
+"την έκδοση <a href='http://en.opensuse.org/Portal:Tumbleweed'>openSUSE "
+"Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Αυτό το CD περιέχει δωρεάν λογισμικό που διανέμεται υπό ιδιόκτητη άδεια, που "
+"δεν επιτρέπει να συμπεριληφθεί στο κεντρικό μέσο εγκατάστασης μαζί με το "
+"δωρεάν λογισμικό ανοιχτού κώδικα. Όλο αυτό το λογισμικό μπορεί να "
+"μεταφορτωθεί από αποθετήριο λογισμικού μη ανοιχτού κώδικα (NOS-OSS)."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Αυτή η έκδοση λειτουργεί σε όλους τους υπολογιστές, συμπεριλαμβανομένων και "
+"αυτών που υποστηρίζουν 64 Bit. Αν όμως έχετε περισσότερο από 3 GB RAM, "
+"προτιμήστε την 64 Bit έκδοση. Το openSUSE δεν υποστηρίζει επεξεργαστές "
+"προγενέστερους από Pentium - τα live CD υποστηρίζουν μόνο i686 (Pentium Pro "
+"και μεταγενέστερους)."
+
+msgid "Type of Computer"
+msgstr "Είδος Υπολογιστή"
+
+msgid "Unsupported distributions:"
+msgstr "Μη υποστηριζόμενες διανομές:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Τα εγχειρίδια χρήσης είναι διαθέσιμα στην διεύθυνση  <a href=\"http://"
+"activedoc.opensuse.org\">activedoc.opensuse.org</a>, για παράδειγμα ο <a "
+"href=\"http://activedoc.opensuse.org/book/opensuse-start-up/\">Επίσημος "
+"Οδηγός Εκκίνησης</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Συνίσταται η χρήση  <a href=\"http://en.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent</a> σε αργές συνδέσεις, ειδικά όταν κατεβάζετε την εικόνα DVD. "
+"Υπάρχουν αρκετά πλεονεκτήματα στην χρήση BitTorrent, οι πελάτες αποτρέπουν "
+"από το να κατέβει κατεστραμμένο, βοηθάτε στην μείωση του φόρτου των "
+"εξυπηρετητών με το να συμμετέχετε στο ανέβασμα - αν αρκετοί συμμετέχουν, θα "
+"είναι πιο γρήγορο από τους κεντρικούς εξυπηρετητές - για όλους. Επίσης, σας "
+"επιτρέπει να σταματήσετε την μεταφόρτωση όποτε θέλετε και να την συνεχίσετε "
+"αργότερα."
+
+msgid "Verify your download before use"
+msgstr "Επαλήθευση λήψης πριν τη χρήση"
+
+msgid "Version"
+msgstr "Έκδοση"
+
+msgid "We offer three different checksums:"
+msgstr "Παρέχουμε τρία διαφορετικά ελεγκτικά σύνολα:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Θα θέλαμε να μας ενημερώσετε σχετικά με την χρήση των DVDs, ώστε\n"
+"        μπορούμε να σας βοηθήσουμε στην προώθηση του οργανισμού, εκδήλωσης ή "
+"σχολείο στην\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>σελίδα "
+"νέων</a>\n"
+"        ή άλλες πηγές. (Συμβουλή! Μας αρέσουν οι φωτογραφίες. Βγάλτε "
+"πολλές!). Παρακαλούμε επικοινωνήστε μαζί μας στην\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        για να συζητήσουμε την προώθηση και/ή άλλους τρόπους που μπορούμε να "
+"σας βοηθήσουμε."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Όταν κατεβάζετε εικόνες εκτός του CD για εγκατάσταση από δίκτυο, συνίσταται "
+"<i>έντονα</i> να χρησιμοποιήσετε διαχειριστή μεταφορτώσεων, για να μειωθούν "
+"οι πιθανότητες να κατέβει χαλασμένο."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Μπορείτε να προσθέσετε το κλειδί αποθετηρίου στο apt. Λάβετε υπόψη ότι ο "
+"χρήστης του κλειδιού μπορεί να διανέμει ενημερώσεις, πακέτα και αποθετήρια "
+"που το σύστημά σας θα εμπιστεύεται (<a href=\"%s\">περισσότερες πληροφορίες</"
+"a>). Για να προσθέσετε το κλειδί, εκτελέστε:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Μπορείτε να δοκιμάσετε να επεκτείνετε την αναζήτησή σας στα υπό ανάπτυξη "
+"πακέτα ή να αναζητήσετε για άλλη βασική διανομή (τρέχον)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Θα μπορούσατε να επαληθεύσετε  το αρχείο κατά την διαδικασία μεταφόρτωσης. "
+"Για παράδειγμα, ένα ελεγκτικό σύνολο (SHA256) θα χρησιμοποιηθεί αυτόματα αν "
+"επιλέξετε <a href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> στο "
+"παραπάνω πεδίο και χρησιμοποιήσετε το πρόσθετο DownThemAll! στο <a "
+"href='http://en.opensuse.org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "Υπογραφή gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"είναι ακόμα το πιο σύνηθες ελεγκτικό σύνολο. Πολλές εφαρμογές εγγραφής ISO "
+"το δείχνουν αμέσως πριν την εγγραφή."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "είναι το λιγότερο γνωστό αλλά πιο ασφαλές ελεγκτικό σύνολο από το md5."
+
+msgid "md5 checksum"
+msgstr "Ελεγκτικό σύνολο md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"προσφέρει την μεγαλύτερη ασφάλεια αφού μπορείτε να επιβεβαιώσετε ποιος το "
+"υπέγραψε. Πρέπει να είναι <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Αντίστροφη Μέτρηση openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Παράγωγα openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"Το openSUSE είναι διαθέσιμο μέσω http (απευθείας σύνδεσμος) ή BitTorrent. Το "
+"CD για εγκατάσταση από δίκτυο είναι διαθέσιμο μόνο μέσω http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "Το openSUSE υποστηρίζει μόνο 32 και 64 bit H/Y "
+
+msgid "see Derivatives on wiki"
+msgstr "Δείτε τα Παράγωγα στο wiki"
+
+msgid "sha1 checksum"
+msgstr "Ελεγκτικό σύνολο sha1"
+
+msgid "switch to"
+msgstr "εναλλαγή στο"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Παρουσιάστηκε ένα εσωτερικό σφάλμα :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Παρακαλώ εισάγετε πάνω από 2 χαρακτήρες"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Τελευταίες αναζητήσεις:"
+
+#~ msgid "Statistics"
+#~ msgstr "Στατιστικά"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Δημοφιλείς 1-click Λήψεις:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Δημοφιλείς αναζητήσεις χωρίς αποτελέσματα:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Δημοφιλείς αναζητήσεις:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Αυτή την στιγμή δεν υπάρχει πιο τελευταία έκδοση στο Factory από την "
+#~ "τελευταία κυκλοφορία openSUSE. <br/> Παρακαλώ ελέγξτε το <href='http://en."
+#~ "opensuse.org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> "
+#~ "για περισσότερες πληροφορίες."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Μπορείτε να προσθέσετε το κλειδί του αποθετηρίου στο apt ως εξής: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Τα Live CD περιέχουν μόνο τέσσερις γλώσσες (Αγγλικά, Γερμανικά, Ρώσικα "
+#~ "και Ιταλικά). Αν θέλετε να υποστηρίζονται πρόσθετες γλώσσες, θα πρέπει να "
+#~ "τις κατεβάσετε από το διαδίκτυο κατά την εγκατάσταση ή όποτε θέλετε "
+#~ "αργότερα. Αν έχετε εύκολη πρόσβαση στο διαδίκτυο ή αν χρησιμοποιείτε DVD "
+#~ "που περιέχει όλες τις γλώσσες, δεν χρειάζεστε αυτό το CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Όταν έχετε μεταφορτώσει επιτυχώς την εικόνα(ες) ISO, εγγράψτε την "
+#~ "εικόνα(ες) με την αγαπημένη σας εφαρμογή εγγραφής CD ή DVD. Παρακαλούμε "
+#~ "<em>μην</em> γράψετε ένα DVD/CD δεδομένων, αλλά επιλέξτε να εγγράψετε "
+#~ "εικόνα iso."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Μία επιφάνεια εργασίας GNOME που μπορείτε να εκτελέσετε από CD ή από "
+#~ "στικάκι USB. <br/>Μπορεί να εγκαταστηθεί ώς έχει (χωρίς αναβάθμιση)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Μία επιφάνεια εργασίας KDE που μπορείτε να εκτελέσετε από CD ή από "
+#~ "στικάκι USB. <br/>Μπορεί να εγκαταστηθεί ώς έχει (χωρίς αναβάθμιση)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "Προσπαθήστε να επεκτείνετε την αναζήτηση σε μηυποστηριζόμενα πακέτα ή να "
+#~ "αναζητήσετε σε άλλη βάση διανομής (τρέχουσα)."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr ""
+#~ "Παρακαλώ οι λέξεις αναζήτησης που χρησιμοποιείτε να έχουν μήκος "
+#~ "τουλάχιστον 2 χαρακτήρες. "
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Εναλλαγή σε ακριβή αντιστοιχία λόγω των πολλών αποτελεσμάτων αναζήτησης "
+#~ "στις επιμέρους λέξεις κλειδιά."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Παρακαλώ γίνετε πιο συγκεκριμένοι στην αναζήτησή σας. Το όριο αναζήτησης "
+#~ "ξεπεράστηκε."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Αδυναμία αναζήτησης: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Δημοφιλής Λογισμικό"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Αγοράστε το openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Εγκατάσταση με 1 κλικ"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Χειροκίνητη Μεταφόρτωση Πακέτου"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Μεταβείτε στο Έργο OBS "
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Συλλογή Εφαρμογών]"
+
+#~ msgid "Search Results"
+#~ msgstr "Αποτελέσματα Αναζήτησης"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Δεν βρέθηκαν πακέτα στο openSUSE Build Service που να ταιριάζουν στην "
+#~ "αναζήτησή σας."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d συλλογές και %d εφαρμογές από %d πηγές πακέτων"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Στιγμιότυπο  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Στατιστικά αναζήτησης:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Στατιστικά Λήψεων:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Αναζήτηση και εγκατάσταση πακέτων λογισμικού από το <a href=\"http://"
+#~ "build.opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Επιλογές αναζήτησης"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Συμπεριλάβετε τα έργα από το home του χρήστη"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Μην συμπεριλάβετε πακέτα επίλυσης σφαλμάτων"
+
+#, fuzzy
+#~| msgid "General Information"
+#~ msgid "Additional Information"
+#~ msgstr "Γενικές Πληροφορίες"
+
+#, fuzzy
+#~| msgid "openSUSE"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "openSUSE"
+
+#, fuzzy
+#~| msgid "openSUSE"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "openSUSE"
+
+#, fuzzy
+#~| msgid "Installation Error"
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Σφάλμα Εγκατάστασης"
+
+#, fuzzy
+#~| msgid "YaST installation source"
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Πηγή εγκατάστασης YaST"
+
+# dialog title for nfs installation
+#, fuzzy
+#~| msgid "NFS Installation"
+#~ msgid "Network Installation"
+#~ msgstr "Εγκατάσταση NFS"
+
+#, fuzzy
+#~| msgid "http://opensuse.org/Projects/KNetworkManager"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://opensuse.org/Projects/KNetworkManager"
+
+#, fuzzy
+#~| msgid "Installation"
+#~ msgid "Internet Installation"
+#~ msgstr "Εγκατάσταση"
+
+#, fuzzy
+#~| msgid "Memory Information"
+#~ msgid "More information"
+#~ msgstr "Πληροφορίες Μνήμης"
+
+#, fuzzy
+#~| msgid "http://opensuse.org/Projects/KNetworkManager"
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://opensuse.org/Projects/KNetworkManager"
+
+#, fuzzy
+#~| msgid "http://opensuse.org/Projects/KNetworkManager"
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://opensuse.org/Projects/KNetworkManager"
+
+#, fuzzy
+#~| msgid "Software"
+#~ msgid "Get Software"
+#~ msgstr "Λογισμικό"
+
+#, fuzzy
+#~| msgid "Software"
+#~ msgid "Build Software"
+#~ msgstr "Λογισμικό"
+
+#, fuzzy
+#~| msgid "Directory\n"
+#~ msgid "User Directory"
+#~ msgstr "Κατάλογος\n"
+
+#, fuzzy
+#~| msgid "Pictures"
+#~ msgid "Features"
+#~ msgstr "Φωτογραφίες"
+
+#~ msgid "Software"
+#~ msgstr "Λογισμικό"
+
+#, fuzzy
+#~| msgid "Software Source"
+#~ msgid "Software Search"
+#~ msgstr "Πηγή Λογισμικού"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Άλλες Επιλογές"
+
+#, fuzzy
+#~| msgid "Error"
+#~ msgid "Mirrors"
+#~ msgstr "Σφάλμα"
+
+#, fuzzy
+#~| msgid "Select the language."
+#~ msgid "In other languages"
+#~ msgstr "Επιλέξτε τη γλώσσα."
+
+#, fuzzy
+#~| msgid "Sound service"
+#~ msgid "Search Build Service"
+#~ msgstr "Υπηρεσία ήχου"
+
+#, fuzzy
+#~| msgid "openSUSE"
+#~ msgid "Get openSUSE"
+#~ msgstr "openSUSE"
+
+#, fuzzy
+#~| msgid "Nothing to do."
+#~ msgid "Nothing found"
+#~ msgstr "Τίποτε για να γίνει."
+
+#, fuzzy
+#~| msgid "Search:"
+#~ msgid "Searching"
+#~ msgstr "Έρευνα:"
+
+#, fuzzy
+#~| msgid "Italian"
+#~ msgid "Metalinks"
+#~ msgstr "Ιταλικά"
+
+#, fuzzy
+#~| msgid "openSUSE"
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "openSUSE"
+
+#~ msgid "Help"
+#~ msgstr "Βοήθεια"
+
+#, fuzzy
+#~| msgid "GNOME Desktop"
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Επιφάνεια Εργασίας GNOME"

--- a/locale/es/software.po
+++ b/locale/es/software.po
@@ -1,0 +1,1129 @@
+# translation of software-opensuse-org.po to Spanish
+# translation of software-opensuse-org.po to
+# Camaleón <noelamac@gmail.com>, 2009.
+# Lluis <lmartinez@sct.ictnet.es>, 2010.
+# lluis, 2010, 2011.
+# Thomas Schmidt <tom@opensuse.org>, 2011.
+# Javier Llorente <javier@opensuse.org>, 2011.
+# lluis <lmartinez@ingelin.es>, 2011, 2012, 2013, 2014.
+# Carlos E. Robinson <carlos.e.r@opensuse.org>, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-03 19:25+0100\n"
+"Last-Translator: Carlos E. Robinson <carlos.e.r@opensuse.org>\n"
+"Language-Team: Spanish <opensuse-translation-es@opensuse.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid " and "
+msgstr " y "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} no es una versión soportada.\""
+
+msgid "(hide)"
+msgstr "(ocultar)"
+
+msgid "(show)"
+msgstr "(mostrar)"
+
+msgid "... and keep us informed"
+msgstr "... y mantenerle informado"
+
+msgid "... get other marketing stuff"
+msgstr "... obtener más material promocional"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD de 4.7GB (también funciona en memorias USB)"
+
+msgid "64 Bit PC"
+msgstr "PC de 64 bits"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Guía de "
+"inicio de openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://es.opensuse.org/Metalink\">Metalink</a> es un estándar "
+"abierto que engloba varias formas (FTP / HTTP / BitTorrent) de obtener "
+"archivos en un solo formato para que las descargas resulten más sencillas. "
+"Esto lo convierte en una buena manera de descargar imágenes ISO, sobre todo "
+"para la gente que no puede usar programas P2P debido a restricciones por "
+"parte del ISP o de la universidad. Permite descargas muy rápidas ya que la "
+"mayoría de los clientes admiten conexiones múltiples a varios servidores de "
+"réplica, automáticamente. Además, puede detectar cualquier error en la "
+"descarga de manera automática, así como corregirlo. Se necesita un cliente "
+"especial para poder gestionar este tipo de recurso."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://es.opensuse.org/OpenSUSE:Licencia\">Licencia</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notas de la versión</a> "
+
+msgid "<b>official release</b>"
+msgstr "<b>Versión oficial</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>Actualización oficial</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un escritorio GNOME que puede ejecutarse desde un %s o una llave USB."
+"<br>Puede instalarse (no apto para actualizaciones)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un escritorio KDE que puede ejecutarse desde un %s o una llave USB.<br>Puede "
+"instalarse (no apto para actualizaciones)."
+
+msgid "Add repository and install manually"
+msgstr "Añadir repositorio e instalar de forma manual"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Descargas adicionales (opcional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Después de descargar correctamente la imagen ISO, preparar una memoria USB "
+"para arrancar o grabar la imagen a un DVD (o un CD si la imagen seleccionada "
+"cabe)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Toda la información es utilizada para enviar material promocional de openSUSE"
+"\\n          y no será divulgada a terceros. Guardamos la información con el "
+"objetivo\\n          de informar a los usuarios sobre nuevas versiones "
+"disponibles. Todas las\\n          peticiones deben ser seleccionadas "
+"cumplimentando las condiciones de\\n          exportación de USA. Más "
+"información sobre las condiciones y la lista de\\n          países se "
+"encuentra disponbile en <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Navegador de aplicaciones"
+
+msgid "Available Images"
+msgstr "Imágenes disponibles"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Arrancar el equipo desde el DVD, CD o dispositivo USB. Si el sistema no "
+"puede arrancar automáticamente desde el dispositivo seleccionado, hay que "
+"entrar en la configuración de la BIOS para permitirlo."
+
+msgid "Bronze Sponsor"
+msgstr "Patrocinador bronce"
+
+msgid "Browser incompatibility"
+msgstr "Navegador incompatible"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Grabar imagen de CD/DVD"
+
+msgid "Categories"
+msgstr "Categorías"
+
+msgid "Category"
+msgstr "Categoría"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Seleccionar un medio de instalación pulsando sobre ellos y hacer clic sobre "
+"el botón de Descargar para iniciar la descarga. También se puede seleccionar "
+"el tipo de equipo (arquitectura) o un método alternativo de descarga."
+
+msgid "Click here to display these alternative versions."
+msgstr "Pulse aquí para ver las versiones alternativas"
+
+msgid "Click to Download"
+msgstr "Pulse para descargar"
+
+msgid "Community"
+msgstr "Comunidad"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Contiene una gran cantidad de software para usar con servidores o sobremesa."
+"<br>Adecuado para instalación o actualización."
+
+msgid "Countdown"
+msgstr "Cuenta atrás"
+
+msgid "Country"
+msgstr "País"
+
+msgid "Development"
+msgstr "Desarrollo"
+
+msgid "Development Version"
+msgstr "Versión en desarrollo"
+
+# src/create_utf8.c:42
+msgid "Development packages"
+msgstr "Paquetes de desarrollo"
+
+msgid "Development-"
+msgstr "Desarrollo"
+
+msgid "Direct Install"
+msgstr "Instalación directa"
+
+msgid "Direct Link"
+msgstr "Descarga directa"
+
+msgid "Documentation"
+msgstr "Documentación"
+
+msgid "Don't show this warning the next time"
+msgstr "No volver a mostrar esta advertencia"
+
+msgid "Download"
+msgstr "Descargar"
+
+msgid "Download %s"
+msgstr "Descargar %s"
+
+msgid "Download Help"
+msgstr "Ayuda para las descargas"
+
+msgid "Download Method"
+msgstr "Método de descarga"
+
+msgid "Download appliance from %s"
+msgstr "Descargando aplicación desde %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Descargar DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Descargar GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Descargar KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Descargar versión de red"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Descargar&nbsp;rescate"
+
+msgid "Downloads"
+msgstr "Descargas"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Descargar el sistema de instalación y todos los paquetes desde repositorios "
+"en línea. <br>Apropiado para nueva instalación y para actualización."
+
+msgid "Expand all sections ('e')"
+msgstr "Expandir todas las secciones('e')"
+
+msgid "Extra Languages"
+msgstr "Idiomas adicionales"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Idiomas adicionales (32 bits)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Idiomas adicionales (64 bits)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Para <strong>%s</strong> ejecute lo siguiente como <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Para <strong>%s</strong> ejecute lo siguiente:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Para <strong>Arch Linux</strong>, edite /etc/pacman.conf y añada lo "
+"siguiente (el orden de los repositorios es importante en pacman.conf, debido "
+"a que pacman siempre descarga el primer paquete que encuentra):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Para cada ISO, ofrecemos un fichero de checksum con la correspondiente suma "
+"SHA256."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Para seguridad extra, puede usar GPG para verificar quien firmó esos "
+"ficheros .sha256. Debería ser %s."
+
+msgid "Games"
+msgstr "Juegos"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Obtener una de las distribuciones especializadas basadas en openSUSE."
+
+msgid "Getting Help"
+msgstr "Ayuda"
+
+msgid "Gold Sponsor"
+msgstr "Patrocinador oro"
+
+msgid "Grab binary packages directly"
+msgstr "Descargar los paquetes binarios directamente"
+
+msgid "Header Logo"
+msgstr "Logo de cabecera"
+
+msgid "Help on Download Method"
+msgstr "Ayuda sobre el método de descarga"
+
+msgid "Help on Type of Computer"
+msgstr "Ayuda sobre el tipo de equipo"
+
+msgid "How to Proceed"
+msgstr "Procedimiento"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"También se puede seleccionar manualmente un servidor de réplica en el caso "
+"de que el redirector no disponga de la suficiente información como para "
+"seleccionar el servidor más rápido."
+
+msgid "Image:"
+msgstr "Imagen:"
+
+msgid "Install package %s / %s"
+msgstr "Instalar paquete %s / %s"
+
+# clients/inst_sw_single.ycp:1116 clients/inst_sw_single.ycp:1176
+# clients/inst_sw_single.ycp:1232 clients/inst_sw_single.ycp:1290
+msgid "Install pattern %s / %s"
+msgstr "Instalar patrón %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instalar usando \"One Click Install\""
+
+msgid "Installation Guides"
+msgstr "Guías de instalación"
+
+msgid "Installation Medium"
+msgstr "Medio de instalación"
+
+# no veo sentido en traducir algunos términos que de todas maneras se utilizarían en inglés.
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Únase a la comunidad de mayor crecimiento, ponga openSUSE en más manos"
+"\\n        consiguiendo los últimos PromoDVD para su grupo, organización sin "
+"fines de\\n        lucro, escuela, universidad o eventos, como reuniones de "
+"usuarios de linux\\n        installfests y conferencias. Los DVD "
+"promocionales ayudan a incrementar\\n        el conocimiento y visibilidad "
+"del proyecto openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Desafortunadamente, el navegador Konqueror de KDE 3 ya no se mantiene y su "
+"implementación de JavaScript contiene errores que impiden que funcione "
+"correctamente con esta página. Hay que asegurarse de que JavaScript se "
+"encuentre desactivado en el navegador antes de pulsar <a "
+"href='%s'>continuar</a>."
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Antiguo PC de 32 bits"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Antiguo 32&nbsp;Bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "GNOME Live"
+
+msgid "Live KDE"
+msgstr "KDE Live"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Muchas aplicaciones pueden verificar la suma de comprobación de una "
+"descarga. Es importante comprobar el archivo descargado ya que al hacerlo se "
+"verifica que se ha descargado el archivo ISO seleccionado y no una versión "
+"corrupta. Ofrecemos tres opciones diferentes para verificar la suma de "
+"comprobación:"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Más información sobre cómo grabar archivos ISO a un CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Más información sobre la creación de un lápiz de memoria ejecutable en <a "
+"href='http://es.opensuse.org/SDB:Live_USB_stick'>bootable USB stick</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Hay más información sobre la descarga de openSUSE en <a href=\"http://es."
+"opensuse.org/SDB:Ayuda_para_la_descarga\">Ayuda a la descarga</a> y <a href="
+"\"http://es.opensuse.org/SDB:Instalar_openSUSE_desde_la_red\">Instalación "
+"desde red</a>, las cuales son páginas del <a href=\"http://es.opensuse.org/"
+"Portal:Documentaci%C3%B3n\">wiki de documentación</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"La mayoría de los equipos nuevos tienen soporte para <a href=\"http://es."
+"wikipedia.org/wiki/X86-64\">x86-64</a> (también conocido como AMD64 e "
+"Intel64) pero algunos procesadores de portátiles y netbooks no lo admiten. "
+"Se debe verificar la Wikipedia para asegurarse de que el equipo lo admite."
+
+# src/create_utf8.c:48
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "¿Necesita ayuda?"
+
+msgid "Network"
+msgstr "Red"
+
+msgid "No appliance data for %s"
+msgstr "No hay datos de  la aplicación %s"
+
+msgid "No appliances found in project %s"
+msgstr "No se han encontrado aplicaciones en el proyecto %s"
+
+msgid "No data for %s / %s"
+msgstr "No hay datos de  %s  /  %s"
+
+msgid "No description found..."
+msgstr "No se ha encontrado ninguna descripción..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "No se han encontrado descargas para %s en el proyecto %s"
+
+msgid "No packages found matching your search. "
+msgstr "No se han encontrado paquetes que coincidan con su búsqueda."
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+msgid "OBS Backend not available"
+msgstr "Servicio OBS no disponible"
+
+msgid "Official Manuals"
+msgstr "Manuales oficiales"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Solo están completamente probadas las versiones en DVD y en red. Las "
+"alternativas como \"Live\" o \"Rescue\" solo están recomendadas para un uso "
+"limitado."
+
+msgid "Package %s not found..."
+msgstr "Paquete %s no encontrado..."
+
+msgid "Package Repositories"
+msgstr "Repositorios de paquetes "
+
+msgid "Package Search"
+msgstr "Búsqueda de paquetes"
+
+msgid "Packages for %s:"
+msgstr "Paquetes de %s:"
+
+msgid "Pick Mirror"
+msgstr "Elegir servidor mirror"
+
+msgid "Platinum Sponsor"
+msgstr "Patrocinador platino"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Por favor, tenga presente que los siguientes paquetes son de repositorios no "
+"oficiales.\n"
+"  Por tanto, no han sido revisados por openSUSE y pueden contener software "
+"inestable o experimental."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Ingrese un motivo <b>breve</b> (en Inglés!) de por qué necesita los DVDs e "
+"incluya un vínculo del evento/propósito."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Esta no es la ultima versión de openSUSE. Puede obtener la ultima versión en "
+"<a href='/'>here</a>."
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Los PromoDVD y todo el trabajo artístico relacionado -etiquetas y carátulas- "
+"pueden descargarse\n"
+"        desde <a href=\"http://download.opensuse.org/promodvd/\">el "
+"directorio promodvd %s</a>.\n"
+"        Tenga en cuenta que se trata de una versión especial de openSUSE,\n"
+"        diseñada exclusivamente para distribución promocional."
+
+msgid "Related categories:"
+msgstr "Categorías relacionadas"
+
+msgid "Released Version"
+msgstr "Versión publicada"
+
+msgid "Reporting Bugs"
+msgstr "Informar de fallos"
+
+msgid "Rescue"
+msgstr "Rescate"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Sistema de rescate que puede ejecutarse desde un CD o una llave USB.<br>No "
+"apto para instalar ni actualizar."
+
+msgid "SHA256 checksum"
+msgstr "Suma de comprobación SHA256"
+
+msgid "Search"
+msgstr "Buscar"
+
+msgid "Select Your Operating System"
+msgstr "Seleccione su sistema operativo"
+
+msgid "Select the image type"
+msgstr "Seleccione el tipo de imagen"
+
+msgid "Show"
+msgstr "Mostrar"
+
+# src/create_utf8.c:42
+msgid "Show development, language and debug packages"
+msgstr "Mostrar paquetes de desarrollo, lenguaje y debug"
+
+msgid "Show distribution:"
+msgstr "Mostrar distribución:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Mostrar más paquetes para las distribuciones no soportadas"
+
+msgid "Show more..."
+msgstr "Mostrar más... "
+
+msgid "Show other versions"
+msgstr "Mostrar otras versiones"
+
+msgid "Show unstable packages"
+msgstr "Mostrar los paquetes inestables"
+
+msgid "Show unsupported packages"
+msgstr "Mostrar los paquetes no soportados"
+
+msgid "Silver Sponsor"
+msgstr "Patrocinador plata"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Algunas alternativas( ej. \"sistemas Live\" y \"Rescue\") también están "
+"disponibles, sin embargo están menos comprobadas y se recomienda un uso "
+"limitado."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Algunas de las distribuciones \"Live\" basadas en openSUSE. Si está "
+"interesado en construir sus propios derivados puede mirar en  <a href="
+"\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Origen"
+
+msgid "Sponsored by"
+msgstr "Patrocinado por"
+
+msgid "Sponsored by: AMD"
+msgstr "Patrocinado por AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Patrocinado por: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Patrocinado por: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Patrocinado por: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Sub-paquetes"
+
+msgid "Support"
+msgstr "Asistencia"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"El proceso de instalación está disponible en muchos idiomas pero, para la "
+"mayoría de ellos, la traducción de las aplicaciones no se incluye en la "
+"imagen. Si desea que su sistema openSUSE soporte idiomas adicionales, debe "
+"descargarlos de Internet durante la instalación o en cualquier momento "
+"posterior. Si cuenta con un acceso fiable a Internet, no necesita este CD, "
+"pero si planea instalar openSUSE en algún sistema sin conexión a internet, "
+"el CD le proporcionará acceso a todas las traducciones disponibles."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Después ejecute lo siguiente como <strong>root</strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"No hay ninguna versión de openSUSE en fase de pruebas en este momento. <br/> "
+"Si quiere usar el software más reciente aún no verificado, puede usar <a "
+"href='http://es.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Este CD contiene software libre distribuido bajo una licencia propietaria no "
+"permitiéndose su inclusión en los medios principales de instalación junto "
+"con software libre y de código abierto. Todo el software de este CD puede "
+"descargarse del repositorio NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Esta versión se puede ejecutar en todos los equipos, incluyendo los que "
+"admiten la arquitectura de 64 bits. Aunque si se tiene instalado más de 3 "
+"GiB de memoria, instalar la versión de 64 bits podría ser recomendable. "
+"openSUSE no tiene soporte para procesadores anteriores a los Pentium - "
+"incluso las versiones LiveCD sólo admiten la arquitectura i686 (Pentium Pro "
+"y posteriores)."
+
+msgid "Type of Computer"
+msgstr "Tipo de equipo"
+
+msgid "Unsupported distributions:"
+msgstr "Distribuciones no soportadas:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Los manuales del usuario están disponibles en <a href=\"http://activedoc."
+"opensuse.org\">activedoc.opensuse.org</a>, por ejemplo la <a href=\"http://"
+"activedoc.opensuse.org/book/opensuse-start-up\">Guía oficial de inicio</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Se recomienda el uso de <a href=\"http://en.opensuse.org/SDB:BitTorrent\"> "
+"BitTorrent </a> con conexiones lentas, especialmente para descargar la "
+"imagen del DVD. Las descargas mediante BitTorrent ofrecen varios beneficios "
+"ya que protege a los clientes contra la corrupción de los datos y se ayuda a "
+"mitigar la carga de los servidores puesto que se participa activamente en la "
+"subida de los archivos (si participa mucha gente puede llegar a ser más "
+"rápido que el uso de servidores centralizados). Además, permite detener la "
+"descarga en cualquier momento y volver a retomarla más adelante."
+
+msgid "Verify your download before use"
+msgstr "Comprobar la descarga antes de usar"
+
+msgid "Version"
+msgstr "Versión"
+
+msgid "We offer three different checksums:"
+msgstr "Le ofrecemos tres sumas de comprobación diferentes:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Nos gustaría que nos mantenga informado sobre el uso de los DVDs, de esa"
+"\\n        manera podemos ayudarle a promover su organización, evento, o "
+"escuela\\n        en nuestro <a href='http://news.opensuse.org' title='news."
+"opensuse.org'>sitio de noticias</a>\\n        u otros recursos. (Consejo. "
+"Nos encantan las fotos. Tome muchas fotos!). Pónganse en\\n        contacto "
+"con <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\\n        para considerar publicidad y/u otras "
+"maneras en que podemos ayudarle."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Cuando se descargan imágenes que no sean las del CD para la instalación "
+"desde la red, se recomienda utilizar un gestor de descargas para reducir en "
+"lo posible una corrupción en los datos."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Puede añadir la clave del repositorio a apt. Tenga en cuenta que el usuario "
+"de la clave puede distribuir actualizaciones, paquetes y repositorios el los "
+"que su sistema confiara  (<a href=\"%s\">mas información</a>). Para añadir, "
+"ejecute :"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Puede intentar extender su búsqueda a paquetes de desarrollo o buscar con "
+"otra distribución base (actualmente )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Debe verificar el archivo que esta descargando. Por ejemplo, automáticamente "
+"se utilizará un \"checksum\" (SHA256) si escoge <a href='http://es.opensuse."
+"org/SDB:Metalink'>Metalink</a> en el campo anterior y usa el complemento "
+"DownThemAll en <a href='http://es.opensuse.org/Mozilla_Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "La firma GPG"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "https://es.opensuse.org/Derivados"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://es.opensuse.org/Repositorios_de_software"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://es.opensuse.org/Portal:Instalación"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://es.opensuse.org/SDB:Ayuda_para_la_descarga"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://es.opensuse.org/SDB:Ayuda_para_la_descarga#Grabar_la_imagen_ISO"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://es.opensuse.org/openSUSE:Envío de informes de error"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES.es."
+"html"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/RELEASE-NOTES.es."
+"html"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/RELEASE-NOTES.es."
+"html"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/RELEASE-NOTES.es."
+"html"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"es el método más utilizado para comprobar la suma. La mayoría de los "
+"programas de grabación de imágenes ISO lo muestran antes de proceder con la "
+"grabación."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "se trata de un sistema menos conocido que MD5, pero es más seguro."
+
+msgid "md5 checksum"
+msgstr "La suma de comprobación MD5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"proporciona la máxima seguridad ya que permite verificar quién lo ha "
+"firmado. Debería ser <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Cuenta atrás de openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivados de openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE se encuentra disponible vía http (descarga directa) o BitTorrent. "
+"El CD para la instalación desde la red sólo está disponible mediante http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE sólo admite equipos con arquitectura de 32 o 64 bits."
+
+msgid "see Derivatives on wiki"
+msgstr "vea los derivados en el wiki"
+
+msgid "sha1 checksum"
+msgstr "La suma de comprobación SHA1"
+
+msgid "switch to"
+msgstr "cambiar a"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Ha ocurrido un error interno del sistema :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Introduzca más de 2 caracteres"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Ultimas búsquedas:"
+
+# clients/lan_inetd_custom.ycp:748
+#~ msgid "Statistics"
+#~ msgstr "Estadísticas"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Principales descargas 1-click :"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Principales búsquedas sin ningún resultado:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Principales búsquedas:"
+
+# Se deja la versión antigua y no se cambia a DOC, porque no hay versión española allí
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES."
+#~ "es.html"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Actualmente no dispone de la ultima versión de Factory que es más "
+#~ "reciente que la suya de openSUSE.<br/>Compruebe <a href='http://en."
+#~ "opensuse.org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> "
+#~ "para más información."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Puede añadir la clave del repositorio a apt de la siguiente manera:"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "DVD de 4,7 GiB"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Los CDs Live sólo tienen cuatro idiomas (inglés, alemán, ruso e "
+#~ "italiano). Si desea añadir otros idiomas, puede descargarlos de Internet "
+#~ "durante o después de la instalación. Si puede acceder fácilmente a "
+#~ "Internet o si usa el DVD que tiene todos los idiomas, no necesita este CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Una vez descargada la imagen (o imágenes) ISO, se graba la imagen en un "
+#~ "CD o DVD utilizando cualquier programa de grabación. Hay que tener en "
+#~ "cuenta que <em>NO</em> se debe grabar un CD/DVD de datos sino seleccionar "
+#~ "la opción de grabar una imagen ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Un escritorio GNOME que puede ejecutarse desde un CD o una llave USB."
+#~ "<br>Puede instalarse ( no apto para actualizaciones)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Un escritorio KDE que puede ejecutarse desde un CD o una llave USB."
+#~ "<br>Puede instalarse ( no apto para actualizaciones)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "Puede intentar extender su búsqueda a paquetes no soportados or buscar en "
+#~ "otra distribución base (actualmente )."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Utilice una cadena de búsqueda de al menos 2 caracteres"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Cambiando a coincidencia exacta debido a que hay demasiados aciertos en "
+#~ "la búsqueda de frase parcial."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Por favor sea más preciso en sus términos de búsqueda, se ha alcanzado el "
+#~ "limite de la búsqueda."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "No se ha podido realizar la búsqueda:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Software popular"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Comprar openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://es.opensuse.org/Comprar_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click Install"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Descarga manual del paquete"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Ir al proyecto OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Colección de software]"
+
+#~ msgid "Search Results"
+#~ msgstr "Resultados de la búsqueda"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "No se han encontrado paquetes en el openSUSE build service que coincidan "
+#~ "con su búsqueda."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d colecciones y %d binarios en %d paquetes fuente"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Instantánea de"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Estadísticas de búsquedas:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Estadísticas de descargas:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Buscar e instalar paquetes de software desde el  <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opciones de búsqueda"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Incluir proyectos de usuarios"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Excluir paquetes de depuración"
+
+#~ msgid "Additional Information"
+#~ msgstr "Información adicional"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Instalación rápida</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Comprar openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Compra openSUSE 11.3"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Para obtener más información sobre la descarga, se puede consultar la "
+#~ "página <a href=\"http://es.opensuse.org/Instrucciones_de_descarga"
+#~ "\">Instrucciones para la descarga.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Instrucciones disponibles para:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Instalación desde CD/DVD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Guía de inicio oficial de %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Guía de instalación paso a paso"

--- a/locale/fi/software.po
+++ b/locale/fi/software.po
@@ -1,0 +1,1105 @@
+# translation of software-opensuse-org.fi.po to suomi
+# Jyri Palokangas <jyri.palokangas@opensuse.org>, 2009, 2010.
+# Jan-Olof Eriksson <jan-olof.eriksson@iki.fi>, 2009.
+# Asko Isonokari <askoin@opensuse.fi>, 2009.
+# Jyri Palokangas <jmp@opensuse.org>, 2010, 2011, 2012, 2013, 2014.
+# Katariina Kemppainen <katariina07@yahoo.se>, 2010.
+# Katariina Kemppainen <katariina@opensuse.fi>, 2010, 2011, 2012.
+# Harri Miettinen <harmie@opensuse.fi>, 2011, 2013, 2014, 2015.
+# Tommi Nieminen <translator@legisign.org>, 2011, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.fi\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-09-27 21:13+0200\n"
+"Last-Translator: Harri Miettinen <harmie@opensuse.fi>\n"
+"Language-Team: Finnish <kde-i18n-doc@kde.org>\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 2.0\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid " and "
+msgstr " ja "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} ei ole tuettu julkaisu.\""
+
+msgid "(hide)"
+msgstr "(piilota)"
+
+msgid "(show)"
+msgstr "(näytä)"
+
+msgid "... and keep us informed"
+msgstr "...ja pidä meidät ajan tasalla"
+
+msgid "... get other marketing stuff"
+msgstr "... hanki muita markkinointi tuotteita"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (sopii myös USB-tikulle)"
+
+msgid "64 Bit PC"
+msgstr "64-bittinen PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE-"
+"käyttöopas</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">Metalinkki</a> on avoin "
+"standardi, joka yhdistää eri lataustapoja (FTP/HTTP/BitTorrent) yhteen "
+"muotoon. Tämä tapa soveltuu hyvin ISO-levykuvien lataamiseen, etenkin "
+"niille, jotka eivät voi käyttää P2P-teknologiaa palveluntarjoajan tai "
+"yliopiston rajoitusten vuoksi. Se voi tarjota erittäin korkean "
+"latausnopeuden, koska useimmat asiakasohjelmat tukevat automaattisesti "
+"yhtäaikaisia yhteyksiä useilta peilipalvelimilta. Lisäksi, standardi "
+"sisältää automaattisen virheen tunnistuksen ja korjauksen. Tämän käyttöön "
+"tarvitaan kuitenkin erityinen ohjelma."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr ""
+"<a href=\"http://en.opensuse.org/OpenSUSE_License\">Käyttöoikeussopimus</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Julkaisutiedot</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>virallinen julkaisu</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>virallinen päivitys</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"GNOME-työpöytäympäristöä voi käyttää sekä %s että USB-tikulta.<br/>Sen voi "
+"myös asentaa niiltä (ei sovellu päivitykseen)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"KDE-työpöytäympäristöä voi käyttää sekä %s että USB-tikulta.<br/>Sen voi "
+"myös asentaa niiltä (ei sovellu päivitykseen)."
+
+msgid "Add repository and install manually"
+msgstr "Lisää asennuslähde ja asenna käsin"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Lisälataukset (valinnainen)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Onnistuneen ISO-kuvan/kuvien lataamisen jälkeen. luo käynnistyvä USB-tikku "
+"tai polta kuvatiedosto(t) DVD:lle (tai jos levykuva sopii, niin CD:lle)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Tietoja käytetään vain openSUSEn tiedotteiden lähettämiseen eikä\n"
+"      niitä levitetä kolmansille osapuolille. Tallennamme tiedot "
+"kertoaksemme\n"
+"      käyttäjille uuden version olevan saatavilla. Kaikki pyynnöt täytyy\n"
+"      seuloa Yhdysvaltain vientirajoitusten takia. Lisätietoa rajoituksista\n"
+"      ja maiden luettelosta löytyy Wikipedian artikkelista <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Sovellusselain"
+
+msgid "Available Images"
+msgstr "Saatavilla olevat levykuvat"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Käynnistä tietokone DVD-, CD-levyltä tai USB:ltä.  Jos automaattinen "
+"käynnistys ei toimi, muuta BIOS-asetusten käynnistysjärjestystä siten, että "
+"tietokoneen käynnistäminen tapahtuu valitulta laitteelta."
+
+msgid "Bronze Sponsor"
+msgstr "Pronssi-tason tukija"
+
+msgid "Browser incompatibility"
+msgstr "Epäsopiva selain"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Polta CD/DVD-levykuva(t)"
+
+msgid "Categories"
+msgstr "Luokat"
+
+msgid "Category"
+msgstr "Luokka"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Valitse asennusmedia napsauttamalla sitä ja paina Lataa-painiketta "
+"aloittaaksesi latauksen. Vaihtoehtoisesti voit valita tietokoneen tyypin tai "
+"vaihtoehtoisen lataustavan."
+
+msgid "Click here to display these alternative versions."
+msgstr "Paina tästä nähdäksesi vaihtoehtoiset versiot."
+
+msgid "Click to Download"
+msgstr "Napsauta ladataksesi"
+
+msgid "Community"
+msgstr "Yhteisö"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Sisältää laajan kokoelman ohjelmistoja työpöytä- tai palvelinkäyttöön.<br/"
+">Soveltuu asennukseen tai päivitykseen."
+
+msgid "Countdown"
+msgstr "Lähtölaskenta"
+
+msgid "Country"
+msgstr "Maa"
+
+msgid "Development"
+msgstr "Kehitys"
+
+msgid "Development Version"
+msgstr "Kehitysversio"
+
+msgid "Development packages"
+msgstr "Kehityspaketit"
+
+msgid "Development-"
+msgstr "Kehitys-"
+
+msgid "Direct Install"
+msgstr "Suora asennus"
+
+msgid "Direct Link"
+msgstr "Suora linkki"
+
+msgid "Documentation"
+msgstr "Dokumentaatio"
+
+msgid "Don't show this warning the next time"
+msgstr "Älä näytä tätä varoitusta uudelleen"
+
+msgid "Download"
+msgstr "Lataa"
+
+msgid "Download %s"
+msgstr "Lataa %s"
+
+msgid "Download Help"
+msgstr "Latauksen ohje"
+
+msgid "Download Method"
+msgstr "Lataustapa"
+
+msgid "Download appliance from %s"
+msgstr "Lataa ohjelmakokonaisuus %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Lataa&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Lataa&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Lataa&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Lataa&nbsp;verkkoasennus"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Lataa&nbsp;Korjausjärjestelmä"
+
+msgid "Downloads"
+msgstr "Lataukset"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Lataa asennusjärjestelmän ja kaikki paketit verkkoasennuslähteistä.<br/"
+">Sopii asennukseen tai päivitykseen."
+
+msgid "Expand all sections ('e')"
+msgstr "Laajenna kaikki osiot ('e')"
+
+msgid "Extra Languages"
+msgstr "Lisäkielet"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Lisäkielet (32-bittinen)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Lisäkielet (64-bittinen)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "<strong>%s</strong> suorita seuraava <strong>root</strong>-käyttäjänä:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "<strong>%s</strong> suorita seuraava:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"<strong>Arch Linux</strong>issa, muokka /etc/pacman.conf-tiedostoa ja lisää "
+"seuraava (huomaa että pakettivarastojen järjestys pacman.conf-tiedostossa on "
+"tärkeää, koska pacman lataa aina ensimmäisen löytämänsä paketin):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"tarjoaa parhaimman turvatason, koska voit tarkistaa kuka allekirjoittaja on. "
+"Sen tulisi olla <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Pelit"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Lataa jokin openSUSEn päälle rakennetuista erikoisjakeluista."
+
+msgid "Getting Help"
+msgstr "Ohjeiden hakeminen"
+
+msgid "Gold Sponsor"
+msgstr "Kulta-tason tukija"
+
+msgid "Grab binary packages directly"
+msgstr "Lataa binääripaketti suoraan asennuslähteestä"
+
+msgid "Header Logo"
+msgstr "Otsikon logo"
+
+msgid "Help on Download Method"
+msgstr "Lataustavan ohje"
+
+msgid "Help on Type of Computer"
+msgstr "Tietokonetyypin ohje"
+
+msgid "How to Proceed"
+msgstr "Kuinka edetä"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Jos haluat käyttää suoraa linkkiä, mutta asut paikassa, josta latauksen "
+"ohjauksella ei ole tarpeeksi tarkkaa tietoa ohjatakseen sinut nopeimmalle "
+"palvelimelle, voit valita palvelimen itse."
+
+msgid "Image:"
+msgstr "Levykuva:"
+
+msgid "Install package %s / %s"
+msgstr "Asenna paketti %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Asenna ohjelmistokokoelma %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Asenna käyttäen 1-Click asennusta"
+
+msgid "Installation Guides"
+msgstr "Asennusoppaat"
+
+msgid "Installation Medium"
+msgstr "Asennusmedia"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Liity nopeasti kasvavaan yhteisöön ja jaa openSUSE useammille tilaamalla "
+"uusin\n"
+"        viimeisin promo-DVD ryhmille, voittoa tuottamattomille "
+"järjestöille,\n"
+"        kouluille, yliopistoille tai esimerkiksi LUG-tapaamisiin, "
+"asennusbileisiin\n"
+"        tai konferensseihin. Promo-DVD:t auttavat openSUSEn näkyvyyttä!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"KDE3-sarjan Konqueroria ei enää valitettavasti ylläpidetä ja sen javascript-"
+"toteutus sisältää virheitä, jotka tekevät tämän sivun käytön mahdottomaksi. "
+"Varmista, että javascript on poistettu käytöstä ennen kuin <a "
+"href='%s'>jatkat</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Kieli"
+
+msgid "Legacy 32 Bit PC"
+msgstr "32-bittinen PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32-bittinen&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Monet sovellukset voivat verrata latauksen tarkistussummaa. Ladatun median "
+"tarkistus voi olla tärkeää koska se vertaa, että lataamasi ISO-tiedosto on "
+"todella haluamasi eikä rikkoutunut versio. "
+
+msgid "Metalink"
+msgstr "Metalinkki"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Lisätietoa ISO-tiedoston polttamisesta CD/DVD-levylle"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Lisätietoa <a href='http://en.opensuse.org/Live_USB_stick'>käynnistyvän USB-"
+"tikun</a> luomisesta"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Lisätietoa openSUSEn lataamisesta löytyy englanninkielisiltä <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> ja <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a>-"
+"sivuilta, jotka sijaitsevat <a href=\"http://en.opensuse.org/Portal:"
+"Documentation\">Documentation</a> wikissä."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Suurin osa uusista tietokoneista sisältää tuen <a href=\"http://en.wikipedia."
+"org/wiki/X86-64\">x86-64</a> (tunnetaan myös nimillä AMD64 ja Intel64), "
+"mutta joidenkin kannettavien ja netbook-tyyppisten minikannettavien "
+"prosessorit eivät tue sitä. Tarkista Wikipediasta, jos haluat olla varma "
+"tukeeko tietokoneesi sitä."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Tarvitsetko apua?"
+
+msgid "Network"
+msgstr "Verkko"
+
+msgid "No appliance data for %s"
+msgstr "Ei ohjelmakokonaisuus dataa %s"
+
+msgid "No appliances found in project %s"
+msgstr "Ohjelmakokonaisuuksia ei löytynyt projektista %s"
+
+msgid "No data for %s / %s"
+msgstr "Ei dataa %s / %s"
+
+msgid "No description found..."
+msgstr "Kuvausta ei löytynyt..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Ei latauksia %s projektissa %s"
+
+msgid "No packages found matching your search. "
+msgstr "Mikään paketti ei vastaa hakuasi. "
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD -levy"
+
+msgid "OBS Backend not available"
+msgstr "OBS-taustaosa ei ole saatavilla"
+
+msgid "Official Manuals"
+msgstr "Viralliset käsikirjat"
+
+#, fuzzy
+#| msgid ""
+#| "Only DVD and Network medias are fully tested. Alternatives, like live or "
+#| "rescue systems, are recomended for only limited use."
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Vain DVD ja verkkoasennus-mediat on täysin testattu. Vaihtoehtoiset live ja "
+"pelastus mediat ovat suositeltuja vain rajoitettuun käyttöön."
+
+msgid "Package %s not found..."
+msgstr "Pakettia %s ei löytynyt..."
+
+msgid "Package Repositories"
+msgstr "Asennuslähteet paketeille"
+
+msgid "Package Search"
+msgstr "Pakettihaku"
+
+msgid "Packages for %s:"
+msgstr "Paketit %s:"
+
+msgid "Pick Mirror"
+msgstr "Valitse peilipalvelin"
+
+msgid "Platinum Sponsor"
+msgstr "Platina-tason tukija"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Huomaa, että seuraavat paketit ovat epävirallisesta asennuslähteestä.\n"
+"    Tämä tarkoittaa sitä, ettei openSUSE ole tarkistanut niitä, ja ne "
+"saattavat sisältää epävakaita ja kokeellisia ohjelmistoja."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Anna <b>lyhyt</b> selitys (englanniksi) miksi tarvitset DVD-levyjä ja anna "
+"linkki tapahtumaan/tarkoitukseen."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Huomaa, että tämä ei ole viimeisin openSUSE-julkaisu. Uusimman julkaisun "
+"löydät <a href='/'>täältä</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo DVD:t ja kaikki niihin liittyvät kansitaide ja kotelot- voidaan\n"
+"        ladata osoitteesta <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        lataushakemistosta %s</a>. Muista että tämä on erikoisversio "
+"openSUSEsta,\n"
+"        joka on nimenomaan suunniteltu mainostustarkoitukseen."
+
+msgid "Related categories:"
+msgstr "Aiheeseen liittyvät luokat:"
+
+msgid "Released Version"
+msgstr "Julkaistu versio"
+
+msgid "Reporting Bugs"
+msgstr "Virheiden raportointi"
+
+msgid "Rescue"
+msgstr "Korjausjärjestelmä"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Korjausjärjestelmää voi käyttää CD-levyltä tai USB-tikulta.<br/>Sitä ei voi "
+"käyttää asennukseen eikä päivitykseen."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "MD5-tarkistussumma"
+
+msgid "Search"
+msgstr "Etsi"
+
+msgid "Select Your Operating System"
+msgstr "Valitse käyttöjärjestelmäsi"
+
+msgid "Select the image type"
+msgstr "Valitse levykuvan tyyppi"
+
+msgid "Show"
+msgstr "Näytä"
+
+msgid "Show development, language and debug packages"
+msgstr "Näytä kehitys, kieli- ja virheenetsintäpaketit"
+
+msgid "Show distribution:"
+msgstr "Näytä jakeluversio:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Näytä enemmän paketteja tuettomille jakeluille"
+
+msgid "Show more..."
+msgstr "Näytä lisää..."
+
+msgid "Show other versions"
+msgstr "Näytä muut versiot"
+
+msgid "Show unstable packages"
+msgstr "Näytä epävakaat paketit"
+
+msgid "Show unsupported packages"
+msgstr "Näytä tuettomat paketit"
+
+msgid "Silver Sponsor"
+msgstr "Hopeatason tukija"
+
+#, fuzzy
+#| msgid ""
+#| "Some alternative media (eg. live and rescue systems) are also available, "
+#| "although they are less tested and recommended for only limited use."
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Joitain vaihtoehtoisia medioita (esim. live ja pelastus) on saatavilla, "
+"mutta ne eivät ole yhtä hyvin testattuja ja ne ovat tarkoitettu rajoitettuun "
+"käyttöön."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Osa live-jakeluista pohjautuu openSUSEen. Jos olet kiinnostunut tekemään "
+"oman johdannaisesi, tutustu <a href=\"http://susestudio.com/\">SUSE Studio -"
+"palveluun</a>."
+
+msgid "Source"
+msgstr "Lähde"
+
+msgid "Sponsored by"
+msgstr "Projektin tukijat"
+
+msgid "Sponsored by: AMD"
+msgstr "Tukijana AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Tukijana B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Tukijana Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Tukijana IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Alipaketit"
+
+msgid "Support"
+msgstr "Tuki"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Asennustoiminto on käytettävissä useilla eri kielillä, mutta suurimmalta "
+"osalta kielistä, sovelluksien käännöstiedostostot puuttuvat "
+"levykuvatiedostoilta. Jos haluat openSUSE järjestelmäsi tukevan lisäkieliä, "
+"sinun pitää ladata niitä Internetistä asennuksen aikana takoska tahansa "
+"asennuksen jälkeen. Jos sinulla on yhteys Internettiin sinun ei tarvitse "
+"ladata tätä CD:tä, mutta jos aiot asentaa openSUSEn koneeseen jossa ei ole "
+"Internet yhteyttä, tämä CD tarjoaa pääsyn kaikkiin käytettävissä oleviin "
+"käännöksiin."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Suorita seuraava <strong>root</strong>-käyttäjänä"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Tällä hetkellä ei ole käynnissä openSUSE julkaisun testivaihetta. <br/> Jos "
+"haluat käyttää uusinta uutta, käytä <a href='http://en.opensuse.org/Portal:"
+"Tumbleweed'>openSUSE Tumbleweed</a>ä."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Tämä CD-levy sisältää ilmaisia, mutta tekijänoikeuden suojaamia "
+"ohjelmistoja, joita ei voi sisällyttää perusasennuslähteeseen yhdessä "
+"avoimen lähdekoodin ohjelmistojen kanssa. Kaikki tällä CD-levyllä olevat "
+"ohjelmistot on ladattavissa NON-OSS-asennuslähteestä."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Tämä versio toimii kaikissa PC-koneissa mukaan lukien ne, joissa on 64-"
+"bittinen tuki. Jos koneessasi on kuitenkin enemmän RAM-muistia kuin 3 Gt, "
+"sinun tulisi valita 64-bittinen versio. openSUSE ei tue Pentiumia vanhempia "
+"prosessoreita - liveCD-levyt on optimoitu ainoastaan i686-prosessoreille "
+"(Pentium Pro ja uudemmat)."
+
+msgid "Type of Computer"
+msgstr "Tietokonetyyppi"
+
+msgid "Unsupported distributions:"
+msgstr "Tukematon jakeluversio:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Englanninkieliset käyttöohjeet ovat ladattavissa osoitteesta <a href="
+"\"http://activedoc.opensuse.org\">activedoc.opensuse.org</a>, esimerkiksi <a "
+"href=\"http://activedoc.opensuse.org/book/opensuse-start-up/\">Virallinen "
+"aloitusopas</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrentin</a> "
+"käyttämistä suositellaan hitaille linkeille, erityisesti kun ladataan DVD-"
+"levykuvaa. BitTorrent-latauksilla on useita etuja: ohjelmat suojaavat datan "
+"virheiltä ja autat vähentämään palvelimen kuormitusta osallistumalla "
+"jakamiseen. Kun riittävän moni tekee saman, lataaminen on myös nopeampaa "
+"kuin keskitetyillä palvelimilla - kaikille. Lisäksi, voit keskeyttää "
+"latauksen koska tahansa ja jatkaa sitä myöhemmin."
+
+msgid "Verify your download before use"
+msgstr "Tarkista ladattu media ennen käyttöä"
+
+msgid "Version"
+msgstr "Versio"
+
+msgid "We offer three different checksums:"
+msgstr "Tarjolla on kolme eri tarkistussummaa:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Haluaisimme sinun pitävän meidät ajan tasalla DVD:iden käytöstäsi, jotta\n"
+"       voimme auttaa sinua mainostaa järjestöäsi, tapahtumaasi tai kouluasi\n"
+"       <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>uutissivullamme</a>\n"
+"       ja muuallakin. (Vihje! Pidämme valokuvista. Ota paljon kuvia!) Kysy "
+"sähköpostitse\n"
+"       <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"       mainonnasta tai muista tavoista, joilla voimme auttaa sinua."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Kun lataat muita levykuvia kuin verkkoasennus-CD:tä, on <i>erittäin</i> "
+"suositeltavaa, että käytät kunnollista latausohjelmaa vähentääksesi datan "
+"vioittumisen mahdollisuutta."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Voit lisätä pakettivaraston avaimen apt:iin. Pidä mielessä että avaimen "
+"omistaja voi jakaa päivityksiä, paketteja ja pakettivarastoja joihin "
+"järjestelmäsi luottaa (<a href=\"%s\">lisää tietoa</a>). Avaimen "
+"lisäämiseksi, suorita:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Voit koettaa laajentaa hakuasi kehityspaketteihin tai etsiä toisella "
+"jakeluversiolla (nykyinen )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Voit tarkistaa tiedoston lataustoiminnon aikana. Esimerkiksi tarkistussummaa "
+"(SHA256) käytetään automaattisesti, jos valitset <a href='http://en.opensuse."
+"org/SDB:Metalink'>Metalink</a>-latauksen yllä olevasta kentästä ja käytät <a "
+"href='http://en.opensuse.org/Firefox'>Firefoxin</a> DownThemAll! -lisäosaa."
+
+msgid "gpg signature"
+msgstr "GPG-allekirjoitus"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"on edelleen yleisin käytetty tarkistussumma. Monet ISO poltto-ohjelmat "
+"näyttävät sen juuri ennen polttoa."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "se on vähemmän tunnettu, mutta paljon turvallisempi kuin md5."
+
+msgid "md5 checksum"
+msgstr "MD5-tarkistussumma"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"tarjoaa parhaimman turvatason, koska voit tarkistaa kuka allekirjoittaja on. "
+"Sen tulisi olla <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "openSUSEn lähtölaskenta"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE-johdannaiset"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE on saatavilla http:n (suora linkki) tai BitTorrentin kautta. "
+"Verkkoasennus-CD on saatavilla ainoastaan http:n kautta."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE tukee vain 32- ja 64-bittistä tietokonetta."
+
+msgid "see Derivatives on wiki"
+msgstr "katso openSUSE-johdannaiset wikistä"
+
+msgid "sha1 checksum"
+msgstr "SHA1-tarkistussumma"
+
+msgid "switch to"
+msgstr "vaihda"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Tapahtui sisäinen virhe :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Anna enemmän kuin kaksi merkkiä"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Viimeisimmät haut:"
+
+#~ msgid "Statistics"
+#~ msgstr "Tilastot"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Eniten 1-click-latauksia:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Eniten hakuja ilman osumia:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Eniten hakuja:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Factory Snapshot on vanhempi kuin viimeisin openSUSE-julkaisu. <br/>Katso "
+#~ "lisätietoja osoitteesta <a href='http://en.opensuse.org/Portal:"
+#~ "Factory'>http://en.opensuse.org/Portal:Factory</a>."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Voit lisätä pakettilähteen avaimen apt:iin näin: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7 Gt DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "LiveCD-levyt sisältävät vain neljä kieltä (englanti, saksa, venäjä ja "
+#~ "italia). Jos haluat tuen muulle kielelle niin sinun täytyy ladata se "
+#~ "erikseen Internetistä asennuksen aikana tai koska tahansa sen jälkeen. "
+#~ "Jos pääset helposti Internetiin tai käytät DVD-levyä, joka sisältää "
+#~ "kaikki kielet, et tarvitse kyseistä CD-levyä."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Saatuasi ISO-levykuvat onnistuneesti ladatuksi polta ne haluamallasi "
+#~ "ohjelmalla DVD- tai CD-levylle. <em>Älä</em> polta kuvaa data-DVD/CD-"
+#~ "levyksi, vaan valitse vaihtoehto ”Polta ISO-levykuva”."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Käytä hakulausetta, jossa on vähintään kaksi merkkiä"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "Vaihdettu tarkkaan hakuun, koska alijonohaku tuotti liikaa osumia."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Rajaa hakusi tarkemmin, tulosten enimmäismäärä saavutettiin."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Hakua ei voitu suorittaa: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Suositut ohjelmistot"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Osta openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click -asennus"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Paketin lataaminen manuaalisesti"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Siirry OBS-projektin sivulle"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Ohjelmistokokoelma]"
+
+#~ msgid "Search Results"
+#~ msgstr "Hakutulokset"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Hakuasi vastaavia paketteja ei löytynyt openSUSEn paketointipalvelusta."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d pakettikokoelmaa, %d pakettia, %d lähdekoodipakettia"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Kuvankaappaus "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Hakutilastot:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Lataustilastot:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Etsi ja asenna ohjelmistopaketteja <a href=\"http://build.opensuse.org"
+#~ "\">openSUSEn paketointipalvelusta</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Hakuvalinnat"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Sisällytä käyttäjien kotiprojektit etsintään"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Poista vianjäljityspaketit etsinnästä"
+
+#~ msgid "Additional Information"
+#~ msgstr "Lisätietoa"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Asennuksen pikaopas</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Osta openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Osta openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Lisätietoa openSUSEn lataamisesta <a href=\"http://en.opensuse.org/"
+#~ "Download_Help\">Latausohje</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Ohjeet on saatavilla seuraavasti:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "DVD/CD-asennus:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Virallinen %s aloitusopas"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Step by step -asennusohje"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Verkkoasennus"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Verkkoasennus"
+
+#~ msgid "More information"
+#~ msgstr "Lisätietoa"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"

--- a/locale/fr/software.po
+++ b/locale/fr/software.po
@@ -1,0 +1,1073 @@
+#
+# Fabien Crespel <fabien@crespel.net>, 2009, 2010, 2011.
+# Guillaume GARDET <guillaume.gardet@opensuse.org>, 2011, 2012, 2013, 2014, 2015.
+# Antoine Belvire <antoine.belvire@laposte.net>, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-06 15:37+0100\n"
+"Last-Translator: Guillaume GARDET <guillaume.gardet@opensuse.org>\n"
+"Language-Team: French <opensuse-fr@opensuse.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid " and "
+msgstr " et "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} n'est pas une version supportée.\""
+
+msgid "(hide)"
+msgstr "(masquer)"
+
+msgid "(show)"
+msgstr "(afficher)"
+
+msgid "... and keep us informed"
+msgstr "... et tenez-nous informé"
+
+msgid "... get other marketing stuff"
+msgstr "... obtenir d'autres matériels marketing"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD de 4.7 Go (convient également pour une clé USB)"
+
+msgid "64 Bit PC"
+msgstr "PC 64 bits"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Guide de "
+"démarrage openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://fr.opensuse.org/SDB:Metalink\">Metalink</a> est un standard "
+"ouvert qui utilise différents protocoles (FTP/HTTP/BitTorrent) pour "
+"télécharger un seul et même fichier. Cela le rend très intéressant pour "
+"télécharger des fichiers ISO, en particulier pour les personnes ne pouvant "
+"pas utiliser le P2P à cause des restrictions de leur FAI ou de leur "
+"Université. Metalink permet d'atteindre des vitesses de téléchargement très "
+"importantes, car la plupart des clients supportent les connexions multiples "
+"à plusieurs sites miroirs. De plus, il intègre la détection et la correction "
+"automatique des erreurs. Un client spécifique est nécessaire pour en tirer "
+"parti, cependant."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licence</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notes de version</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>Version officielle</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>Mise à jour officielle</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un bureau GNOME que vous pouvez exécuter à partir de %s ou depuis une clé "
+"USB.<br /> Peut être installé tel quel (pas de mise à niveau)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un bureau KDE que vous pouvez exécuter à partir de %s ou depuis une clé USB."
+"<br /> Peut être installé tel quel (pas de mise à niveau)."
+
+msgid "Add repository and install manually"
+msgstr "Ajouter le dépôt et installer manuellement"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Téléchargement de produits complémentaires (optionnel)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Après avoir téléchargé l'image ISO, créer une clé USB amorçable ou graver "
+"l'image sur un DVD (ou un CD si l'image choisie loge)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Toutes les données sont uniquement utilisée pour envoyer du matériel de "
+"promotion\n"
+"      et ne seront pas transmises à des tiers. Nous stockons nos données\n"
+"      pour informer les utilisateurs lorsqu'une nouvelle version est "
+"disponible. Toutes les requêtes\n"
+"      doivent être vérifiées pour se conformer à l'embargo d'exportation US. "
+"Plus d'information sur cet embargo\n"
+"      et une liste de pays sur wikipedia <a href='http://en.wikipedia.org/"
+"wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+# TLABEL printer_2002_08_07_0216__246
+msgid "App Browser"
+msgstr "Explorateur d'applications"
+
+msgid "Available Images"
+msgstr "Images disponibles"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Amorcez votre système depuis le DVD, le CD ou une clé USB. Dans le cas où "
+"votre ordinateur ne démarre pas automatiquement depuis le périphérique "
+"choisi, entrez dans la configuration du BIOS pour autoriser cette option."
+
+msgid "Bronze Sponsor"
+msgstr "Sponsor Bronze"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilité du navigateur"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Gravure d'images CD/DVD"
+
+msgid "Categories"
+msgstr "Catégories"
+
+msgid "Category"
+msgstr "Catégorie"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Cliquez sur un média d'installation pour le sélectionner, puis cliquez sur "
+"le bouton Télécharger pour commencer le téléchargement. Choisissez "
+"éventuellement votre type d'ordinateur ou une méthode de téléchargement "
+"alternative."
+
+msgid "Click here to display these alternative versions."
+msgstr "Cliquer ici pour afficher ces versions alternatives."
+
+msgid "Click to Download"
+msgstr "Cliquez pour télécharger"
+
+msgid "Community"
+msgstr "Communauté"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Contient une large collection de logiciels pour une utilisation de bureau ou "
+"en tant que serveur.<br/>Convient pour l'installation comme pour la mise à "
+"jour."
+
+msgid "Countdown"
+msgstr "Décompte"
+
+msgid "Country"
+msgstr "Pays"
+
+msgid "Development"
+msgstr "Développement"
+
+msgid "Development Version"
+msgstr "Version de développement"
+
+msgid "Development packages"
+msgstr "Paquets de développement"
+
+msgid "Development-"
+msgstr "Développement-"
+
+msgid "Direct Install"
+msgstr "Installation directe"
+
+msgid "Direct Link"
+msgstr "Lien direct"
+
+msgid "Documentation"
+msgstr "Documentation"
+
+msgid "Don't show this warning the next time"
+msgstr "Ne pas afficher cet avertissement la prochaine fois"
+
+msgid "Download"
+msgstr "Télécharger"
+
+msgid "Download %s"
+msgstr "Télécharger %s"
+
+msgid "Download Help"
+msgstr "Aide au téléchargement"
+
+msgid "Download Method"
+msgstr "Type de téléchargement"
+
+msgid "Download appliance from %s"
+msgstr "Télécharger l'image depuis %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Télécharger le DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Télécharger GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Télécharger KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Télécharger Réseau"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Télécharger&nbsp;le système de secours"
+
+msgid "Downloads"
+msgstr "Téléchargements"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Télécharge le système d'installation et tous les paquets depuis les dépôts "
+"en ligne.<br/>Convient pour l'installation comme pour la mise à jour."
+
+msgid "Expand all sections ('e')"
+msgstr "Développer toutes les sections ('e')"
+
+msgid "Extra Languages"
+msgstr "Langues supplémentaires"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Langues supplémentaires (32 bits)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Langues supplémentaires (64 bits)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "Pour <strong>%s</strong>, executez en tant que <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Pour <strong>%s</strong>, exécutez :"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Pour <strong>Arch Linux</strong>, modifiez /etc/pacman.conf et ajoutez : "
+"(remarque : l'ordre des dépôts est important dans pacman.conf, puisque "
+"pacman télécharge toujours le premier paquet trouvé)"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Pour chaque ISO, nous proposons un fichier de somme de contrôle avec la "
+"somme SHA256 correspondante."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Pour plus de sécurité, vous pouvez utiliser GPG pour vérifier qui a signé "
+"ces fichiers .sha256. Ce devrait être %s."
+
+msgid "Games"
+msgstr "Jeux"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Obtenez une distribution spécialisée basée sur openSUSE."
+
+msgid "Getting Help"
+msgstr "Obtenir de l'aide"
+
+msgid "Gold Sponsor"
+msgstr "Sponsor Gold"
+
+msgid "Grab binary packages directly"
+msgstr "Récupérer les paquets binaires directement"
+
+msgid "Header Logo"
+msgstr "Logo d'en-tête"
+
+msgid "Help on Download Method"
+msgstr "Aide sur la méthode de téléchargement"
+
+# TLABEL rpm-groups_2002_03_14_2340__25
+msgid "Help on Type of Computer"
+msgstr "Aide sur le type d'ordinateur"
+
+msgid "How to Proceed"
+msgstr "Comment procéder"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Si vous voulez utiliser un lien direct mais habitez à un endroit du monde "
+"pour lequel notre redirecteur de téléchargement ne dispose pas d'assez "
+"d'informations pour choisir le miroir le plus rapide, vous pouvez choisir un "
+"miroir vous-même."
+
+msgid "Image:"
+msgstr "Image :"
+
+msgid "Install package %s / %s"
+msgstr "Installation du paquet %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Installer le modèle %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Installer en utilisant le One Click Install"
+
+msgid "Installation Guides"
+msgstr "Guides d'installation"
+
+msgid "Installation Medium"
+msgstr "Média d'installation"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Rejoignez la communauté grandissante, mettez openSUSE entre de nombreuses "
+"mains en\n"
+"        obtenant les derniers PromoDVD pour votre groupe, votre association, "
+"votre école, \n"
+"        votre université ou pour un évènement tel que les rencontres de "
+"GULL, les install parties \n"
+"        ou encore des conférences. Les Promo DVD aide à augmenter la "
+"visibilité d'openSUSE !"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror de KDE 3 n'est malheureusement plus maintenu et son implémentation "
+"Javascript contient des bogues qui le rendent incompatible avec cette page. "
+"Veuillez vous assurer que vous avez désactivé Javascript avant de <a "
+"href='%s'>continuer</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Langue"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Ancien PC 32 bits"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Ancien&nbsp;PC&nbsp;32&nbsp;bits"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"De nombreuses applications peuvent vérifier la somme de contrôle (checksum) "
+"d'un téléchargement. Vérifier votre téléchargement peut être important pour "
+"s'assurer que vous avez réellement obtenu le fichier ISO que vous vouliez et "
+"non une version corrompue."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Plus d'informations sur la gravure du fichier ISO sur un CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Plus d'informations sur la création d'une <a href='http://fr.opensuse.org/"
+"Live_USB_stick'>clé USB bootable</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Plus d'informations sur le téléchargement d'openSUSE sont disponibles dans "
+"les pages <a href=\"http://fr.opensuse.org/SDB:Aide_au_téléchargement\">Aide "
+"au téléchargement</a> et <a href=\"http://fr.opensuse.org/SDB:"
+"Installation_réseau\">Installation réseau</a> de notre <a href=\"http://fr."
+"opensuse.org/Portal:Documentation\">Documentation Wiki</a> (en anglais)."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"La plupart des nouveaux ordinateurs supportent <a href=\"http://fr.wikipedia."
+"org/wiki/X86-64\">x86-64</a> (aussi appelé AMD64 et Intel64), mais certains "
+"processeurs d'ordinateur portable ou de netbook ne le prennent pas en "
+"charge. Vous devriez donc vous assurer que votre ordinateur le supporte, en "
+"vérifiant sur Wikipedia par exemple."
+
+# TLABEL fr_FR_2002_02_20_2232__9
+msgid "Multimedia"
+msgstr "Multimédia"
+
+msgid "Need help?"
+msgstr "Besoin d'aide ?"
+
+# TLABEL linuxrc_2002_03_29_0036__161
+msgid "Network"
+msgstr "Réseau"
+
+msgid "No appliance data for %s"
+msgstr "Pas de données d'image pour %s"
+
+msgid "No appliances found in project %s"
+msgstr "Pas d'image trouvée dans le projet %s"
+
+msgid "No data for %s / %s"
+msgstr "Pas de données pour %s / %s"
+
+msgid "No description found..."
+msgstr "Aucune description trouvée..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Aucun téléchargement trouvé pour %s dans le projet %s"
+
+msgid "No packages found matching your search. "
+msgstr "Aucun paquet correpondant à votre recherche."
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+msgid "OBS Backend not available"
+msgstr "Backend OBS non disponible"
+
+msgid "Official Manuals"
+msgstr "Manuels officiels"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Seuls les DVD et l'installation par réseau sont intégralement testés. Les "
+"alternatives telles que les systèmes live ou de secours ne sont recommandés "
+"que pour un usage limité."
+
+msgid "Package %s not found..."
+msgstr "Paquet '%s' introuvable..."
+
+msgid "Package Repositories"
+msgstr "Dépôts de paquets"
+
+msgid "Package Search"
+msgstr "Recherche de paquets"
+
+# TLABEL restore_2002_08_07_0216__60
+msgid "Packages for %s:"
+msgstr "Paquets pour '%s':"
+
+msgid "Pick Mirror"
+msgstr "Choisir un miroir"
+
+msgid "Platinum Sponsor"
+msgstr "Sponsor Platinum"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Veuillez noter que les paquets suivants sont issus de dépôts non officiels.\n"
+"  Ceci signifie qu'ils ne sont pas vérifiés par openSUSE et qu'ils peuvent "
+"contenir des logiciels instables ou expérimentaux."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Veuillez entrer un <b>brève</b> raison (en anglais !) pour laquelle vous "
+"avez besoin de DVD et fournissez un lien vers l'évènement/le but."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Veuillez noter que ceci n'est pas la dernière version d'openSUSE. Vous "
+"pouvez obtneir la dernière version  <a href='/'>ici</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Les promo DVDs et leur pochette peuvent être \n"
+"        téléchargés depuis le <a href=\"http://download.opensuse.org/"
+"promodvd/\">dossier de\n"
+"        téléchargement des promodvds %s</a>. Gardez à l'esprit qu'il s'agit "
+"d'une version spéciale d'openSUSE,\n"
+"        conçue spécialement pour une distribution promotionnelle."
+
+msgid "Related categories:"
+msgstr "Catégories liées :"
+
+msgid "Released Version"
+msgstr "Version stable"
+
+msgid "Reporting Bugs"
+msgstr "Signaler des bogues"
+
+msgid "Rescue"
+msgstr "Secours"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Système de secours que vous pouvez exécuter à partir de d'un CD ou depuis "
+"une clé USB.<br /> Ne peut pas utilisé pour l'installation ou la mise à "
+"niveau."
+
+msgid "SHA256 checksum"
+msgstr "somme de contrôle SHA256"
+
+# TLABEL packages_2002_01_04_0147__110
+msgid "Search"
+msgstr "Recherche"
+
+msgid "Select Your Operating System"
+msgstr "Sélectionnez votre système d'exploitation"
+
+msgid "Select the image type"
+msgstr "Sélectionnez le type d'image"
+
+# TLABEL partitioning_2002_01_04_0147__125
+msgid "Show"
+msgstr "Afficher"
+
+msgid "Show development, language and debug packages"
+msgstr "Afficher les paquets de développement, de langue et de debug"
+
+msgid "Show distribution:"
+msgstr "Afficher la distribution:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Afficher plus de paquets pour les distributions non supportées"
+
+msgid "Show more..."
+msgstr "Afficher plus..."
+
+msgid "Show other versions"
+msgstr "Afficher les autres versions"
+
+msgid "Show unstable packages"
+msgstr "Afficher les paquets instables"
+
+msgid "Show unsupported packages"
+msgstr "Afficher les paquets non supportés"
+
+msgid "Silver Sponsor"
+msgstr "Sponsor Silver"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Certains médias alternatifs (comme les systèmes live ou de secours) sont "
+"également disponibles, bien qu'ils soient moins testés et ne sont "
+"recommandés que pour un usage limité."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Quelques-unes des distributions \"live\" basées sur openSUSE. Les personnes "
+"intéressées par la création de leurs propres dérivés peuvent essayer <a href="
+"\"http://susestudio.com/\">SUSE Studio</a>."
+
+# TLABEL profile-manager_2002_08_07_0216__49
+msgid "Source"
+msgstr "Source"
+
+msgid "Sponsored by"
+msgstr "Sponsorisé par"
+
+msgid "Sponsored by: AMD"
+msgstr "Sponsorisé par : AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponsorisé par : B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponsorisé par : Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponsorisé par : IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Sous-paquets"
+
+msgid "Support"
+msgstr "Support"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Le processus d'installation est disponible dans de nombreuses langues, mais "
+"pour la plupart, les traductions des applications ne sont pas incluses dans "
+"l'image. Si vous souhaitez que votre système openSUSE supporte des langues "
+"supplémentaires, vous devrez les télécharger depuis Internet lors de "
+"l'installation ou n'importe quand après. Si vous avez un accès à Internet, "
+"vous n'avez pas besoin de ce CD, mais si vous envisagez d'installer openSUSE "
+"sur une machine sans connexion Internet, il vous fournira toutes les "
+"traductions disponibles."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Puis exécutez executez en tant que <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Il n'y a aucune version d'openSUSE en phase de test actuellement . <br/> Si "
+"vous souhaitez utiliser et tester les logiciels dans leur toute dernière "
+"version, veuillez utiliser  <a href='http://en.opensuse.org/Portal:"
+"Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Ce CD contient des logiciels gratuits sous licence propriétaire, "
+"n'autorisant pas leur inclusion dans le média d'installation aux côtés des "
+"logiciels libres et open-source. Les logiciels de ce CD peuvent également "
+"être téléchargés depuis le dépôt NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Cette version fonctionne sur tous les PC, dont ceux qui supportent le mode "
+"64 bits. Si vous avez plus de 3 Go de RAM, vous devriez préférer la version "
+"64 bits. openSUSE ne supporte pas les processeurs antérieurs au Pentium - et "
+"les LiveCD ne supportent que i686 (Pentium Pro et plus récent)."
+
+# TLABEL rpm-groups_2002_03_14_2340__25
+msgid "Type of Computer"
+msgstr "Type d'ordinateur"
+
+msgid "Unsupported distributions:"
+msgstr "Distribution non supportées :"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Les manuels de l'utilisateur sont disponibles sur <a href=\"http://activedoc."
+"opensuse.org\">activedoc.opensuse.org</a>, par exemple le <a href=\"http://"
+"activedoc.opensuse.org/book/opensuse-start-up/\">Guide de démarrage</a> "
+"officiel."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"L'utilisation de <a href=\"http://fr.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent</a> est recommandée pour les connexions lentes, en particulier "
+"pour télécharger l'image DVD. Les téléchargements BitTorrent ont plusieurs "
+"avantages, les clients protègent contre la corruption des données et vous "
+"aidez à réduire la charge sur les serveurs en participant à l'envoi - si "
+"assez de gens participent, le débit dépassera même celui des serveurs "
+"centralisés. De plus, vous pouvez stopper le téléchargement à n'importe quel "
+"moment et le reprendre plus tard."
+
+msgid "Verify your download before use"
+msgstr "Vérifiez votre téléchargement avant utilisation"
+
+msgid "Version"
+msgstr "Version"
+
+msgid "We offer three different checksums:"
+msgstr "Nous fournissons trois sommes de contrôle différentes :"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Nous voudrions que vous nous teniez informé à propos de l'utilisation des "
+"DVD, pour que\n"
+"        nous puissions vous aider à promouvoir votre association, votre "
+"évènement ou votre école\n"
+"        sur notre <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>page de news</a>\n"
+"        ou sur d'autres ressources. (Un conseil, nous aimons les photos, "
+"alors prenez en plein !). Merci de nous\n"
+"        contacter sur <a href='mailto:opensuse-marketing@opensuse."
+"org'>opensuse-marketing@opensuse.org</a>\n"
+"        pour discuter de la promotion et/ou des autres moyens par lesquels "
+"nous pouvons vous aider."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Lorsque du téléchargement d'images autres que le CD pour l'installation "
+"réseau, il est <i>fortement</i> recommandé d'utiliser un gestionnaire de "
+"téléchargement pour réduire le risque de corruption des données."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Vous pouvez ajouter la clé du dépôt à apt. Gardez à l'esprit que le "
+"propriétaire de la clé peut fournir des mises à jour, des paquets et des "
+"dépôts envers lesquels votre système aura confiance (<a href=\"%s\">plus "
+"d'informations</a>). Pour ajouter la clé, exécutez :"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Vous pouvez essayer d'étendre votre recherche aux paquets de développement "
+"ou chercher pour une autre distribution (actuellement )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Vous pouvez vérifier le fichier au fur et à mesure du téléchargement. Par "
+"exemple, une somme de contrôle (SHA256) sera automatiquement utilisée si "
+"vous choisissez <a href='http://fr.opensuse.org/Metalink'>Metalink</a> dans "
+"le champ ci-dessus et utilisez le module complémentaire DownThemAll! dans <a "
+"href='http://fr.opensuse.org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "signature GPG"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://fr.opensuse.org/Dépôts_de_paquets"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://fr.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://fr.opensuse.org/SDB:Aide_au_téléchargement"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+"http://fr.opensuse.org/SDB:Aide_au_t%C3%A9l"
+"%C3%A9chargement#Graver_l.27image_ISO"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES.fr."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/RELEASE-NOTES.fr."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/RELEASE-NOTES.fr."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/RELEASE-NOTES.fr."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES.fr."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"est toujours la somme de contrôle la plus utilisée. De nombreux logiciels de "
+"gravure d'images ISO l'affichent avant de graver."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "est moins connu mais plus sécurisé que MD5."
+
+msgid "md5 checksum"
+msgstr "somme de contrôle MD5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"offre le plus de sécurité car vous pouvez vérifier qui l'a signé. Ce devrait "
+"être <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Décompte openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Dérivés d'openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE est disponible via http (lien direct) ou BitTorrent. Le CD pour "
+"l'installation réseau n'est disponible que via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE supporte uniquement les PC 32 bits et 64 bits."
+
+msgid "see Derivatives on wiki"
+msgstr "Voir Dérivés sur le Wiki"
+
+msgid "sha1 checksum"
+msgstr "somme de contrôle SHA1"
+
+msgid "switch to"
+msgstr "Passer à la"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Une erreur interne est survenue :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Veuillez entrer plus de 2 caractères"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES."
+#~ "fr.html"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES."
+#~ "fr.html"
+
+#~ msgid "Last searches:"
+#~ msgstr "Dernières recherches :"
+
+# TLABEL lan_inetd_2002_01_04_0147__28
+#~ msgid "Statistics"
+#~ msgstr "Statistiques"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Téléchargements 1-click les plus populaires :"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Recherches les plus courantes sans résultats :"
+
+#~ msgid "Top searches:"
+#~ msgstr "Recherches les plus courantes :"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr ""
+#~ "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES."
+#~ "fr.html"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Il n'y a pour le moment pas de version Factory plus récente que la "
+#~ "dernière version officielle d'openSUSE. <br/>Veuillez consulter <a "
+#~ "href='http://en.opensuse.org/Portal:Factory'>http://en.opensuse.org/"
+#~ "Portal:Factory</a> pour plus d'informations."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Vous pouvez ajouter la clé du dépôt à apt avec :"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "DVD 4.7 Go"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Les Live CDs ne contiennent que 4 langues (anglais, allemand, russe et "
+#~ "italien). Si vous voulez avoir accès à d'autres langues, vous devrez les "
+#~ "télécharger depuis Internet lors de l'installation ou à tout moment "
+#~ "ultérieurement. Si vous avez facilement accès à Internet ou si vous "
+#~ "utilisez le DVD contenant toutes les langues, vous n'avez pas besoin de "
+#~ "ce CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Après avoir téléchargé avec succès la ou les image(s) ISO, gravez-les "
+#~ "avec votre logiciel de gravure préféré sur un DVD ou un CD. Prenez garde "
+#~ "à ne <em>pas</em> graver un DVD/CD de données, mais choisissez l'option "
+#~ "pour graver une image ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Un bureau GNOME que vous pouvez exécuter depuis un CD ou une clé USB.<br/"
+#~ ">Peut être installé tel quel (pas de mise à jour)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Un bureau KDE que vous pouvez exécuter depuis un CD ou une clé USB.<br/"
+#~ ">Peut être installé tel quel (pas de mise à jour)."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.fr.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.fr.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "L'objet de votre recherche doit faire plus de 2 caractères"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "La recherche a été restreinte aux résultats exacts en raison d'un trop "
+#~ "grand nombre de résultats approchés."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Veuillez préciser votre recherche, la limite en nombre de résultats a été "
+#~ "atteinte."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Impossible d'exécuter la recherche : "
+
+#~ msgid "Popular Software"
+#~ msgstr "Logiciels populaires"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Achetez openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click Install"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Téléchargement manuel des paquets"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Aller au projet OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Collection de logiciels]"
+
+#~ msgid "Search Results"
+#~ msgstr "Résultats de recherche"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Aucun paquet ne correspond à votre requête dans l'openSUSE Build Service."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d collections et %d binaires de %d paquets sources"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Capture d'écran de "

--- a/locale/gl/software.po
+++ b/locale/gl/software.po
@@ -1,0 +1,1133 @@
+# Manuel A. Vázquez <xixirei@yahoo.es>, 2009.
+# Manuel A. Vazquez <xixirei@yahoo.es>, 2010, 2011, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-07 15:43+0100\n"
+"Last-Translator: Manuel A. Vázquez <xixirei@yahoo.es>\n"
+"Language-Team: Galician <proxecto@trasno.net>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+msgid " and "
+msgstr " e "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} non é unha versión admitida.\""
+
+msgid "(hide)"
+msgstr "(agochar)"
+
+msgid "(show)"
+msgstr "(mostrar)"
+
+msgid "... and keep us informed"
+msgstr "...e mantelo informado"
+
+msgid "... get other marketing stuff"
+msgstr "... obter máis material de promoción"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD de 4.7GB (tamén funciona en memorias USB)"
+
+msgid "64 Bit PC"
+msgstr "PC de 64 bit"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Manual de "
+"inicio de openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> é un estándar "
+"aberto que combina varias formas (FTP/HTTP/BitTorrent) de obter ficheiros "
+"nun único formato doado de descargar. Isto convérteo nun bo xeito de "
+"descargar imaxes ISO, principalmente para persoas que non poden usar "
+"programas P2P debido a restricións dos seus provedores ou da universidade. "
+"Permite descargas moi rápidas posto que a meirande parte dos clientes "
+"admiten conexións múltiples a varios servidores de réplica, de xeito "
+"automático. Cómpre ter un cliente especial para poder xestionar este tipo de "
+"recurso."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licenza</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notas da versión</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>versión oficial</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>actualización oficial</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un escritorio GNOME que pode executarse desde %s ou unha memoria USB.<br/> "
+"Pode instalarse (non serve para anovar)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un escritorio KDE que pode executarse desde %s ou unha memoria USB.<br/> "
+"Pode instalarse (non serve para anovar)."
+
+msgid "Add repository and install manually"
+msgstr "Engadir repositorio e instalar manualmente"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Descargas de complementos (opcional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Despois de descargar correctamente a(s) imaxe(s) ISO, preparar unha memoria "
+"USB para arrancar ou gravar a(s) imaxe(s) nun DVD (ou nun CD se a imaxe "
+"seleccionada collese)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Toda a información úsase para enviar material promocional de openSUSE\n"
+"     e non será divulgada a terceiros. Gardamos a información co obxecto\n"
+"     de informar aos usuarios de novas versións dispoñíbeis. Todas as\n"
+"     peticións deben seleccionarse cumprindo as condicións de\n"
+"     exportación de USA. Máis información sobre as condicións e a lista "
+"países está dispoñíbel en <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Navegador de aplicativos"
+
+msgid "Available Images"
+msgstr "Imaxes dispoñíbeis"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Arranque a partires do DVD, CD ou memoria USB. Se o computador non pode "
+"arrincar automaticamente desde o dispositivo escollido, entre na "
+"configuración da BIOS para permitir o arranque desde ese dispositivo."
+
+msgid "Bronze Sponsor"
+msgstr "Patrocinador bronce"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilidade do navegador"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Gravar imaxe(s) de CD/DVD"
+
+msgid "Categories"
+msgstr "Categorías"
+
+msgid "Category"
+msgstr "Categoría"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Escolla un medio de instalación premendo sobre eles e sobre o botón "
+"Descargar para iniciar a descarga. Opcionalmente, escolla o tipo de "
+"computador (arquitectura) ou un método alternativo de descarga."
+
+msgid "Click here to display these alternative versions."
+msgstr "Prema aquí para ver as versións aternativas."
+
+msgid "Click to Download"
+msgstr "Premer para descargar"
+
+msgid "Community"
+msgstr "Comunidade"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Contén unha grande colección de software para o uso do escritorio ou en "
+"servidores.<br/>Axeitado para a instalar ou anovar."
+
+msgid "Countdown"
+msgstr "Contador"
+
+msgid "Country"
+msgstr "País"
+
+msgid "Development"
+msgstr "Desenvolvemento"
+
+msgid "Development Version"
+msgstr "Versión de desenvolvemento"
+
+msgid "Development packages"
+msgstr "Paquetes de desenvolvemento"
+
+msgid "Development-"
+msgstr "Desenvolvemento-"
+
+msgid "Direct Install"
+msgstr "Instalación directa"
+
+msgid "Direct Link"
+msgstr "Ligazón directa"
+
+msgid "Documentation"
+msgstr "Documentación"
+
+msgid "Don't show this warning the next time"
+msgstr "Non volver mostrar este aviso"
+
+msgid "Download"
+msgstr "Descarga"
+
+msgid "Download %s"
+msgstr "Descargue %s"
+
+msgid "Download Help"
+msgstr "Axuda para a descarga"
+
+msgid "Download Method"
+msgstr "Método de descarga"
+
+msgid "Download appliance from %s"
+msgstr "Descargar aplicativo desde %"
+
+msgid "Download&nbsp;DVD"
+msgstr "Descargue&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Descargue&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Descargue&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Descargue&nbsp;Instalación mediante a rede"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Descargue&nbsp;Rescate"
+
+msgid "Downloads"
+msgstr "Descargas"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Descargue o sistema de instalación e todos os paquetes desde repositorios "
+"conectados.<br/>Axeitado para instalar ou anovar."
+
+msgid "Expand all sections ('e')"
+msgstr "Expandir todas as seccións ('e')"
+
+# AU
+msgid "Extra Languages"
+msgstr "Idiomas adicionais"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Idiomas adicionais (32 bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Idiomas adicionais (64 bits)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Para <strong>%s</strong> execute o seguinte como <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Para <strong>%s</strong> execute o seguinte:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Para <strong>Arch Linux</strong>, edite /etc/pacman.conf e engada o seguinte "
+"(a orde dos repositorios é importante en pacman.conf, xa que pacman sempre "
+"descarga o primeiro paquete que atopa):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Para cada ISO, ofrecemos un ficheiro de comprobación coa correspondente suma "
+"SHA256."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Para maior seguridade, pode usar GPG para verificar quen asinou eses "
+"ficheiros .sha256. Debería ser %s."
+
+msgid "Games"
+msgstr "Xogos"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Obteña unha das distribucións especializadas feitas en openSUSE."
+
+msgid "Getting Help"
+msgstr "Obter axuda"
+
+msgid "Gold Sponsor"
+msgstr "Patrocinador ouro"
+
+msgid "Grab binary packages directly"
+msgstr "Obter paquetes binarios directamente"
+
+msgid "Header Logo"
+msgstr "Logotipo da cabeceira"
+
+msgid "Help on Download Method"
+msgstr "Axuda no método de descarga"
+
+msgid "Help on Type of Computer"
+msgstr "Axuda no tipo de computador"
+
+msgid "How to Proceed"
+msgstr "Como proceder"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Se quere usar unha ligazón directa pero vive nun lugar do mundo onde o noso "
+"redireccionador de descargas non ten moita información para conectalo ao "
+"servidor de réplica máis rápido, pode escoller vostede mesmo un servidor de "
+"réplica."
+
+msgid "Image:"
+msgstr "Imaxe:"
+
+msgid "Install package %s / %s"
+msgstr "Instalar o paquete %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Instalar patrón %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instalar empregando One Click Install"
+
+msgid "Installation Guides"
+msgstr "Guías de instalación"
+
+msgid "Installation Medium"
+msgstr "Medio de instalación"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Únase á comunidade de maior crecemento, poña openSUSE en máis mans\n"
+"         solicitando os últimos DVD promocionais para o seu grupo, "
+"organización sen ánimo de lucro,\n"
+"       universidade ou eventos, como reunións de LUG, festivais de "
+"instalación e conferencias.\n"
+"       Os DVDs de promoción axudan a aumentar o coñecemento e visibilidade "
+"do proxecto openSUSE!    "
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"O navegador Konqueror de KDE 3 xa non se mantén e a súa implementación de "
+"javascript contén fallos que fan imposíbel o seu uso nesta páxina. Asegúrese "
+"ter desactivado javascript no navegador antes de <a href='%s'>continuar</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Antigo PC de 32 bits"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Antigo 32&nbsp;Bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "LiveCD GNOME"
+
+msgid "Live KDE"
+msgstr "LiveCD KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Moitos aplicativos poden comprobar a suma de comprobación dunha descarga. É "
+"importante comprobar o ficheiro descargado posto que se verifica se "
+"realmente descargou o ficheiro ISO correcto e non unha versión corrupta."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Máis información sobre a gravación dun ficheiro ISO nun CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Máis información sobre a creación dunha <a href='http://en.opensuse.org/"
+"Live_USB_stick'>memoria USB arrancábel</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Máis información sobre como descargar openSUSE nas páxinas <a href=\"http://"
+"en.opensuse.org/SDB:Download_help\">Axuda para descarga</a> e <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Instalación mediante a "
+"rede</a> e no noso wiki<a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Wiki de documentación</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"A meirande parte dos computadores novos son compatíbeis con <a href=\"http://"
+"en.wikipedia.org/wiki/X86-64\">x86-64</a> (tamén coñecido como AMD64 e "
+"Intel64), pero algúns procesadores de portátiles e ultraportátiles non o "
+"admiten. Débese verificar na wikipedia para estar seguro de que o equipo "
+"admite isto."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Necesita axuda?"
+
+msgid "Network"
+msgstr "Rede"
+
+msgid "No appliance data for %s"
+msgstr "Sen datos do aplicativo para %"
+
+msgid "No appliances found in project %s"
+msgstr "Non se atopou ningún aplicativo no proxecto %s"
+
+msgid "No data for %s / %s"
+msgstr "Sen datos para %s / %s"
+
+msgid "No description found..."
+msgstr "Non se atopou ningunha descrición..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Non se atopou ningunha descarga para %s no proxecto %s"
+
+msgid "No packages found matching your search. "
+msgstr "Non se atoparon paquetes que concorden coa súa busca. "
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+msgid "OBS Backend not available"
+msgstr "Infraestrutura OBS non dispoñíbel"
+
+msgid "Official Manuals"
+msgstr "Manuais oficiais"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Só están completamente probadas as versións en DVD e en rede. As "
+"alternativas como live ou rescate só están recomendas para un uso limitado."
+
+msgid "Package %s not found..."
+msgstr "Paquete %s non atopado..."
+
+msgid "Package Repositories"
+msgstr "Repositorios de paquetes"
+
+msgid "Package Search"
+msgstr "Buscar paquetes"
+
+msgid "Packages for %s:"
+msgstr "Paquetes para %s:"
+
+msgid "Pick Mirror"
+msgstr "Escolla un servidor de réplica"
+
+msgid "Platinum Sponsor"
+msgstr "Patrocinador platino"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Teña en conta que os seguintes paquetes son de repositorios non oficiais.\n"
+" Por iso non foron revisados por openSUSE e poden conter software inestábel "
+"ou experimental."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Especifique un motivo <b>breve</b> (en inglés) polo que necesita os DVDs e "
+"inclúa unha ligazón do evento/obxectivo."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Esta non é a última versión de openSUSE. Pode obter a última versión en <a "
+"href='/'>here</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"OS DVD promocionais e todo o traballo artístico relacionado pode\n"
+"        descargarse desde <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        o directorio promodvd %s</a>. Teña en conta que se trata dunha "
+"versión especial de openSUSE,\n"
+"        deseñada unicamente para distribución promocional."
+
+msgid "Related categories:"
+msgstr "Categoría relacionadas:"
+
+msgid "Released Version"
+msgstr "Versión publicada"
+
+msgid "Reporting Bugs"
+msgstr "Enviar erros"
+
+msgid "Rescue"
+msgstr "Rescate"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Sistema de rescate que pode executarse desde CD ou desde unha memoria USB."
+"<br/>Non serve nin para instalar nin anovar."
+
+msgid "SHA256 checksum"
+msgstr "Suma de comprobación SHA256"
+
+msgid "Search"
+msgstr "Buscar"
+
+msgid "Select Your Operating System"
+msgstr "Seleccione o seu sistema operativo"
+
+msgid "Select the image type"
+msgstr "Seleccione o tipo de imaxe"
+
+msgid "Show"
+msgstr "Mostrar"
+
+msgid "Show development, language and debug packages"
+msgstr "Mostar paquetes de desenvolvemento, idioma e depuración"
+
+msgid "Show distribution:"
+msgstr "Mostar distribución:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Mostrar máis paquetes para as distribucións non admitidas"
+
+msgid "Show more..."
+msgstr "Mostrar máis..."
+
+msgid "Show other versions"
+msgstr "Mostrar outras versións"
+
+msgid "Show unstable packages"
+msgstr "Mostrar paquetes inestábeis"
+
+msgid "Show unsupported packages"
+msgstr "Mostar os paquetes non admitidos"
+
+msgid "Silver Sponsor"
+msgstr "Patrocinador prata"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Algunhas alternativas (ex. sistemas live ou rescate) tamén están "
+"dispoñíbeis, pero están menos comprobadas e recoméndase un uso limitado."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Algunhas das distribucións live baseadas en openSUSE. Se ten interese en "
+"construír os seus propios derivados, pode mirar en <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+# install source menu title
+# *keep it short*
+msgid "Source"
+msgstr "Fonte"
+
+msgid "Sponsored by"
+msgstr "Patrocinado por"
+
+msgid "Sponsored by: AMD"
+msgstr "Patrocinado por: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Patrocinado por: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Patrocinado por: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Patrocinado por: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Subpaquetes"
+
+msgid "Support"
+msgstr "Asistencia técnica"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"O proceso de instalación está dispoñíbel en moitos idiomas, pero non se "
+"inclúe na imaxe a tradución dos aplicativos para a meirande parte deles. Se "
+"quere que o seu sistema openSUSE permita idiomas adicionais, debe "
+"descargalos de Internet durante a instalación ou en calquera intre "
+"posterior. Se conta cun acceso rápido a Internet, non precisa este CD, pero "
+"se planea instalar openSUSE nalgún sistema sen conexión a Internet, o CD "
+"forneceralle acceso a todas as traducións dispoñíbeis."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Despois execute o seguinte como <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Neste intre non hai ningunha versión de openSUSE en fase de probas. <br/> Se "
+"quere empregar o software máis recente pero sen verificar, pode usar <a "
+"href='http://en.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Este CD contén software de balde distribuído baixo licenzas propietarias que "
+"non permiten a súa inclusión no medio de instalación principal xunto co "
+"software libre. Todo o software deste CD pódese baixar do repositorio NON-"
+"OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Esta versión pódese executar en todos os equipos incluíndo os que admiten 64 "
+"bits. Se ten máis de 3 GB de memoria RAM no computador, debería preferir a "
+"versión de 64 bits. openSUSE non dá compatibilidade a procesadores máis "
+"vellos ca o Pentium - os LiveCD dan soporte só a i686 (Pentium Pro e "
+"posteriores)."
+
+msgid "Type of Computer"
+msgstr "Tipo de computador"
+
+msgid "Unsupported distributions:"
+msgstr "Distribucións non admitidas:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Os manuais de usuarios están en <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, por exemplo, o <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up//\">Manual de inicio oficial</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Recoméndase o uso de <a href=\"http://en.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent</a> con conexións lentas, especialmente ao descargar a imaxe "
+"do DVD. A descarga mediante BitTorrent ten moitos beneficios, protexe aos "
+"clientes contra o dano nos datos e axuda a diminuír a carga dos servidores "
+"xa que se participa activamente no envío de ficheiros - ao participar moita "
+"xente pode chegar a ser máis rápido ca os servidores centralizados -. "
+"Ademais, permite deter a descarga en calquera intre e reanudala máis tarde."
+
+msgid "Verify your download before use"
+msgstr "Comprobe a súa descarga antes de usar"
+
+msgid "Version"
+msgstr "Versión"
+
+msgid "We offer three different checksums:"
+msgstr "Ofrecemos tres métodos diferentes de suma de comprobación:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Gustaríanos que nos mantivese informados sobre o uso dos DVDs, dese xeito\n"
+"       podemos axudalo a promover a súa organización, evento ou escola na\n"
+"       <a href='http://news.opensuse.org' title='news.opensuse.org'>páxina "
+"de noticias</a>\n"
+"    ou noutros recursos. (Un consello. Gústannos as fotos.Tire moitas "
+"fotos!). Póñase en contacto connosco en\n"
+"      <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"       para tratar o tema da publicidade e/ou outros xeitos de poder axudalo."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Ao descargar outras imaxes que non sexan as do CD para a instalación desde a "
+"rede, recoméndase utilizar un xestor de descargas axeitado para reducir o "
+"risco de dano nos datos."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Pode engadir a chave do repositorio a apt. Teña en conta que o usuario da "
+"chave pode distribuír actualizacións, paquetes e repositorios nos que o seu "
+"sistema vai confiar (<a href=\"%s\">máis información</a>). Para engadir a "
+"chave, execute :"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Pode tentar estender a súa busca aos paquetes de desenvolvemento ou buscar "
+"por outra distribución base (actualmente )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Pode comprobar o ficheiro durante o proceso de descarga. Por exemplo, unha "
+"suma de comprobación (SHA256) empregarase automaticamente se escolle <a "
+"href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> no campo de enriba e "
+"usar o complemento DownThemAll! en <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "A sinatura gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"é o método máis empregado para comprobar a suma. Moitos gravadores de imaxes "
+"ISO amósanos antes da gravación."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "é a menos coñecida pero é máis segura ca MD5."
+
+msgid "md5 checksum"
+msgstr "A suma de comprobación md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"ofrece a maior seguridade xa que permite verificar quen o asinou. Debería "
+"ser <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Contador de openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivados do openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE está dispoñíbel vía http (ligazón directa) ou BitTorrent. O CD para "
+"a instalación desde a rede está só dispoñíbel mediante http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE só admite PCs de 32 bits e 64 bits"
+
+msgid "see Derivatives on wiki"
+msgstr "Vexa os derivados na wiki"
+
+msgid "sha1 checksum"
+msgstr "A suma de comprobación sha1"
+
+msgid "switch to"
+msgstr "cambiar a"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Ocorreu un erro interno do sistema :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Introduza máis de dous caracteres"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Últimas buscas:"
+
+#~ msgid "Statistics"
+#~ msgstr "Estatísticas"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Principais descargas 1-click:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Buscas máis frecuentes sen descargas:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Buscas máis frecuentes:"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Arestora non temos unha imaxe de Factory que sexa máis recente ca a "
+#~ "última versión de openSUSE. <br/> Comprobe <a href='http://en.opensuse."
+#~ "org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> para obter "
+#~ "máis información."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Pode engadir a chave do repositorio a apt do seguinte xeito: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "DVD de 4,7GB"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Os LiveCD conteñen só catro idiomas (inglés, alemán, ruso e italiano). Se "
+#~ "quixese ter soporte para os demais idiomas restantes precisa descargalos "
+#~ "de Internet durante a instalación ou en calquera momento despois da "
+#~ "instalación. Se ten acceso doado a Internet ou se emprega o DVD que "
+#~ "contén todos os idiomas, non precisará deste CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Despois de ter baixada a imaxe ISO, grávase a imaxe nun CD ou DVD co seu "
+#~ "aplicativo de gravación preferido. <em>NON</em> grave un CD/DVD de datos, "
+#~ "debe escoller gravar unha imaxe ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Un escritorio GNOME que pode executar a partir do CD ou desde unha "
+#~ "memoria USB. <br/>Pode ser instalada deste xeito (sen actualización)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Un escritorio KDE que pode executar a partir do CD ou desde unha memoria "
+#~ "USB. <br/>Pode ser instalada deste xeito (sen actualización)."
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Empregue na cadea de busca dous caracteres polo menos"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Conmutado para coincidencia exacta debido a moitas ocorrencias na busca "
+#~ "da subcadea"
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Sexa máis preciso na súa busca, chegou ao límite da busca."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Non se puido buscar:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Software popular"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Compre openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click Install"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Descarga non automática de paquetes"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Ir ao Proxecto OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Colección de software]"
+
+#~ msgid "Search Results"
+#~ msgstr "Resultados da busca"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Non se atopou ningún paquete en openSUSE build que corresponda coa súa "
+#~ "consulta."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d coleccións e %d executables de %d paquetes de código fonte"
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "Capturas do CVS de Wine"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Estatísticas da busca:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Estatísticas de descarga:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Buscar e instalar paquetes de software de <a href=\"http://build.opensuse."
+#~ "org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opcións de busca"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Incluír os proxectos persoais dos usuarios"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Excluír paquetes de depuración"
+
+#~ msgid "Additional Information"
+#~ msgstr "Información adicional"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Guía rápida de instalación</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Compre openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Compre openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Para obter máis información sobre a descarga, pódese consultar a páxina "
+#~ "<a href=\"http://en.opensuse.org/SDB:Download_help\">Instrucións para a "
+#~ "descarga.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Instrucións dispoñibles para:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Instalación desde CD/DVD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Guía de inicio oficial de %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Guía de instalación paso a paso"
+
+#~ msgid "Network Installation"
+#~ msgstr "Instalación desde a rede"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Instalación desde Internet"
+
+#~ msgid "More information"
+#~ msgstr "Máis información"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Descargar software"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "User Directory"
+#~ msgstr "Directorio de usuario"
+
+#~ msgid "Features"
+#~ msgstr "openFATE"
+
+#~ msgid "News"
+#~ msgstr "Noticias"
+
+#~ msgid "Forums"
+#~ msgstr "Foros"
+
+#~ msgid "Shop"
+#~ msgstr "Tenda"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Busca de software"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Repositorios de actualización"
+
+#~ msgid "Source Repository"
+#~ msgstr "Repositorio de código fonte"

--- a/locale/hu/software.po
+++ b/locale/hu/software.po
@@ -1,0 +1,1257 @@
+# translation of software-opensuse-org.hu.po to
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Kalman Kemenczy <kkemenczy@novell.com>, 2009, 2010.
+# Kalman Kemenczy <kkemenczy@opensuse.org>, 2011.
+# Kalman Kemenczy <kkemenczy@gmail.com>, 2011, 2012, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.hu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2013-02-24 12:10+0100\n"
+"Last-Translator: Kalman Kemenczy <kkemenczy@opensuse.org>\n"
+"Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.2\n"
+
+msgid " and "
+msgstr " és "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"a(z) #{release} nem támogatott kiadás.\""
+
+msgid "(hide)"
+msgstr "(elrejtés)"
+
+msgid "(show)"
+msgstr "(megjelenítés)"
+
+msgid "... and keep us informed"
+msgstr "... és maradjunk informáltak"
+
+msgid "... get other marketing stuff"
+msgstr "... további marketing anyagok igénylése"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "64 bites"
+
+#, fuzzy
+#| msgid ""
+#| "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#| "startup/\">openSUSE startup guide</a>"
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+"startup/\">openSUSE startup guide</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> egy nyílt "
+"szabvány, amely számos módot (FTP/HTTP/BitTorrent) ötvöz a könnyebb letöltés "
+"érdekében. Ezért rendkívül jó megoldás az ISO-fájlok letöltéséhez, főleg "
+"azoknak, akik nem tudnak P2P megoldásokat használni az internetszolgáltató "
+"vagy az egyetemi hálózatok megkötése miatt. Rendkívül gyors letöltést képes "
+"biztosítani egyszerre több mirrorról, mivel minden kliens több kapcsolatot "
+"támogat. Emellett automatikus hibakezelést és hibajavítást biztosít. Azonban "
+"speciális kliensprogram szükséges hozzá."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://hu.opensuse.org/Licenc\">Licencmegállapodás</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Kiadási megjegyzések</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>hivatalos kiadás</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>hivatalos frissítés</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"%s-ről vagy pendrive-ról futtatható GNOME grafikus környezet.<br/> "
+"Telepítésre is használható (frissítésre azonban nem)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"%s-ről vagy pendrive-ról futtatható KDE grafikus környezet.<br/>Telepítésre "
+"is használható (frissítésre azonban nem)."
+
+msgid "Add repository and install manually"
+msgstr "Telepítési forrás hozzáadása és telepítés kézzel"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Kiegészítők letöltése (nem kötelező)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "All data is used only for sending openSUSE promotional material"
+#| "\\n          and will not be spread to third parties. We store the data to"
+#| "\\n          inform the users if a new version is available. All requests "
+#| "have\\n          to be screened to fulfill the US export embargo. More "
+#| "information\\n          about the embargo and a list of countries at "
+#| "wikipedia <a href='http://en.wikipedia.org/wiki/"
+#| "United_States_embargoes'>http://en.wikipedia.org/wiki/"
+#| "United_States_embargoes</a>."
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Minden adatot kizárólag a openSUSE népszerűsítő anyagok\\n          kapcsán "
+"használunk fel és nem osztjuk meg másokkal.\\n          Azért tárolunk "
+"adatokat, hogy ismertessük a felhasználókkal, ha újabb verziók érhetők el."
+"\\n          Minden kérések meg kell felelnie az amerikai embargó "
+"szabályoknak.\\n          Ezzel kapcsolatos további információ a wikipedia "
+"<a href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://en."
+"wikipedia.org/wiki/United_States_embargoes</a> oldalán található."
+
+msgid "App Browser"
+msgstr "Alkalmazásböngésző"
+
+msgid "Available Images"
+msgstr "Elérhető lemezképek"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Indítás DVD-ről vagy CD-ről. Amennyiben a számítógép nem indul el "
+"automatikusan a CD-ről vagy a DVD-ről, akkor ezt engedélyezni kell a BIOS-"
+"ban."
+
+msgid "Bronze Sponsor"
+msgstr "Bronz fokozatú támogató"
+
+msgid "Browser incompatibility"
+msgstr "Böngésző inkompatibilitás"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "CD/DVD-lemezkép(ek) készítése"
+
+msgid "Categories"
+msgstr "Kategóriák"
+
+msgid "Category"
+msgstr "Kategória"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"A letöltés megkezdéséhez válassza ki a telepítőkészlet típusát és nyomja meg "
+"a Letöltés gombot. Tetszés szerint válassza ki a számítógép típusát, vagy "
+"egy alternatív letöltési módszert."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Letöltés"
+
+msgid "Community"
+msgstr "Közösség"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Hatalmas szoftvergyűjteményt tartalmaz asztali számítógépekhez és "
+"kiszolgálókhoz egyaránt.<br/>Alkalmas telepítéshez vagy frissítéshez."
+
+msgid "Countdown"
+msgstr "Visszaszámlálás"
+
+msgid "Country"
+msgstr "Ország"
+
+msgid "Development"
+msgstr "Fejlesztés"
+
+msgid "Development Version"
+msgstr "Fejlesztői verzió"
+
+msgid "Development packages"
+msgstr "Fejlesztői csomagok"
+
+msgid "Development-"
+msgstr "Fejlesztés-"
+
+msgid "Direct Install"
+msgstr "Közvetlen telepítés"
+
+msgid "Direct Link"
+msgstr "Közvetlen letöltés"
+
+msgid "Documentation"
+msgstr "Dokumentáció"
+
+msgid "Don't show this warning the next time"
+msgstr "Ne mutassa többször ezt a figyelmeztetést"
+
+msgid "Download"
+msgstr "Letöltés"
+
+msgid "Download %s"
+msgstr "%s letöltése"
+
+msgid "Download Help"
+msgstr "Segítség a letöltéshez"
+
+msgid "Download Method"
+msgstr "Letöltés módja"
+
+msgid "Download appliance from %s"
+msgstr "Készülék letöltése innen: %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "DVD&nbsp;letöltés"
+
+msgid "Download&nbsp;GNOME"
+msgstr "GNOME&nbsp;letöltés"
+
+msgid "Download&nbsp;KDE"
+msgstr "KDE&nbsp;letöltés"
+
+msgid "Download&nbsp;Network"
+msgstr "Hálózati&nbsp;letöltés"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "KDE&nbsp;letöltés"
+
+msgid "Downloads"
+msgstr "Letöltések"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"A telepítő és az összes csomag letöltése az online telepítési forrásokból."
+"<br/>Alkalmas telepítésre vagy frissítésre."
+
+msgid "Expand all sections ('e')"
+msgstr "Összes rész kinyitása ('e')"
+
+msgid "Extra Languages"
+msgstr "További nyelvek"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "További nyelvek (32 bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "További nyelvek (64 bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Ehhez: <strong>%s</strong> futtassa a következőt <strong>root</strong>-ként:"
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+"Ehhez: <strong>%s</strong> futtassa a következőt <strong>root</strong>-ként:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"a legnagyobb biztonságot nyújtja, mivel ellenőrizhető az aláíró személye, "
+"ennek a következőnek kell lennie: <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Játékok"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Töltse le az egyik speciális, openSUSE alapú disztribúciót."
+
+msgid "Getting Help"
+msgstr "Segítség"
+
+msgid "Gold Sponsor"
+msgstr "Arany fokozatú támogató"
+
+msgid "Grab binary packages directly"
+msgstr "Bináris csomagok közvetlen letöltése"
+
+msgid "Header Logo"
+msgstr "Fejléc logó"
+
+msgid "Help on Download Method"
+msgstr "Segítség a letöltési mód kiválasztásában"
+
+msgid "Help on Type of Computer"
+msgstr "Segítség az architektúra kiválasztásában"
+
+msgid "How to Proceed"
+msgstr "Telepítés előkészítése"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Ha közvetlen hivatkozás használatával szeretne letölteni, de olyan helyen "
+"van, hogy a letöltés-átirányítók nem kapnak elegendő információt a "
+"leggyorsabb mirrorra való átirányításhoz, akkor kiválaszthat egy mirrort."
+
+msgid "Image:"
+msgstr "Lemezkép:"
+
+msgid "Install package %s / %s"
+msgstr "Csomag telepítése %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Minta telepítése %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Telepítés 1-kattintásos telepítéssel"
+
+msgid "Installation Guides"
+msgstr "Telepítési útmutató"
+
+msgid "Installation Medium"
+msgstr "Telepítőkészlet"
+
+#, fuzzy
+#| msgid ""
+#| "Join the fast-growing community, put openSUSE into more hands by"
+#| "\\n        ordering the latest PromoDVD for your group, non-profit "
+#| "organization, school\\n        university or event like LUG meetings, "
+#| "installfests, and conferences.\\n        Promo DVDs help to increase "
+#| "awareness and visibility of openSUSE!"
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Csatlakozzon a gyorsan növekvő közösséghez, juttassa el a legújabb\\n        "
+"openSUSE PromoDVD-t non profit szervezetekhez, iskolákhoz\\n        "
+"egyetemekhez, Linux felhasználói csoportoknak és konferenciákra.\\n        A "
+"Promo DVD-k terjesztésével növelhető az openSUSE ismertsége!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"A KDE3 Konqueror sajnos már nincs karbantartva és a javascript kódrészben "
+"hibák vannak, amelyek nem teszik lehetővé az oldal használatát. "
+"Bizonyosodjon meg arról, hogy a javascript le van tiltva mielőtt <a "
+"href='%s'>tovább lép</a>."
+
+msgid "Language"
+msgstr "Nyelv"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "32 bit"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32 bites"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Számos alkalmazás képes ellenőrizni a letöltést az ellenőrzőösszeg "
+"segítségével. A letöltött telepítőkészlet ellenőrzése azért fontos, hogy "
+"megbizonyosodjon arról, hogy nem egy hibás ISO-lemezképet töltött le. Három "
+"különböző ellenőrzőösszeg áll rendelkezésre:"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "További információ az ISO fájl CD-re/DVD-re történő írásáról"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"További információ az <a href='http://en.opensuse.org/"
+"Live_USB_stick'>indítható pendrive készítéséről</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Az openSUSE letöltésével kapcsolatos további információ a <a href=\"http://"
+"en.opensuse.org/SDB:Download_help\">Letöltési segédlet</a> és a <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Hálózati telepítés</a> "
+"oldalon található a <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Dokumentációs wikiben</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"A legtöbb új számítógép támogatja az <a href=\"http://hu.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> architektúrát (amelyet AMD64 és Intel64 néven is "
+"ismernek), de néhány laptop és netbookprocesszor nem támogatja ezt. Ha meg "
+"akar bizonyosodni arról, hogy számítógépe támogatja-e a 64 bites "
+"architektúrát, ellenőrizze ezt a Wikipedián."
+
+msgid "Multimedia"
+msgstr "Multimédia"
+
+msgid "Need help?"
+msgstr "Segítségre van szüksége?"
+
+msgid "Network"
+msgstr "Hálózat"
+
+msgid "No appliance data for %s"
+msgstr "Nincs készülékadat ehhez: %s %s"
+
+msgid "No appliances found in project %s"
+msgstr "Nem található készülék a(z) %s projektben"
+
+msgid "No data for %s / %s"
+msgstr "Nincs adat ehhez: %s %s"
+
+msgid "No description found..."
+msgstr "Nem található leírás…"
+
+msgid "No downloads found for %s in project %s"
+msgstr "Nem található letöltés ehhez: %s a(z) %s projektben"
+
+msgid "No packages found matching your search. "
+msgstr "Nem található olyan csomag, amely megfelel a keresési feltételeknek."
+
+msgid "NonOSS CD"
+msgstr "Nem nyílt forrású komponenseket tartalmazó CD"
+
+msgid "OBS Backend not available"
+msgstr "az OSB nem érhető el"
+
+msgid "Official Manuals"
+msgstr "Hivatalos kézikönyvek"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr "'%s' nem található…"
+
+msgid "Package Repositories"
+msgstr "Telepítési források"
+
+msgid "Package Search"
+msgstr "Csomagkeresés"
+
+msgid "Packages for %s:"
+msgstr "Csomagok ehhez: %s"
+
+msgid "Pick Mirror"
+msgstr "Mirror kiválasztása"
+
+msgid "Platinum Sponsor"
+msgstr "Platina fokozatú támogató"
+
+#, fuzzy
+#| msgid ""
+#| "Please be aware that the following packages are from unofficial "
+#| "repositories.\\n  That means they are not reviewed by openSUSE and may "
+#| "contain unstable or experimental software."
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Vegye figyelembe, hogy a következő csomagok nem hivatalos telepítési "
+"forrásból valók.\n"
+"    Ez azt jelenti, hogy ezeket az openSUSE nem vizsgálta meg, így "
+"tartalmazhat nem stabil vagy kísérleti szoftvereket."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Foglalja össze <b>röviden</b> (angolul!), hogy miért van szüksége DVD-re és "
+"adja meg az esemény hivatkozását."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Ez nem a legfrissebb openSUSE kiadás. A legfrissebb verzió <a "
+"href='/'>innen</a> tölthető le. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+msgid "Related categories:"
+msgstr "Vonatkozó kategóriák:"
+
+msgid "Released Version"
+msgstr "Megjelent verzió"
+
+msgid "Reporting Bugs"
+msgstr "Hibabejelentés"
+
+msgid "Rescue"
+msgstr "Mentőrendszer"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Mentőrendszer, amely CD-ről vagy pendrive-ról futtatható.<br/>Nem "
+"használható telepítésre vagy rendszerfrissítésre."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "md5-ellenőrzőösszeg:"
+
+msgid "Search"
+msgstr "Keresés"
+
+msgid "Select Your Operating System"
+msgstr "Operációs rendszer kiválasztása"
+
+msgid "Select the image type"
+msgstr "Válassza ki a lemezkép típusát."
+
+msgid "Show"
+msgstr "Megjelenítés"
+
+msgid "Show development, language and debug packages"
+msgstr "Fejlesztői, nyelvi és debug csomagok megjelenítése"
+
+msgid "Show distribution:"
+msgstr "Disztribúció megjelenítése:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Több csomag megjelenítése a nem támogatott disztribúciókhoz "
+
+msgid "Show more..."
+msgstr "Több..."
+
+msgid "Show other versions"
+msgstr "Más verziók megjelenítése"
+
+msgid "Show unstable packages"
+msgstr "Nem stabil csomagok megjelenítése"
+
+msgid "Show unsupported packages"
+msgstr "nem támogatott csomagok megjelenítése"
+
+msgid "Silver Sponsor"
+msgstr "Ezüst fokozatú támogató"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Néhány live disztribúció openSUSE-alapú. Akik szeretnék kipróbálni a saját "
+"disztribúciókészítést, azok látogassanak el a <a href=\"http://susestudio."
+"com/\">SUSE Studio</a> weboldalára."
+
+msgid "Source"
+msgstr "Forrás"
+
+msgid "Sponsored by"
+msgstr "Támogatók"
+
+msgid "Sponsored by: AMD"
+msgstr "Az AMD támogatásával"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Támogató: B1 System"
+
+msgid "Sponsored by: Heinlein"
+msgstr "A Heinlein támogatásával"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Az IP Exchange támogatásával"
+
+msgid "Sub-Packages"
+msgstr "Részcsomagok"
+
+msgid "Support"
+msgstr "Támogatás"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+"Ehhez: <strong>%s</strong> futtassa a következőt <strong>root</strong>-ként:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Ez a CD azokat az ingyenesen terjeszthető szoftvereket tartalmazza, amelyek "
+"olyan licencekkel van ellátva, amelyek nem teszik lehetővé, hogy az ingyenes "
+"nyílt forrású szoftverkomponensekkel közös telepítőkészleten szerepeljenek. "
+"Az összes, ezen a CD-n található szoftver letölthető a NON-OSS telepítési "
+"forrásból."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Ez a változat minden számítógépen fut, beleértve a 64 bites számítógépeket "
+"is. Amennyiben több, mint 3GB memória van a számítógépében, akkor a 64 bites "
+"változat használata javasolt, azonban ez nem támogatja a Pentiumnál korábbi "
+"processzorokat - a live CD pedig csak az i686 (legalább Pentium Pro) "
+"architektúrát támogat."
+
+msgid "Type of Computer"
+msgstr "Architektúra"
+
+msgid "Unsupported distributions:"
+msgstr "Nem támogatott disztribúció:"
+
+#, fuzzy
+#| msgid ""
+#| "User manuals are available from <a href=\"http://doc.opensuse.org\">doc."
+#| "opensuse.org</a>, for example the <a href=\"http://doc.opensuse.org/"
+#| "products/opensuse/openSUSE/opensuse-startup/\">Official Start-Up Guide</"
+#| "a>."
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"A felhasználói kézikönyvek a <a href=\"doc.opensuse.org\">doc.opensuse.org</"
+"a> weboldalon érhetők el, például a <a href=\"http://doc.opensuse.org/"
+"products/opensuse/openSUSE/opensuse-startup/\">hivatalos Start-Up Guide</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"A <a href=\"http://en.opensuse.org/SDB:BitTorren\">BitTorrent</a> használata "
+"az alacsony sávszélességű hálózati kapcsolatok használata esetén javasolt, "
+"különösen DVD-lemezképek letöltésekor. A BitTorrent letöltésnek számos "
+"előnye van, a kliens védve van az adathibák ellen és segít a kiszolgálok "
+"terhelésének enyhítésében a feltöltések elosztásával - megfelelő számú "
+"közreműködő esetén még gyorsabb is, mint egy központi kiszolgáló. Mindezek "
+"mellett a letöltések bármikor leállíthatók, és folytathatók."
+
+msgid "Verify your download before use"
+msgstr "Letöltés ellenőrzése használat előtt"
+
+msgid "Version"
+msgstr "Verzió"
+
+msgid "We offer three different checksums:"
+msgstr "Három különböző ellenőrzőösszeg áll rendelkezésre:"
+
+#, fuzzy
+#| msgid ""
+#| "We would like you, to keep us informed about your usage of the DVDs, so we"
+#| "\\n        can help you to promote your organization, event or school on "
+#| "our\\n        <a href='http://news.opensuse.org' title='news.opensuse."
+#| "org'>news page</a>\\n        or other resources. (Hint! We love photos. "
+#| "Take lots of them!). Please contact us at\\n        <a href='mailto:"
+#| "opensuse-marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>"
+#| "\\n        to discuss promotion and/or other ways we can assist you."
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Szeretnék visszajelzéseket kapni a DVD-k felhasználásáról,\\n        így "
+"népszerűsíteni tudjuk az adott szervezetet, eseményt vagy iskolát a"
+"\\n        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>hírek oldalunkon</a>. \\n        (Szeretjük a fényképeket, ezért "
+"érdemes minél többet készíteni!) \\n        Vegye fel velünk a kapcsolatot "
+"az <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a> \\n        címen keresztül, hogy megbeszélhessük, "
+"hogyan segíthetünk."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Amennyiben nem a hálózati telepítéshez szükséges CD lemezképét tölti le, "
+"akkor <i>kifejezetten</i> javasolt valamilyen letöltéskezelő használata, "
+"azért, hogy csökkenjen a hibás lemezkép kockázata."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"A keresés kiterjeszthető a fejlesztői csomagokra vagy átváltható másik "
+"disztribúcióra."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Ellenőrizni tudja a fájlt a letöltés közben, Például az ellenőrzőösszeget "
+"(SHA256)  <a href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> "
+"automatikusan használja, és használja a <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a> használatakor DownThemAll! kiegészítőt."
+
+msgid "gpg signature"
+msgstr "gpg-aláírás:"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.2/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.2/"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.3"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.3"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"a legelterjedtebb ellenőrzőösszeg, amelyet a legtöbb CD/DVD-író program "
+"megjelenít az írás megkezdése előtt."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "a legkevésbé elterjedt, de biztonságosabb az md5-ellenőrzőösszegnél."
+
+msgid "md5 checksum"
+msgstr "md5-ellenőrzőösszeg:"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"a legnagyobb biztonságot nyújtja, mivel ellenőrizhető az aláíró személye, "
+"ennek a következőnek kell lennie: <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE visszaszámlálás"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE változatok"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"Az openSUSE elérhető http (közvetlen hivatkozás) vagy BitTorrent protokollon "
+"keresztül. A hálózati telepítéshez használható CD csak http-n keresztül "
+"érhető el."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "Az openSUSE csak 32 és 64 bites architektúrát támogat."
+
+msgid "see Derivatives on wiki"
+msgstr "openSUSE változatok a wikiben"
+
+msgid "sha1 checksum"
+msgstr "sha1-ellenőrzőösszeg:"
+
+msgid "switch to"
+msgstr "váltás erre:"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Belső rendszerhiba történt :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Legalább 2 karaktert kell megadni"
+
+#, fuzzy
+#~| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Legutóbbi keresések:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statisztika"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Leggyakoribb letöltések:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Leggyakoribb, találat nélküli keresések:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Leggyakoribb keresések:"
+
+#, fuzzy
+#~| msgid "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Jelenleg nem érhető el olyan Factory Snapshot, amely frissebb, mint a "
+#~ "legutóbbi openSUSE kiadás. <br/>További információ a <a href='http://en."
+#~ "opensuse.org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> "
+#~ "weboldalon található."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr ""
+#~ "A telepítési forrás kulcsát a következőképpen lehet az apt-hez adni:"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "A Live CD-k csak négy (angol, német, orosz és olasz) nyelvet "
+#~ "tartalmaznak. Ha más nyelv támogatására van szüksége, akkor azokat a "
+#~ "telepítés során, vagy később bármikor letöltheti az interneten keresztül. "
+#~ "Amennyiben könnyen hozzáfér az internethez, vagy rendelkezik, az összes "
+#~ "nyelvet tartalmazó DVD-vel, akkor nincs szüksége erre a CD-re."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Az ISO-lemezkép(ek) letöltését követően ki kell írni őket a megfelelő "
+#~ "médiára. <em>Nem</em> adat DVD/CD-ként kell ezeket kiírni, hanem ISO-"
+#~ "lemezképként."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "CD-ről vagy pendrive-ról futtatható GNOME grafikus környezet.<br/> "
+#~ "Telepítésre is használható (frissítésre azonban nem)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "CD-ről vagy pendrive-ról futtatható KDE grafikus környezet.<br/"
+#~ ">Telepítésre is használható (frissítésre azonban nem)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "A keresés kiterjeszthető a nem támogatott csomagokra vagy átváltható "
+#~ "másik disztribúcióra."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.hu.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.hu.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "A keresésnek legalább 2 karakterből kell állnia"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Áttérés teljes egyezésre, mivel a részleges keresés túl sok találatot "
+#~ "eredményez."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Adjon meg pontosabb keresési feltételt, a találatok száma elérte a "
+#~ "határértéket."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "A keresés nem hajtható végre: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Népszerű szoftver"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "openSUSE-vásárlás"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Kattintásos telepítés"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Kézi csomagletöltés"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "OBS projekt"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Szoftvergyűjtemény]"
+
+#~ msgid "Search Results"
+#~ msgstr "Keresési eredmények"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Nem találhatók olyan csomagok az openSUSE Build Service-ben, amelyek "
+#~ "illeszkednének a keresésre."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d gyűjtemény és %d bináris a %d forráscsomagból"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Képernyőkép erről: "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Keresési statisztikák:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Letöltési statisztikák:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Csomagok keresése és telepítése az <a href=\"http://build.opensuse.org"
+#~ "\">openSUSE Build Service</a>-ből:"
+
+#~ msgid "Search options"
+#~ msgstr "Keresési beállítások"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Felhasználók projektjeivel"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Debug csomagok kivétele"
+
+#~ msgid "Additional Information"
+#~ msgstr "További információ"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Telepítési gyorskalauz</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "openSUSE 11.3 vásárlása"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Vásároljon openSUSE 11.3-at!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Letöltéssel kapcsolatos probléma esetén látogasson el a <a href=\"http://"
+#~ "hu.opensuse.org/Let%C3%B6lt%C3%A9si_seg%C3%ADts%C3%A9g\">Letöltési "
+#~ "segítség</a> oldalra."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Az alábbi leírások érhetők el:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Telepítés DVD/CD-ről:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Hivatalos %s Start-Up kézikönyv"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Részletes telepítési segédlet"
+
+#~ msgid "Network Installation"
+#~ msgstr "Telepítés hálózatról"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Telepítés internetről"
+
+#~ msgid "More information"
+#~ msgstr "További információ"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://hu.opensuse.org/Telep%C3%ADt%C3%A9si_seg%C3%ADts%C3%A9g"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://hu.opensuse.org/Telep%C3%ADt%C3%A9si_seg%C3%ADts%C3%A9g"
+
+#~ msgid "Get Software"
+#~ msgstr "Letöltés"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Szoftverkészítés"
+
+#~ msgid "User Directory"
+#~ msgstr "Felhasználók"
+
+#~ msgid "Features"
+#~ msgstr "Funkciók"
+
+#~ msgid "News"
+#~ msgstr "Hírek"
+
+#~ msgid "Forums"
+#~ msgstr "Fórumok"
+
+#~ msgid "Shop"
+#~ msgstr "Vásárlás"
+
+#~ msgid "Software"
+#~ msgstr "Programok"
+
+#~ msgid "Software Search"
+#~ msgstr "Keresés"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Frissítési források"
+
+#~ msgid "Source Repository"
+#~ msgstr "Forráskód"
+
+#~ msgid "Other Options"
+#~ msgstr "Egyéb"
+
+#~ msgid "Mirrors"
+#~ msgstr "Mirror"
+
+#~ msgid "In other languages"
+#~ msgstr "Más nyelven"
+
+#~ msgid "Get it"
+#~ msgstr "Letöltés"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Keresés a Build Service-ben"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "További csomagok keresése és telepítése az openSUSE Build Service-ből."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "openSUSE letöltése"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Közvetlen hivatkozás ehhez a találathoz"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nincs találat"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Letöltés az openSUSE Build Service-ből"
+
+#~ msgid "Searching"
+#~ msgstr "Keresés"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Hatalmas szoftvergyűjteményt tartalmaz asztali számítógépekhez és "
+#~ "kiszolgálókhoz egyaránt. Alkalmas telepítéshez vagy frissítéshez."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "CD-ről vagy pendrive-ról futtatható GNOME grafikus környezet. Telepítésre "
+#~ "is használható (frissítésre azonban nem)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "CD-ről vagy pendrive-ról futtatható KDE grafikus környezet. Telepítésre "
+#~ "is használható (frissítésre azonban nem)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "A telepítő és az összes csomag letöltése az online telepítési "
+#~ "forrásokból.  Alkalmas telepítésre vagy frissítésre."

--- a/locale/it/software.po
+++ b/locale/it/software.po
@@ -1,0 +1,1277 @@
+# Andrea Turrini <andrea.turrini@gmail.com>, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2014-11-03 23:47+0800\n"
+"Last-Translator: Andrea Turrini <andrea.turrini@gmail.com>\n"
+"Language-Team: Italian <opensuse-translation@opensuse.org>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid " and "
+msgstr " e "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} non è un rilascio supportato.\""
+
+msgid "(hide)"
+msgstr "(nascondi)"
+
+msgid "(show)"
+msgstr "(mostra)"
+
+msgid "... and keep us informed"
+msgstr "... e tienici informati"
+
+msgid "... get other marketing stuff"
+msgstr "... ottieni altro materiale informativo"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD 4.7GB (adatto anche per le chiavette USB)"
+
+msgid "64 Bit PC"
+msgstr "PC 64 bit"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Manuale "
+"iniziale di openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://it.opensuse.org/SDB:Metalink\">Metalink</a> è uno standard "
+"aperto che mette insieme molti modi (FTP/HTTP/BitTorrent) per ottenere file "
+"in un formato che semplifica lo scaricamento. Questo lo rende utile per "
+"scaricare le ISO, in particolare per le persone che non possono usare il P2P "
+"a causa delle restrizioni dei propri ISP o università. Metalink può ottenere "
+"elevate velocità di scaricamento in quanto molti client supportano "
+"automaticamente connessioni multiple a mirror multipli. Inoltre, può "
+"eseguire controlli automatici per gli errori, e correzioni. Metalink "
+"richiede un client speciale per essere usato."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licenza</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Note di rilascio</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>rilascio ufficiale</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>aggiornamento ufficiale</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un desktop GNOME che puoi avviare da %s o da chiavetta USB.<br/>Può essere "
+"installato così com'è (no aggiornamento)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un desktop KDE che puoi avviare da %s o da chiavetta USB.<br/>Può essere "
+"installato così com'è (no aggiornamento)."
+
+msgid "Add repository and install manually"
+msgstr "Aggiungi il repository e installa manualmente"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Scaricamento componenti aggiuntivi (facoltativo)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Dopo aver scaricato con successo l'immagine ISO, creare una chiavetta USB "
+"avviabile o masterizzare l'immagine su un DVD (o un CD se l'immagine scelta "
+"ci sta)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Tutti i dati sono usati solamente per inviare materiale promozionale di "
+"openSUSE\n"
+"e non verranno forniti a terze parti. Memorizziamo i dati per informare\n"
+"gli utenti se è disponibile una nuova versione. Tutte le richieste devono "
+"essere\n"
+"vagliate per soddisfare l'embargo sulle esportazioni degli USA. Maggiori "
+"informazioni\n"
+"sull'embargo e un elenco di paesi è disponibile su wikipedia\n"
+"<a href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://en."
+"wikipedia.org/wiki/United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Browser delle app"
+
+msgid "Available Images"
+msgstr "Immagini disponibili"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Avvia da DVD, CD o chiavetta USB. Nel caso il tuo computer non si avviasse "
+"automaticamente dal dispositivo scelto, entra nelle impostazioni del BIOS "
+"per permetterne l'avvio."
+
+msgid "Bronze Sponsor"
+msgstr "Sponsor Bronzo"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilità dei browser"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Masterizza immagine(i) di CD/DVD"
+
+msgid "Categories"
+msgstr "Categorie"
+
+msgid "Category"
+msgstr "Categoria"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Seleziona un supporto di installazione cliccando su di esso e premendo il "
+"pulsante Scarica per avviare lo scaricamento. Se vuoi, scegli il tipo di "
+"computer o un metodo di scaricamento alternativo."
+
+msgid "Click here to display these alternative versions."
+msgstr "Clicca qui per mostrare tali versioni alternative."
+
+msgid "Click to Download"
+msgstr "Fai clic per scaricare"
+
+msgid "Community"
+msgstr "Comunità"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Contiene un'ampia collezione di programmi per uso desktop o server.<br/"
+">Appropriato per installazione e aggiornamento."
+
+msgid "Countdown"
+msgstr "Conto alla rovescia"
+
+msgid "Country"
+msgstr "Nazione"
+
+msgid "Development"
+msgstr "Sviluppo"
+
+msgid "Development Version"
+msgstr "Versione di sviluppo"
+
+msgid "Development packages"
+msgstr "Pacchetti di sviluppo"
+
+msgid "Development-"
+msgstr "Sviluppo-"
+
+# TLABEL modules/inst_target_part.ycp:680
+msgid "Direct Install"
+msgstr "Installa direttamente"
+
+msgid "Direct Link"
+msgstr "Collegamento diretto"
+
+msgid "Documentation"
+msgstr "Documentazione"
+
+msgid "Don't show this warning the next time"
+msgstr "Non mostrare questo messaggio la prossima volta"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Download %s"
+msgstr "Scarica %s"
+
+msgid "Download Help"
+msgstr "Aiuto per lo scaricamento"
+
+msgid "Download Method"
+msgstr "Metodo di scaricamento"
+
+msgid "Download appliance from %s"
+msgstr "Scarica appliance da %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Scarica&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Scarica&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Scarica&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Scarica&nbsp;Rete"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Scarica&nbsp;Ripristino"
+
+msgid "Downloads"
+msgstr "Download"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Scarica il sistema di installazione e tutti i pacchetti dai repository in "
+"internet.<br/>Appropriato per installazione e aggiornamento."
+
+msgid "Expand all sections ('e')"
+msgstr "Espandi tutte le sezioni ('e')"
+
+msgid "Extra Languages"
+msgstr "Ulteriori lingue"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Ulteriori lingue (32 bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Ulteriori lingue (64 bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Per <strong>%s</strong> eseguire quanto segue come <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Per <strong>%s</strong> eseguire quanto segue:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Per <strong>Arch Linux</strong>, modificare /etc/pacman.conf e aggiungere "
+"quanto segue (si noti che l'ordine dei repository in pacman.conf è "
+"fondamentale, dato che pacman scarica sempre il primo pacchetto trovato):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"offre maggiore sicurezza in quanto puoi verificare chi lo ha firmato. "
+"Dovrebbe essere <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Giochi"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Ottieni una delle distribuzioni derivate costruita a partire da openSUSE."
+
+msgid "Getting Help"
+msgstr "Ottieni aiuto"
+
+msgid "Gold Sponsor"
+msgstr "Sponsor Oro"
+
+msgid "Grab binary packages directly"
+msgstr "Prendi direttamente i pacchetti binari"
+
+msgid "Header Logo"
+msgstr "Logo intestazione"
+
+msgid "Help on Download Method"
+msgstr "Aiuto sul Metodo di scaricamento"
+
+msgid "Help on Type of Computer"
+msgstr "Aiuto sul Tipo di computer"
+
+msgid "How to Proceed"
+msgstr "Come procedere"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Se vuoi usare un collegamento diretto ma vivi in un posto nel mondo dove il "
+"nostro sistema di gestione degli scaricamenti non ha abbastanza informazioni "
+"per reindirizzarti sul mirror più veloce, puoi scegliere tu stesso un mirror."
+
+msgid "Image:"
+msgstr "Immagine:"
+
+msgid "Install package %s / %s"
+msgstr "Installa pacchetto %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Installa modello %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Installa con One Click Install"
+
+msgid "Installation Guides"
+msgstr "Guide di installazione"
+
+msgid "Installation Medium"
+msgstr "Supporto di installazione"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Unisciti alla comunità in rapida espansione, fai conoscere openSUSE "
+"ottenendo\n"
+"l'ultimo DVD promozionale per il tuo gruppo, organizzazione senza scopo di "
+"lucro, scuola,\n"
+"università o evento come incontri LUG, party di installazione e conferenze.\n"
+"I DVD promozionali aiutano ad ampliare la visibilità e la consapevolezza di "
+"openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Sfortunatamente Konqueror in KDE3 non è più mantenuto e la sua "
+"implementazione di javascript contiene dei bug che ne rendono impossibile "
+"l'uso con questa pagina. Assicurati di avere javascript disabilitato prima "
+"di <a href='%s'>continuare</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Lingua"
+
+msgid "Legacy 32 Bit PC"
+msgstr "PC 32 bit obsoleto"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "PC&nbsp;32&nbsp;bit obsoleto"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Molte applicazioni possono verificare il codice di controllo di un file "
+"scaricato. Verificare il file scaricato può essere importante in quanto "
+"controlli che il file ISO scaricato sia effettivamente quello che volevi "
+"scaricare e non qualche versione corrotta."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Maggiori informazioni sulla masterizzazione di un file ISO su CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Maggiori informazioni sulla creazione di una <a href='http://it.opensuse.org/"
+"SDB:Chiavetta_USB_Live'>chiavetta USB avviabile</a>."
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Ulteriori informazioni sullo scaricamento di openSUSE sono disponibili nelle "
+"pagine <a href=\"http://it.opensuse.org/SDB:Aiuto_per_lo_scaricamento"
+"\">Aiuto per lo scaricamento</a> e <a href=\"http://it.opensuse.org/SDB:"
+"Network_installation\">Installazione via rete</a> del <a href=\"http://it."
+"opensuse.org/Portal:Documentation\">Wiki della documentazione</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Molti computer recenti supportano <a href=\"http://it.wikipedia.org/wiki/"
+"AMD64\">x86-64</a> (conosciuto anche come AMD64 e Intel64), ma alcuni "
+"processori dei portatili e dei netbook non lo supportano. Quindi devi "
+"controllare su wikipedia se vuoi essere sicuro che il tuo computer lo "
+"supporti."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Serve aiuto?"
+
+msgid "Network"
+msgstr "Rete"
+
+msgid "No appliance data for %s"
+msgstr "Nessun dato di appliance per %s"
+
+msgid "No appliances found in project %s"
+msgstr "Non è stata trovata alcuna appliance nel progetto %s"
+
+msgid "No data for %s / %s"
+msgstr "Nessun dato per %s / %s"
+
+msgid "No description found..."
+msgstr "Nessuna descrizione trovata..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Non è stato trovato alcun scaricamento per %s nel progetto %s"
+
+msgid "No packages found matching your search. "
+msgstr "Nessun pacchetto corrispondente alla ricerca."
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+msgid "OBS Backend not available"
+msgstr "Back end di OBS non disponibile"
+
+msgid "Official Manuals"
+msgstr "Manuali ufficiali"
+
+#, fuzzy
+#| msgid ""
+#| "Only DVD and Network medias are fully tested. Alternatives, like live or "
+#| "rescue systems, are recomended for only limited use."
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Sono stati testati a fondo solo i DVD e via rete. Le versioni alternative, "
+"come i sistemi live e di ripristino, sono raccomandate solo per un uso "
+"limitato."
+
+msgid "Package %s not found..."
+msgstr "Pacchetto %s non trovato..."
+
+msgid "Package Repositories"
+msgstr "Repository dei pacchetti"
+
+msgid "Package Search"
+msgstr "Cerca pacchetto"
+
+# TLABEL modules/inst_config_x11.ycp:578
+msgid "Packages for %s:"
+msgstr "Pacchetti per %s:"
+
+msgid "Pick Mirror"
+msgstr "Scegli mirror"
+
+msgid "Platinum Sponsor"
+msgstr "Sponsor Platino"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Ricorda che i seguenti pacchetti provengono da repository non ufficiali.\n"
+"Questo significa che non sono verificati da openSUSE e possono contenere "
+"programmi non stabili o sperimentali."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Inserisci una <b>breve</b> motivazione (in inglese!) del perché richiedi i "
+"DVD e fornisci un collegamento all'evento o scopo."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Considera che questa non è l'ultima versione di openSUSE. Puoi trovarla <a "
+"href='/'>qui</a>."
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"I DVD promozionali e i relativi lavori artistici (etichette e custodie)\n"
+"possono essere scaricati dalla <a href=\"http://download.opensuse.org/"
+"promodvd/\">directory %s\n"
+"di scaricamento dei dvd promozionali</a>. Si consideri che questa è una "
+"versione speciale\n"
+"di openSUSE progettata espressamente per la distribuzione promozionale."
+
+msgid "Related categories:"
+msgstr "Categorie relative:"
+
+msgid "Released Version"
+msgstr "Versione rilasciata"
+
+msgid "Reporting Bugs"
+msgstr "Segnalare bug"
+
+msgid "Rescue"
+msgstr "Ripristino"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Un sistema di ripristino che puoi avviare da CD o da chiavetta USB.<br/>Non "
+"può essere usato né per l'installazione, né per l'aggiornamento."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "codice di controllo md5"
+
+# "c" as a keyboard accel is already taken.
+msgid "Search"
+msgstr "Cerca"
+
+msgid "Select Your Operating System"
+msgstr "Seleziona il sistema operativo"
+
+msgid "Select the image type"
+msgstr "Selezionare il tipo di immagine"
+
+msgid "Show"
+msgstr "Mostra"
+
+msgid "Show development, language and debug packages"
+msgstr "Mostra pacchetti di sviluppo, lingua e debug"
+
+msgid "Show distribution:"
+msgstr "Mostra distribuzione:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Mostra altri pacchetti per distribuzioni non supportate"
+
+msgid "Show more..."
+msgstr "Mostra altri..."
+
+msgid "Show other versions"
+msgstr "Mostra altre versioni"
+
+msgid "Show unstable packages"
+msgstr "Mostra pacchetti non stabili"
+
+msgid "Show unsupported packages"
+msgstr "Mostra pacchetti non supportati"
+
+msgid "Silver Sponsor"
+msgstr "Sponsor Argento"
+
+#, fuzzy
+#| msgid ""
+#| "Some alternative media (eg. live and rescue systems) are also available, "
+#| "although they are less tested and recommended for only limited use."
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Sono anche disponibili alcuni supporti alternativi (come i sistemi live e di "
+"ripristino), per quanto siano meno testati e raccomandati solamente per un "
+"uso limitato."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Alcune delle distribuzioni live basate su openSUSE. Si consiglia a coloro "
+"che sono interessati a provare a costruire la propria distribuzione derivata "
+"di visitare <a href=\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Sorgente"
+
+msgid "Sponsored by"
+msgstr "Sponsorizzato da"
+
+msgid "Sponsored by: AMD"
+msgstr "Sponsorizzato da: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponsorizzato da: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponsorizzato da: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponsorizzato da: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Sottopacchetti"
+
+msgid "Support"
+msgstr "Supporto"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Il processo di installazione è disponibile in molte lingue ma, per la "
+"maggior parte di esse, la traduzione delle applicazioni non è inclusa "
+"nell'immagine. Se si vuole che il proprio sistema openSUSE supporti alcune "
+"lingue aggiuntive, bisogna scaricarle da internet durante l'installazione o "
+"in qualunque momento in seguito. Se si dispone di un accesso facile a "
+"internet, non si ha bisogno di questo CD, ma se si prevede di installare "
+"openSUSE su una macchina senza connessione ad internet, questo CD fornirà "
+"tutte le traduzioni disponibili."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Quindi eseguire quanto segue come <strong>root</strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Attualmente non c'è un rilascio di openSUSE in fase di test.<br/>Se vuoi "
+"usare i programmi più recenti possibile, usa <a href='http://it.opensuse.org/"
+"Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Questo CD contiene programmi gratuiti distribuiti secondo una licenza "
+"proprietaria che non permette la loro inclusione nel supporto "
+"d'installazione principale insieme a programmi gratuiti open-source. Tutti i "
+"programmi contenuti in questo CD possono essere scaricati dal repository NON-"
+"OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Questa versione funziona su tutti i PC inclusi quelli che supportano i 64 "
+"bit. Se hai più di 3 GB di RAM dovresti preferire la versione a 64 bit. "
+"openSUSE non supporta processori precedenti al Pentium. I CD live supportano "
+"solamente i686 (Pentium Pro e successivi)."
+
+msgid "Type of Computer"
+msgstr "Tipo di computer"
+
+msgid "Unsupported distributions:"
+msgstr "Distribuzioni non supportate:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"I manuali utente sono disponibili in <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, ad esempio il <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Manuale iniziale ufficiale</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"L'uso di <a href=\"http://it.opensuse.org/BitTorrent\">BitTorrent</a> è "
+"raccomandato per le linee lente, specialmente se scarichi un'immagine DVD. "
+"Scaricare usando BitTorrent presenta molti vantaggi: i client ti proteggono "
+"dalla corruzione dei dati e puoi aiutare a ridurre il carico sui server "
+"partecipando al caricamento: se abbastanza persone partecipano questo lo "
+"rende anche più veloce dei server centralizzati, per tutti. Inoltre, ti "
+"permette di interrompere lo scaricamento in ogni momento e di ripristinarlo "
+"successivamente."
+
+msgid "Verify your download before use"
+msgstr "Verifica il file scaricato prima di usarlo"
+
+msgid "Version"
+msgstr "Versione"
+
+msgid "We offer three different checksums:"
+msgstr "Offriamo tre codici di controllo diversi:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Vorremmo che ci mantenessi informati circa l'uso dei DVD in modo che "
+"possiamo\n"
+"aiutarti a promuovere la tua organizzazione, scuola o evento nella nostra\n"
+"<a href='http://news.opensuse.org' title='news.opensuse.org'>pagina delle "
+"news</a>\n"
+"o altre risorse (ehi! a noi piacciono le foto, fanne molte!). Contattaci "
+"presso\n"
+"<a href='mailto:opensuse-marketing@opensuse.org'>opensuse-marketing@opensuse."
+"org</a>\n"
+"per discutere della promozione e/o altri modi in cui possiamo assisterti."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Quando si scaricano immagini diverse dal CD per l'installazione di rete, è "
+"<i>fortemente</i> raccomandato di usare un gestore dei download appropriato "
+"per ridurre il rischio di ottenere dati corrotti."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Si può aggiungere la chiave del repository ad apt. Si ricordi che il "
+"possessore della chiave può distribuire aggiornamenti, pacchetti e "
+"repository che il proprio sistema riterrà fidati (<a href=\"%s\">maggiori "
+"informazioni</a>). Per aggiungere la chiave, eseguire:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Puoi provare ad estendere la ricerca ai pacchetti di sviluppo o cercare in "
+"un'altra distribuzione di base (attualmente)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Puoi verificare il file durante lo scaricamento. Ad esempio un codice di "
+"controllo (SHA256) verrà usato automaticamente se selezioni <a href='http://"
+"it.opensuse.org/SDB:Metalink'>Metalink</a> nel campo soprastante e usi il "
+"componente aggiuntivo DownThemAll! in <a href='http://it.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "firma gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://it.opensuse.org/Derivate"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://it.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://it.opensuse.org/Portal:Installazione"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://it.opensuse.org/SDB:Aiuto_per_lo_scaricamento"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+"http://it.opensuse.org/SDB:"
+"Aiuto_per_lo_scaricamento#Masterizzare_le_immagini_ISO"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://it.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"è ancora il codice di controllo più comunemente usato. Molti programmi di "
+"masterizzazione ISO lo visualizzano prima di masterizzare."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "è un codice di controllo meno noto ma più sicuro di md5."
+
+msgid "md5 checksum"
+msgstr "codice di controllo md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"offre maggiore sicurezza in quanto puoi verificare chi lo ha firmato. "
+"Dovrebbe essere <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Conto alla rovescia per openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivate openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE è disponibile via http (collegamento diretto) o BitTorrent. Il CD "
+"per l'installazione di rete è disponibile solamente via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE supporta solamente PC a 32 e 64 bit."
+
+msgid "see Derivatives on wiki"
+msgstr "vedi Derivate sul wiki"
+
+msgid "sha1 checksum"
+msgstr "codice di controllo sha1"
+
+msgid "switch to"
+msgstr "passa a"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Si è verificato un errore interno :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Inserisci più di 2 caratteri"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Ultime ricerche:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistiche"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Download 1-click principali:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Ricerche principali senza suggerimenti:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Ricerche principali:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Al momento non abbiamo un'istantanea della Factory che sia più recente "
+#~ "del nostro ultimo rilascio di openSUSE. <br/>Controlla <a href='http://it."
+#~ "opensuse.org/Portal:Factory'>http://it.opensuse.org/Portal:Factory</a> "
+#~ "per maggiori informazioni."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Puoi aggiungere la chiave del repository ad apt come segue:"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "I CD live contengono solamente quattro lingue (inglese, tedesco, russo e "
+#~ "italiano). Se vuoi usare un'altra lingua la devi scaricare da internet "
+#~ "durante l'installazione o in qualunque momento successivo. Se hai un "
+#~ "facile accesso a internet o se usi il DVD che contiene tutte le lingue, "
+#~ "non hai bisogno di questo CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Dopo aver completato con successo lo scaricamento dell'immagine ISO, "
+#~ "masterizzala su DVD o CD con la tua applicazione di masterizzazione "
+#~ "preferita. Ricordati di <em>non</em> masterizzare un DVD/CD dati, ma "
+#~ "scegli di masterizzare un'immagine ISO."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.it.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.it.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Usa una stringa di ricerca di almeno 2 caratteri"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Passato alla corrispondenza esatta a causa dei troppi suggerimenti sulla "
+#~ "sottostringa di ricerca."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Sii più accurato nella tua ricerca, sono stati raggiunti i limiti di "
+#~ "ricerca."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Impossibile eseguire la ricerca: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Software popolare"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Acquista openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://it.opensuse.org/Buy_openSUSE"
+
+# TLABEL modules/inst_target_part.ycp:680
+#~ msgid "1-Click Install"
+#~ msgstr "Installazione 1-Click"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Scaricamento manuale dei pacchetti"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Vai al Progetto OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Collezione software]"
+
+#~ msgid "Search Results"
+#~ msgstr "Risultati della ricerca"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Non è stato trovato nessun pacchetto nel build service di openSUSE che "
+#~ "corrisponde alla richiesta."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d collezioni e %d binari dai %d pacchetti sorgente"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Istantanea di  "
+
+# "c" as a keyboard accel is already taken.
+#~ msgid "Search Statistics:"
+#~ msgstr "Statistiche di ricerca:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Statistiche download:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Cerca e installa pacchetti di programmi dal <a href=\"http://build."
+#~ "opensuse.org\">Build Service di openSUSE</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opzioni di ricerca"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Includi i progetti home degli utenti"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Escludi pacchetti di debug"
+
+#~ msgid "Additional Information"
+#~ msgstr "Informazioni aggiuntive"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Guida rapida all'Installazione</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Acquista openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Acquista openSUSE 11.3!"
+
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Maggiori informazioni sul download di openSUSE sono disponibili in <a "
+#~ "href=\"http://en.opensuse.org/SDB:Download_Help\">Aiuto download</a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Le istruzioni sono disponibili come segue:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Installazione da CD/DVD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Guida ufficiale per l'avvio di %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Guida passo-passo all'installazione"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Installazione di rete"
+
+#~| msgid "http://en.opensuse.org/Derivatives"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Installazione tramite Internet"
+
+# TLABEL modules/inst_sw_single.ycp:732
+#~ msgid "More information"
+#~ msgstr "Maggiori informazioni"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Ottieni software"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Produci Software"
+
+#~ msgid "User Directory"
+#~ msgstr "Directory utente"
+
+#~ msgid "Features"
+#~ msgstr "Funzionalità"
+
+#~ msgid "News"
+#~ msgstr "News"
+
+#~ msgid "Forums"
+#~ msgstr "Forum"
+
+#~ msgid "Shop"
+#~ msgstr "Negozio"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Cerca software"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Repository degli aggiornamenti"
+
+#~ msgid "Source Repository"
+#~ msgstr "Repository dei sorgenti"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Altre opzioni"
+
+#~ msgid "Mirrors"
+#~ msgstr "Mirror"
+
+#~ msgid "In other languages"
+#~ msgstr "In altre lingue"
+
+#~ msgid "Get it"
+#~ msgstr "Ottienilo"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Cerca nel Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Ricerca ed installa pacchetti software aggiunti dal Build Service di "
+#~ "openSUSE."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Ottieni openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Collegamento permanente a questo risultato"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nessun risultato trovato"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Ottieni software dal Build Service di openSUSE"
+
+# "c" as a keyboard accel is already taken.
+#~ msgid "Searching"
+#~ msgstr "Ricerca"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Contiene un'ampia collezione di programmi per uso desktop o server. "
+#~ "Appropriato per installazione e aggiornamento."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Un desktop GNOME che puoi avviare da CD o da chiavetta USB. Può essere "
+#~ "installato così com'è (no aggiornamento)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Un desktop KDE che puoi avviare da CD o da chiavetta USB. Può essere "
+#~ "installato così com'è (no aggiornamento)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Scarica il sistema di installazione e tutti i pacchetti dai repository in "
+#~ "internet. Appropriato per installazione e aggiornamento."
+
+# TLABEL modules/inst_target_part.ycp:680
+#~ msgid "Metalinks"
+#~ msgstr "Metalinks"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "openSUSE 11"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Per i nuovi utenti Linux, la versione supportata di openSUSE potrebbe "
+#~ "essere la scelta migliore&mdash;avrai un documentazione completa, un "
+#~ "supporto installabile per sistemi a 32 e 64 Bit, oltre a 90 giorni di "
+#~ "supporto per l'installazione."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 è disponibile su diversi negozi <a href=\"http://en."
+#~ "opensuse.org/Buy_openSUSE\">online</a> e rivenditori autorizzati."
+
+#, fuzzy
+#~ msgid "Expert view"
+#~ msgstr "Opzioni avanzate"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Ad esempio su computer con AMD&reg; Sempron o Intel&red; "
+#~ "Celeron&trade;, quasi tutti i computer del 2004 o precedenti, Questa "
+#~ "versione gira anche sui PC a 64bit."
+
+#~ msgid "Help"
+#~ msgstr "Aiuto"
+
+#, fuzzy
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Desktop GNOME"
+
+#, fuzzy
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Desktop KDE"

--- a/locale/ja/software.po
+++ b/locale/ja/software.po
@@ -1,0 +1,913 @@
+# translation of software-opensuse-org.po to Japanese
+# Yasuhiko Kamata <belphegor@belbel.or.jp>, 2009, 2010, 2011, 2012, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-04 07:58+0900\n"
+"Last-Translator: Yasuhiko Kamata <belphegor@belbel.or.jp>\n"
+"Language-Team: Japanese <opensuse-ja@opensuse.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: KBabel 1.11.4\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid " and "
+msgstr " と "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} はサポート対象外のリリースです。\""
+
+msgid "(hide)"
+msgstr "(隠す)"
+
+msgid "(show)"
+msgstr "(表示)"
+
+msgid "... and keep us informed"
+msgstr "... さらに何かあれば知らせてください"
+
+msgid "... get other marketing stuff"
+msgstr "... その他のマーケティング資料を取得する"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (USB メモリに書き込んで利用することもできます)"
+
+msgid "64 Bit PC"
+msgstr "64 ビット PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE ス"
+"タートアップガイド</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://ja.opensuse.org/SDB:Metalink\">メタリンク</a> はダウンロード"
+"を簡単にするためのオープンスタンダードで、ファイルの取得に際して様々な方法 "
+"(FTP/HTTP/BitTorrent) を 1 つにまとめた形式になっています。これは、特に ISP "
+"や大学などによって P2P が制限されている方が ISO ファイルをダウンロードする際"
+"に便利な仕組みです。多くのクライアントは複数のミラーサイトにそれぞれ同時に接"
+"続できるため、とても速いダウンロードをご利用いただくことができます。さらに、"
+"自動的なエラー／データ破壊検出機能も備えています。ただし、メタリンクを処理す"
+"るための特別なクライアントが必要です。"
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://ja.opensuse.org/OpenSUSE:License\">ライセンス</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>リリースノート</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>公式リリース</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>公式の更新</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"%s や USB メモリから起動できる GNOME デスクトップ (英語, ドイツ語, ロシア語, "
+"イタリア語のみ対応) です。 <br/> もちろんそのままインストールすることもできま"
+"す (なお、アップグレードには対応していません) 。"
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"%s や USB メモリから起動できる KDE デスクトップ (英語, ドイツ語, ロシア語, イ"
+"タリア語のみ対応) です。 <br/> もちろんそのままインストールすることもできま"
+"す (なお、アップグレードには対応していません) 。"
+
+msgid "Add repository and install manually"
+msgstr "手作業でリポジトリを追加してインストールする"
+
+msgid "Add-On Downloads (optional)"
+msgstr "アドオンのダウンロード (任意)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"ISO イメージのダウンロードが完了したら、 USB メモリや DVD (または CD サイズの"
+"ものであれば CD) にそのイメージを書き込んで、起動可能なメディアを作成してくだ"
+"さい。"
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"送信される全てのデータは、 openSUSE のプロモーション活動の資料としてのみ利用"
+"され、\n"
+"          これらを第三者に送信することはありません。また、送信したデータ"
+"は、\n"
+"          新バージョンのお知らせの際にも利用します。なお、全てのリクエスト"
+"は\n"
+"          米国禁輸措置に従って処理されます。禁輸措置について詳しくは、\n"
+"          <a href='http://ja.wikipedia.org/wiki/%E7%B1%B3%E5%9B%BD%E3%81%AE"
+"%E7%A6%81%E8%BC%B8%E6%8E%AA%E7%BD%AE'>Wikipedia\n"
+"          の情報</a> をお読みください。"
+
+msgid "App Browser"
+msgstr "アプリケーションブラウザ"
+
+msgid "Available Images"
+msgstr "利用可能なイメージ"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"DVD, CD, USB メモリから起動します。お使いのコンピュータが選択したメディアから"
+"自動で起動しない場合は、 BIOS セットアップを起動してそれらから起動できるよう"
+"に設定してください。"
+
+msgid "Bronze Sponsor"
+msgstr "ブロンズスポンサー"
+
+msgid "Browser incompatibility"
+msgstr "ブラウザの非互換性"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "CD/DVD イメージの書き込み"
+
+msgid "Categories"
+msgstr "カテゴリ"
+
+msgid "Category"
+msgstr "カテゴリ"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"インストールメディアを選択し、ダウンロードボタンを押すとダウンロードが始まり"
+"ます。また、任意でお使いのコンピュータの種類や代替のダウンロード方法を選ぶこ"
+"ともできます。"
+
+msgid "Click here to display these alternative versions."
+msgstr "ここを押すと、その他のバージョンを表示することができます。"
+
+msgid "Click to Download"
+msgstr "クリックしてダウンロード"
+
+msgid "Community"
+msgstr "コミュニティ"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"デスクトップやサーバとして使用するための巨大なソフトウエアコレクションが含ま"
+"れています。 <br/> インストールやアップグレードにご利用いただけます。"
+
+msgid "Countdown"
+msgstr "カウントダウン"
+
+msgid "Country"
+msgstr "国"
+
+msgid "Development"
+msgstr "開発"
+
+msgid "Development Version"
+msgstr "開発版"
+
+msgid "Development packages"
+msgstr "開発用パッケージ"
+
+msgid "Development-"
+msgstr "開発-"
+
+msgid "Direct Install"
+msgstr "直接インストール"
+
+msgid "Direct Link"
+msgstr "直接リンク"
+
+msgid "Documentation"
+msgstr "文書"
+
+msgid "Don't show this warning the next time"
+msgstr "次回以降はこの警告を表示しない"
+
+msgid "Download"
+msgstr "ダウンロード"
+
+msgid "Download %s"
+msgstr "%s のダウンロード"
+
+msgid "Download Help"
+msgstr "ダウンロードのヘルプ"
+
+msgid "Download Method"
+msgstr "ダウンロード手段"
+
+msgid "Download appliance from %s"
+msgstr "%s からアプライアンスをダウンロードする"
+
+msgid "Download&nbsp;DVD"
+msgstr "DVD 版&nbsp;ダウンロード"
+
+msgid "Download&nbsp;GNOME"
+msgstr "GNOME 版&nbsp;ダウンロード"
+
+msgid "Download&nbsp;KDE"
+msgstr "KDE 版&nbsp;ダウンロード"
+
+msgid "Download&nbsp;Network"
+msgstr "ネットワーク版&nbsp;ダウンロード"
+
+msgid "Download&nbsp;Rescue"
+msgstr "レスキュー版&nbsp;ダウンロード"
+
+msgid "Downloads"
+msgstr "ダウンロード"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"インストールシステムと必要な全てのパッケージをオンラインのリポジトリからダウ"
+"ンロードする仕組みです。 <br/> インストールやアップグレードにご利用いただけま"
+"す。"
+
+msgid "Expand all sections ('e')"
+msgstr "全てのセクションを展開する ('e')"
+
+msgid "Extra Languages"
+msgstr "追加言語"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "追加言語 (32 ビット)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "追加言語 (64 ビット)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"<strong>%s</strong> の場合は、 <strong>root</strong> で下記のコマンドを実行し"
+"てください:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "<strong>%s</strong> の場合は、下記のコマンドを実行してください:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"<strong>Arch Linux</strong> の場合は /etc/pacman.conf を編集し、下記を追加し"
+"てください (ただし、 pacman が想定どおりのパッケージをダウンロードできるよ"
+"う、リポジトリの順序についても注意してください):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "それぞれの ISO に対して SHA256 によるチェックサムを提供しています。"
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"また、さらなるセキュリティ確保のため、 GPG を利用して .sha256 ファイル自身の"
+"署名を検証することもできます。こちらは %s であるべきものです。"
+
+msgid "Games"
+msgstr "ゲーム"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "openSUSE 上で構築された特別仕様のディストリビューションの取得。"
+
+msgid "Getting Help"
+msgstr "ヘルプ"
+
+msgid "Gold Sponsor"
+msgstr "ゴールドスポンサー"
+
+msgid "Grab binary packages directly"
+msgstr "バイナリパッケージを直接取得する"
+
+msgid "Header Logo"
+msgstr "ヘッダロゴ"
+
+msgid "Help on Download Method"
+msgstr "ダウンロード手段に関するヘルプ"
+
+msgid "Help on Type of Computer"
+msgstr "コンピュータの種類に関するヘルプ"
+
+msgid "How to Proceed"
+msgstr "続行するには"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"直接リンクをお使いの場合で、最も高速なミラーサイトに転送するためのダウンロー"
+"ドリダイレクタが適切なミラーサイトを検出できない場合、ご自身でミラーサイトを"
+"選択することもできます。"
+
+msgid "Image:"
+msgstr "イメージ:"
+
+msgid "Install package %s / %s"
+msgstr "パッケージのインストール: %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "パターンのインストール: %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "1-クリックインストールでインストールする"
+
+msgid "Installation Guides"
+msgstr "インストールガイド"
+
+msgid "Installation Medium"
+msgstr "インストールメディア"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"プロモーション DVD を注文して配布することで、 openSUSE をさらに多くの人々に\n"
+"        広めることができます。たとえば、あなたが参加されているグループや非営"
+"利団体、\n"
+"        大学の友達や LUG ミーティングのようなイベント、インストールフェスタ"
+"や\n"
+"        カンファレンスなどがあります。\n"
+"        プロモーション DVD で openSUSE の普及をご支援ください。"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"既にメンテナンスされていない KDE 3 の Konqueror には、 Javascript の実装にバ"
+"グが存在していて、このページを利用することができません。このページをご利用い"
+"ただく前に Javascript を無効に設定し、 <a href='%s'>継続</a> を押してくださ"
+"い。"
+
+# label for language selection
+msgid "Language"
+msgstr "言語"
+
+msgid "Legacy 32 Bit PC"
+msgstr "旧 32 ビット PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "旧 32&nbsp;ビット&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "GNOME 版ライブメディア"
+
+msgid "Live KDE"
+msgstr "KDE 版ライブメディア"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"様々なアプリケーションを利用して、チェックサムによるダウンロードの検証を行な"
+"うことができます。ダウンロードの検証を行なうことは、ダウンロードした ISO ファ"
+"イルが壊れていないことを確認するのに重要な作業です。"
+
+msgid "Metalink"
+msgstr "メタリンク"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "CD/DVD に ISO ファイルを書き込む際の詳しい情報"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"<a href='http://ja.opensuse.org/Live_USB_stick'>起動可能な USB メモリ</a> に"
+"ついて、詳しくは左記のリンクをお読みください。"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"openSUSE のダウンロードについてさらに詳しい情報は、 <a href=\"http://ja."
+"opensuse.org/Portal:Documentation\">ドキュメンテーション Wiki</a> 内の <a "
+"href=\"http://ja.opensuse.org/SDB:Download_help\">ダウンロードに関するヘルプ"
+"</a> や <a href=\"http://ja.opensuse.org/Network_Install\">ネットワークインス"
+"トール</a> をお読みください。"
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"多くの新しいコンピュータは <a href=\"http://ja.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (AMD64 や Intel64 としても知られています) に対応していま"
+"すが、ラップトップやネットブック向けのプロセッサによっては対応していないもの"
+"もあります。お使いのコンピュータの対応可否については、 wikipedia などをご確認"
+"ください。"
+
+msgid "Multimedia"
+msgstr "マルチメディア"
+
+msgid "Need help?"
+msgstr "ヘルプが必要ですか？"
+
+msgid "Network"
+msgstr "ネットワーク"
+
+msgid "No appliance data for %s"
+msgstr "%s 向けのアプライアンスデータはありません"
+
+msgid "No appliances found in project %s"
+msgstr "プロジェクト %s 内にはアプライアンスがありませんでした"
+
+msgid "No data for %s / %s"
+msgstr "%s / %s 向けのデータがありません"
+
+msgid "No description found..."
+msgstr "説明が見つかりませんでした..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "プロジェクト %2$s 内には %1$s 向けのダウンロードは見つかりませんでした"
+
+msgid "No packages found matching your search. "
+msgstr "該当するパッケージが見つかりません。"
+
+msgid "NonOSS CD"
+msgstr "非オープンソース CD"
+
+msgid "OBS Backend not available"
+msgstr "OBS バックエンドが利用できません"
+
+msgid "Official Manuals"
+msgstr "公式マニュアル"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"DVD メディア、およびネットワークメディアのみが完全にテストされています。ライ"
+"ブメディアやレスキューシステムなど、その他のメディアは、それぞれ特定の用途の"
+"みに推奨されるものです。"
+
+msgid "Package %s not found..."
+msgstr "パッケージ %s が見つかりません..."
+
+msgid "Package Repositories"
+msgstr "パッケージリポジトリ"
+
+msgid "Package Search"
+msgstr "パッケージ検索"
+
+msgid "Packages for %s:"
+msgstr "%s 向けのパッケージ:"
+
+msgid "Pick Mirror"
+msgstr "ミラーの選択"
+
+msgid "Platinum Sponsor"
+msgstr "プラチナスポンサー"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"以下のパッケージは、非公式のリポジトリから公開されていることに注意してくださ"
+"い。\n"
+"  これらは openSUSE 側での動作確認は行なわれておらず、不安定であったり実験的"
+"なものであったりする場合があります。"
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"DVD を必要とする理由とイベントの Web サイトリンク、または目的などの <b>大まか"
+"な</b> 説明を、\"英語で!\"入力してください。"
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"本リリースは openSUSE の最新リリースではないことに注意してください。最新バー"
+"ジョンは <a href='/'>こちら</a> からダウンロードできます。 "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"プロモーション DVD とそれに関連するアートワーク類 (ラベルやスリーブなど)\n"
+"        は、 <a href=\"http://download.opensuse.org/promodvd/\">プロモーショ"
+"ン DVD の\n"
+"        ダウンロードディレクトリ %s</a> からダウンロードすることができます。"
+"なお、本 DVD は\n"
+"        宣伝用に設計された openSUSE の特別版であることにご注意ください。"
+
+msgid "Related categories:"
+msgstr "関連するカテゴリ:"
+
+msgid "Released Version"
+msgstr "リリース版"
+
+msgid "Reporting Bugs"
+msgstr "バグの報告"
+
+msgid "Rescue"
+msgstr "レスキュー"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"CD や USB メモリから起動できるレスキューシステムです。 <br/>インストールや"
+"アップグレードに利用することはできません。"
+
+msgid "SHA256 checksum"
+msgstr "SHA256 チェックサム"
+
+msgid "Search"
+msgstr "検索"
+
+msgid "Select Your Operating System"
+msgstr "お使いのオペレーティングシステムの選択"
+
+msgid "Select the image type"
+msgstr "イメージの種類を選択してください。"
+
+msgid "Show"
+msgstr "表示"
+
+msgid "Show development, language and debug packages"
+msgstr "開発用パッケージ, 言語パッケージ, デバッグ用パッケージを表示する"
+
+msgid "Show distribution:"
+msgstr "ディストリビューションの表示:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "サポート対象外のディストリビューション向けのパッケージを表示"
+
+msgid "Show more..."
+msgstr "さらに表示..."
+
+msgid "Show other versions"
+msgstr "他のバージョンを表示"
+
+msgid "Show unstable packages"
+msgstr "不安定版を表示する"
+
+msgid "Show unsupported packages"
+msgstr "サポート対象外のパッケージを表示する"
+
+msgid "Silver Sponsor"
+msgstr "シルバースポンサー"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"その他のメディア (ライブメディア、レスキューシステム) もご利用いただけます"
+"が、これらに対するテストは上記のものに比べると分量を少なく設定しています。そ"
+"のため、それぞれ特定の用途のみにお使いいただくことをお勧めします。"
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"openSUSE をベースにした、いくつかのライブディストリビューションです。独自の派"
+"生物を作成したい場合は、 <a href=\"http://susestudio.com/\">SUSE Studio</a> "
+"(英語) をご覧ください。"
+
+msgid "Source"
+msgstr "ソース"
+
+msgid "Sponsored by"
+msgstr "スポンサー"
+
+msgid "Sponsored by: AMD"
+msgstr "提供: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "提供: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "提供: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "提供: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "サブパッケージ"
+
+msgid "Support"
+msgstr "サポート"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"インストールプログラムは多数の言語に対応していますが、イメージ内に収録されて"
+"いるアプリケーションの翻訳データは、それら全ての言語には対応できていません。 "
+"openSUSE のシステムを追加の言語に対応させるには、インストール時またはインス"
+"トール後、インターネットからダウンロードする必要があります。インターネットに"
+"容易に接続できる環境であれば CD は不要となりますが、インターネットに接続され"
+"ていないマシンに openSUSE をインストールする場合は、この CD でアプリケーショ"
+"ン用の翻訳データをインストールすることができます。"
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "その後、 <strong>root</strong> で下記のコマンドを実行してください:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"現時点のテストフェーズでは、 openSUSE のリリースは提供されていません。 <br/> "
+"最新のソフトウエアをお使いになりたい場合は、 <a href='http://ja.opensuse.org/"
+"Portal:Tumbleweed'>openSUSE Tumbleweed</a> をお使いください。"
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"この CD にはプロプライエタリライセンスで提供され、無償で利用することができる"
+"ものの、オープンソースのソフトウエアとの同梱が許されていないフリーソフトウエ"
+"アが含まれています。この CD 内にある全てのソフトウエアは、 NON-OSS リポジトリ"
+"からダウンロードすることができます。"
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"このバージョンは、 64 ビット対応のものを含む全ての PC で動作します。ただし、"
+"お使いのコンピュータのメモリが 3GB より多い場合は、 64 ビット版をお使いになる"
+"のがよいでしょう。なお、 openSUSE は初代 Pentium より前のプロセッサには対応し"
+"ていません - また、ライブ CD は i686 のみ (Pentium Pro およびそれ以降) の対応"
+"です。"
+
+msgid "Type of Computer"
+msgstr "コンピュータの種類"
+
+msgid "Unsupported distributions:"
+msgstr "サポート対象外のディストリビューション:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"ユーザマニュアルは <a href=\"http://activedoc.opensuse.org\">activedoc."
+"opensuse.org</a> で公開しています。たとえば <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">公式スタートアップガイド</a> などがあ"
+"ります。"
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"<a href=\"http://ja.opensuse.org/index.php?title=SDB:BitTorrent"
+"\">BitTorrent</a> は、特に DVD イメージのダウンロードなどにおいて、低速なイン"
+"ターネット接続環境をお使いの場合はお勧めです。 BitTorrent のダウンロードには"
+"いくつかの利点があります。クライアント側でデータの整合性を確認できるほか、ダ"
+"ウンロードしながら同時に他のユーザにもアップロードする仕組みになっているた"
+"め、サーバの負荷を減らすことができます - つまり、十分なユーザ数の参加があれ"
+"ば、中央のサーバからダウンロードするよりも誰もが速くダウンロードすることがで"
+"きます。さらに、任意の場所でダウンロードを一時停止し、後から再開することもで"
+"きます。"
+
+msgid "Verify your download before use"
+msgstr "お使いになる前にダウンロードを検証してください"
+
+msgid "Version"
+msgstr "バージョン"
+
+msgid "We offer three different checksums:"
+msgstr "下記の 3 種類のチェックサムが利用できます:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"DVD の使用に関して、情報提供をお願いしています。これにより、\n"
+"        団体やイベント、学校での普及促進活動を <a href='http://news.opensuse."
+"org' title='news.opensuse.org'>news page</a>\n"
+"        などで紹介したりすることができます (特にできる限り多くの\n"
+"        写真を提供していただけると助かります!) 。なお、普及促進活動に\n"
+"        関するご意見やお問い合わせは、 <a href='mailto:opensuse-"
+"marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>\n"
+"        宛にお送りください。"
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"ネットワークインストール向けの CD を除き、イメージのダウンロードを行なう場合"
+"は、ダウンロード時にデータが壊れてしまう危険性を回避するため、適切なダウン"
+"ロードマネージャのご利用を <i>強く</i> お勧めします。"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"リポジトリの鍵を apt に登録することもできます。鍵を apt に登録すると、その鍵"
+"の所有者が配布する更新やパッケージ、リポジトリなどについても、それらを信頼す"
+"ることになります (<a href=\"%s\">詳しくはこちらをお読みください</a>) 。鍵を追"
+"加するには、下記のように実行します:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"サポート対象外のパッケージについても検索するように設定できるほか、他のベース"
+"ディストリビューション向けのものも検索することができます。"
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"なお、ダウンロード時にファイルを検証することもできます。たとえば上記にある "
+"<a href='http://ja.opensuse.org/SDB:Metalink'>メタリンク</a> を選択し、 "
+"DownloadThemAll! プラグインを <a href='http://ja.opensuse.org/"
+"Firefox'>Firefox</a> で利用すると、自動的にチェックサム (SHA256) の検証が行な"
+"われます。"
+
+msgid "gpg signature"
+msgstr "gpg 署名"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://ja.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://ja.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://ja.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://ja.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+"http://ja.opensuse.org/%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC"
+"%E3%83%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E3%83%98%E3%83%AB%E3%83%97#CD_."
+"E3.82.A4.E3.83.A1.E3.83.BC.E3.82.B8.E3.82.92.E6.9B.B8.E3.81.8D.E8.BE.BC."
+"E3.82.80"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://ja.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES.ja."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/RELEASE-NOTES.ja."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/RELEASE-NOTES.ja."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/RELEASE-NOTES.ja."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES.ja."
+"html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.ja.html"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr ""
+"https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.ja.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"は広く一般的に使われているチェックサムです。多くの ISO 書き込みソフトウエアで"
+"は、書き込み前にこのチェックサムの値を表示します。"
+
+msgid "is the less known but more secure checksum than md5."
+msgstr ""
+"はあまり知られていませんが、 md5 よりは厳密な検証を行なうことができます。"
+
+msgid "md5 checksum"
+msgstr "md5 チェックサム"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"は、署名者を検証する機能を備えているため、最も良い方法です。鍵のフィンガープ"
+"リント (指紋) は <tt>%s</tt> です。"
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE カウントダウン"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE からの派生物"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE は http (直接リンク) または BitTorrent でダウンロードできます。ネッ"
+"トワークインストール向けの CD は http のみの提供です。"
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE は 32 ビットと 64 ビットの各 PC にのみ対応しています。"
+
+msgid "see Derivatives on wiki"
+msgstr "Wiki 上にある派生物の一覧を参照"
+
+msgid "sha1 checksum"
+msgstr "sha1 チェックサム"
+
+msgid "switch to"
+msgstr "切り替え"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "内部エラーが発生しました :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "少なくとも 2 文字以上を入力してください"

--- a/locale/km/software.po
+++ b/locale/km/software.po
@@ -1,0 +1,1029 @@
+# translation of software-opensuse-org.km.po to Khmer
+# Khoem Sokhem <khoemsokhem@khmeros.info>, 2009, 2010, 2011.
+# Seng Sutha <sutha@khmeros.info>, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.km\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2011-02-10 08:50+0700\n"
+"Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
+"Language-Team: Khmer <support@khmeros.info>\n"
+"Language: km\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: KBabel 1.11.4\n"
+"X-Language: km-KH\n"
+
+#, fuzzy
+msgid " and "
+msgstr "%s និង %s"
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr "(លាក់)"
+
+msgid "(show)"
+msgstr "(បង្ហាញ)"
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "កុំព្យូទ័រ ៦៤ ប៊ីត"
+
+#, fuzzy
+#| msgid ""
+#| "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#| "startup/\">openSUSE startup guide</a>"
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+"startup/\">មគ្គុទ្ទេសក៍​ចាប់ផ្ដើម​អូផឹនស៊ូស៊ី</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">តំណ​មេតា</a> គឺ​ជា​ស្តង់ដារ​បើក​ចំហ​ដែល​"
+"មាន​វិធី​ជា​ច្រើន (FTP/HTTP/BitTorrent) ដើម្បី​ទទួល​បាន​ឯកសារ​មាន​​ទ្រង់ទ្រាយ​មួយ ​សម្រាប់​ការ​ទាញ​យក​ដ៏​"
+"លឿន​បំផុត ។ ធ្វើ​ឲ្យ​វា​កាន់តែ​ល្អ​​ សម្រាប់​ការ​ទាញ​យក ISOs ជា​ពិសេស​សម្រាប់​មនុស្ស​ដែល​មិន​អាច​ប្រើ P2P ដោយ​"
+"សារ​តែ​ កា​រ​ដាក់កម្រិត​ពី ISP ឬ​សកលវិទ្យាល័យ​ ។ វា​អាច​បញ្ជូន​នូវ​ល្បឿន​ទាញ​យក​​លឿន​បំផុត​តាំង​ពី​​​មាន​ការ​គាំទ្រ​"
+"ការ​​តភ្ជាប់​​ម៉ាស៊ីន​ភ្ញៀវ​ជា​ច្រើន​​ទៅ​កញ្ចក់​នានា​​ដោយ​ស្វ័យ​ប្រវត្តិ ។ បន្ថែម​លើ​នេះ វា​អាច​រក​ឃើញ​កំហុស​ និង​​កែ​វា​"
+"ដោយ​ស្វ័យប្រវត្តិ​ទៀត​ផង ។ ទោះ​បី​យ៉ាងណា វា​នៅ​តែ​ត្រូវការ​ម៉ាស៊ីន​ភ្ញៀវ​ពិសេស​ដើម្បី​គ្រប់គ្រង​វា ។"
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">អាជ្ញាប័ណ្ណ​</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>ឯកសារ​ចេញផ្សាយ</a>"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "ឯកសារ​ចេញផ្សាយ​ផ្លូវការ"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "បច្ចុប្បន្នភាព​ផ្លូវការ"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"ផ្ទៃតុ GNOME ដែល​អ្នក​អាច​រត់​​ពី​ស៊ីឌី ឬ​ពី​ USB ។<br/>អាច​ត្រូវ​បាន​ដំឡើង​ (គ្មាន​ភាព​ធ្វើ​ឲ្យ​ប្រសើ​រ​ឡើង​"
+"ទេ) ។"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"ផ្ទៃតុ KDE ដែល​អ្នក​អាច​រត់​ពី​ស៊ីឌី ឬ​ពី USB ។<br/>អាច​ត្រូវ​បាន​ដំឡើង (គ្មាន​ភាព​ធ្វើ​ឲ្យ​ប្រសើរ​ឡើង​ទេ) ។"
+
+msgid "Add repository and install manually"
+msgstr "បន្ថែម​ឃ្លាំង និង​ដំឡើង​ដោយដៃ"
+
+msgid "Add-On Downloads (optional)"
+msgstr "ទាញយក​ផ្នែក​បន្ថែម (ជម្រើស)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+msgid "App Browser"
+msgstr "កម្មវិធី​រុករក​កម្មវិធី"
+
+msgid "Available Images"
+msgstr "រូបភាព​ដែល​មាន"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"ចាប់ផ្ដើម​ពី​ឌីវីឌី ឬ​ស៊ីឌី ។ ក្នុងករណី​ដែល​កុំព្យូទ័រ​របស់​អ្នក​មិន​ចាប់ផ្ដើមដោយ​ស្វ័យ​ប្រវត្តិ​ពី​ស៊ីឌី/ឌីវីឌី បើក​ការ​រៀបចំ "
+"BIOS ដើម្បី​អនុញ្ញាត​ឲ្យ​ចាប់ផ្ដើម​ពី​ស៊ីឌី ឬ​ឌីវីឌី ។"
+
+msgid "Bronze Sponsor"
+msgstr "អ្នក​ឧបត្ថម្ភ Bronze "
+
+msgid "Browser incompatibility"
+msgstr "ភាព​មិន​ឆប​គ្នា​របស់​កម្មវិធីរុករក"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "ដុតរូបភាព​​ស៊ីឌី/ឌីវីឌី"
+
+msgid "Categories"
+msgstr "ប្រភេទ"
+
+msgid "Category"
+msgstr "ប្រភេទ"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"ជ្រើស​ឧបករណ៍​ផ្ទុក​ដំឡើង​ដោយ​ចុច​លើ​វា និង​ចុច​ប៊ូតុង​ទាញ​យក​ ដើម្បី​ចាប់ផ្ដើមការ​​ទាញ​យក ។ ជា​ជម្រើស​ ជ្រើស​"
+"ប្រភេទ​កុំព្យូទ័រ​ ឬ​វិធី​សាស្ត្រ​ទាញ​យក​ជា​ជម្រើស ។"
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "ចុច ​ដើម្បី​ទាញ​យក"
+
+msgid "Community"
+msgstr "សហគមន៍"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"មាន​បណ្ដុំ​កម្មវិធី​ជា​ច្រើន​សម្រាប់​​​ប្រើ​លើ​កុំព្យូទ័រ​​ធម្មតា ឬ​ម៉ាស៊ីន​បម្រើ ។<br/>សម​ស្រប​សម្រាប់​ដំឡើង ឬ​សម្រាប់​"
+"ការ​​ធ្វើ​ឲ្យ​ប្រសើរ​ឡើង ។"
+
+msgid "Countdown"
+msgstr "រាប់​ថយ​ក្រោយ"
+
+#, fuzzy
+msgid "Country"
+msgstr "រាប់​ថយ​ក្រោយ"
+
+msgid "Development"
+msgstr "អភិវឌ្ឍន៍"
+
+msgid "Development Version"
+msgstr "កំណែ​អភិវឌ្ឍន៍"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "កញ្ចប់​អភិវឌ្ឍន៍ ៖"
+
+#, fuzzy
+msgid "Development-"
+msgstr "អភិវឌ្ឍន៍"
+
+msgid "Direct Install"
+msgstr "ដំឡើង​ដោយ​ផ្ទាល់"
+
+msgid "Direct Link"
+msgstr "តំណ​ផ្ទាល់"
+
+msgid "Documentation"
+msgstr "ឯកសារ​"
+
+msgid "Don't show this warning the next time"
+msgstr "កុំ​បង្ហាញ​សារ​ព្រមាន​នេះ​ម្ដងទៀត"
+
+msgid "Download"
+msgstr "​​ទាញយក​"
+
+msgid "Download %s"
+msgstr "ទាញយក %s"
+
+msgid "Download Help"
+msgstr "ជំនួយ​ទាញ​យ​ក​"
+
+msgid "Download Method"
+msgstr "វិធីសាស្ត្រ​ទាញយក​"
+
+msgid "Download appliance from %s"
+msgstr "ទាញ​យក​ឧបករណ៍​ប្រើប្រាស់​ពី %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "ទាញ​យក&nbsp;ឌីវីឌី"
+
+msgid "Download&nbsp;GNOME"
+msgstr "ទាញ​យក&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "ទាញ​យក&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "ទាញ​យក&nbsp;បណ្ដាញ"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "ទាញ​យក&nbsp;KDE"
+
+msgid "Downloads"
+msgstr "​​ទាញយក​"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"ទាញ​យក​ប្រព័ន្ធ​ដំឡើង និង​កញ្ចប់​ទាំងអស់​ពី​ឃ្លាំង​លើ​បណ្ដាញ ។<br/>សមស្រប​សម្រាប់​ដំឡើង ឬ​ធ្វើ​ឲ្យ​ប្រសើរ​ឡើង ។"
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "ភាសា​បន្ថែម"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "ភាសា​បន្ថែម (៣២ ប៊ីត)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "ភាសា​បន្ថែម (៦៤ ប៊ីត)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "សម្រាប់​ <strong>%s</strong> ដំណើរការ​អ្វី​ៗ​ដូច​ខាងក្រោម​ជា <strong>root</strong>:"
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "For <strong>%s</strong> run the following:"
+msgstr "សម្រាប់​ <strong>%s</strong> ដំណើរការ​អ្វី​ៗ​ដូច​ខាងក្រោម​ជា <strong>root</strong>:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"ផ្ដល់​នូវ​សុវត្ថិភាព​បំផុត​ ព្រោះ​អ្នក​អាច​ផ្ទៀងផ្ទាត់​ថា​អ្នក​ណា​បាន​ចុះហត្ថលេខា​លើ​វា ។ វា​គួរតែ​ជា <tt>%s</"
+"tt> ។"
+
+msgid "Games"
+msgstr "ល្បែង"
+
+#, fuzzy
+#| msgid "Get one of the specialized distribution built on openSUSE."
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "យក​ការ​ចែកចាយ​ពិសេស​ដែល​បាន​ស្ថាបនា​លើ​អូផឹន​ស៊ូស៊ី ។"
+
+msgid "Getting Help"
+msgstr "យក​ជំនួយ"
+
+msgid "Gold Sponsor"
+msgstr "អ្នក​ឧបត្ថម្ភ​ Gold"
+
+msgid "Grab binary packages directly"
+msgstr "ចាប់​យក​កញ្ចប់​គោល​ពីរ​ដោយផ្ទាល់"
+
+msgid "Header Logo"
+msgstr "រូបសញ្ញា​​ក្បាល"
+
+msgid "Help on Download Method"
+msgstr "ជំនួយ​អំពី​វិធីសាស្ត្រ​ទាញ​យក"
+
+msgid "Help on Type of Computer"
+msgstr "ជំនួយ​អំពី​ប្រភេទ​កុំព្យូទ័រ"
+
+msgid "How to Proceed"
+msgstr "របៀប​បន្ត"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"ប្រសិនបើ​អ្នក​ចង់​ប្រើ​តំណ​​​ផ្ទាល់​ ប៉ុន្តែ​មាន​កន្លែង​ដែល​កម្មវិធី​បង្វែរ​​ទាញ​យក​របស់​យើង​​មិន​មាន​ព័ត៌មាន​គ្រប់គ្រាន់​ "
+"ដើម្បី​បញ្ជូន​ទៅកាន់​កញ្ចក់​ដែល​លឿន​បំផុត អ្នក​អាច​ជ្រើសរើស​​កញ្ចក់​ដោយ​ខ្លួន​អ្នក​ផ្ទាល់ ។"
+
+msgid "Image:"
+msgstr "រូបភាព ៖"
+
+msgid "Install package %s / %s"
+msgstr "ដំឡើង​កញ្ចប់ %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "ដំឡើង​លំនាំ %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "ដំឡើង​ដោយ​ប្រើ​ One Click Install"
+
+msgid "Installation Guides"
+msgstr "មគ្គុទ្ទេសក៍​ដំឡើង​"
+
+msgid "Installation Medium"
+msgstr "ឧបករណ៍​ផ្ទុក​ដំឡើង"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror របស់ KDE 3 ជាអកុសល​មិន​ត្រូវបាន​ថែទាំ ហើយ​​ការ​អនុវត្ត javascript របស់​វា​មាន​​កំហុស​ ដែល​"
+"ធ្វើ​ឲ្យ​វា​ប្រើ​មិនបាន​ក្នុង​ទំព័រ​នេះ ។ សូម​ប្រាកដ​ថា​អ្នក​បាន​បិទ javascript មុន​នឹង​អ្នក <a "
+"href='%s'>បន្ត</a> ។"
+
+# label for language selection
+msgid "Language"
+msgstr "ភាសា"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "កុំព្យូទ័រ ៣២ ប៊ីត"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32&nbsp;Bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "GNOME បន្ត​ផ្ទាល់"
+
+msgid "Live KDE"
+msgstr "KDE បន្ត​ផ្ទាល់"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"កម្មវិធី​ជាច្រើន​អាច​ផ្ទៀងផ្ទាត់​ឆេកសាំ​នៃ​ការ​ទាញ​យក​របស់​អ្នក​បាន ។ ការ​ផ្ទៀងផ្ទាត់​នូវ​អ្វី​ដែល​អ្នក​ទាញ​យក គឺ​"
+"ពិត​ជា​មាន​សារ​សំខាន់ ពីព្រោះ​នៅ​ពេល​ដែល​វា​ផ្ទៀងផ្ទាត់ អ្នក​នឹង​ទទួល​បាន​ឯកសារ​ ISO ពិត​ប្រាកដ​ដែល​អ្នក​ចង់​"
+"ទាញ​យក មិន​មែន​ទទួល​បាន​​កំណែ​ដែល​ខូច​នោះ​ទេ ។"
+
+msgid "Metalink"
+msgstr "តំណ​មេតា"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "ព័ត៌មាន​បន្ថែម​អំពី​ការ​​ដុត​ឯកសារ​ ISO ​ទៅ​ក្នុងស៊ីឌី/ឌីវីឌី"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"ព័ត៌មាន​បន្ថែម​អំពី​ការ​បង្កើត <a href='http://en.opensuse.org/Live_USB_stick'>ឧបករណ៍​"
+"ផ្ទុក USB ដែល​អាច​ចាប់​ផ្ដើម​បាន</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"ព៌ត៌មាន​បន្ថែម​អំពី​ការ​ទាញយក​អូផឹនស៊ូស៊ី​អាច​រក​បាន​ពី <a href=\"http://en.opensuse.org/SDB:"
+"Download_help\">ជំនួយ​ទាញយក</a> និង <a href=\"http://en.opensuse.org/SDB:"
+"Network_installation\">ទំព័រ​ដំឡើង​តាម​បណ្ដាញ</a> នៅ​ក្នុង <a href=\"http://en."
+"opensuse.org/Portal:Documentation\">ឯកសារ​វីគី</a> ។"
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"កុំព្យូទ័រ​ថ្មី​ភាគ​ច្រើន​គាំទ្រ <a href=\"http://en.wikipedia.org/wiki/X86-64\">x86-64</"
+"a> (ក៏​ត្រូវ​បាន​ស្គាល់​ថា​ជា AMD64 និង Intel64) ប៉ុន្តែ​ប្រព័ន្ធ​ដំណើរការ​កុំព្យូទ័រ​យួរ​ដៃ និង​ប្រព័ន្ធ​"
+"ដំណើរការ​កុំព្យូទ័រ​មួយ​ចំនួន​​​មិន​គាំទ្រ​វា​ទេ ។ ដូច្នេះ​​អ្នក​ត្រូវ​ពិនិត្យ​មើល wikipedia ប្រសិនបើ​អ្នក​​ចង់ឲ្យ​​ប្រាកដ​"
+"ថា​កុំព្យូទ័រ​របស់​អ្នក​គាំទ្រ​វា ។"
+
+msgid "Multimedia"
+msgstr "ពហុ​ព័ត៌មាន"
+
+msgid "Need help?"
+msgstr "ត្រូវការ​ជំនួយ ?"
+
+msgid "Network"
+msgstr "បណ្ដាញ​"
+
+msgid "No appliance data for %s"
+msgstr "គ្មាន​ទិន្នន័យ​ឧបករណ៍​ប្រើប្រាស់​សម្រាប់ %s"
+
+msgid "No appliances found in project %s"
+msgstr "រក​មិន​ឃើញ​ឧបករណ៍​ប្រើប្រាស់​នៅ​ក្នុង​គម្រោង %s ទេ"
+
+msgid "No data for %s / %s"
+msgstr "គ្មាន​ទិន្នន័យ​សម្រាប់ %s / %s"
+
+msgid "No description found..."
+msgstr "រក​មិន​ឃើញ​សេចក្ដី​ពិពណ៌នា..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "រក​មិន​ឃើញ​ការ​ទាញ​យក​សម្រាប់​ %s នៅ​ក្នុង​គម្រោង​ %s ទេ"
+
+msgid "No packages found matching your search. "
+msgstr "រក​មិន​ឃើញ​កញ្ចប់​ដែល​ផ្គូផ្គង​នឹង​ការ​ស្វែងរក​របស់​អ្នក​ទេ ។"
+
+msgid "NonOSS CD"
+msgstr "ស៊ីឌី​ NonOSS"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "scdb មិន​អាច​ប្រើ​បាន"
+
+msgid "Official Manuals"
+msgstr "សៀវភៅ​ដៃ​ផ្លូវការ"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr "រក​មិន​ឃើញ​កញ្ចប់ %s..."
+
+msgid "Package Repositories"
+msgstr "ឃ្លាំងកញ្ចប់"
+
+msgid "Package Search"
+msgstr "ស្វែងរក​កញ្ចប់"
+
+msgid "Packages for %s:"
+msgstr "កញ្ចប់​សម្រាប់ %s ៖"
+
+msgid "Pick Mirror"
+msgstr "យក​​កញ្ចក់"
+
+msgid "Platinum Sponsor"
+msgstr "អ្នក​ឧបត្ថម្ភ​ Platinum "
+
+#, fuzzy
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"សូម​ចងចាំ​ថា កញ្ចប់​ដូច​ខាងក្រោម​មកពី​ឃ្លាំង​មិន​ផ្លូវការ ។\n"
+"    មាន​ន័យ​ថា ពួកវា​មិន​ត្រូវ​បាន​ត្រួតពិនិត្យ​ដោយ​អូផឹនស៊ូស៊ី​ទេ ហើយ​អាច​នឹង​មាន​កម្មវិធី​ដែល​គ្មាន​ស្ថិរភាព ឬ​បែប​"
+"ពិសោធន៍ ។"
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"សូម​ចំណាំ​ថា នេះ​មិនមែន​ជា​ឯកសារ​ចេញ​​ផ្សាយ​ចុងក្រោយ​របស់​អូផឹនស៊ូស៊ី​ទេ ។ អ្នក​នឹង​ទទួល​បាន​កំណែ​ថ្មី​បំផុត​ <a "
+"href='/'>នៅ​ទីនេះ</a> ។ "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+msgid "Related categories:"
+msgstr "ប្រភេទ​ដែល​ទាក់ទង ៖"
+
+msgid "Released Version"
+msgstr "កំណែ​ចេញ​ផ្សាយ"
+
+msgid "Reporting Bugs"
+msgstr "រាយការណ៍​កំហុស​"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "សង្គ្រោះ​ប្រព័ន្ធ"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"ផ្ទៃតុ KDE ដែល​អ្នក​អាច​រត់​ពី​ស៊ីឌី ឬ​ពី USB ។<br/>អាច​ត្រូវ​បាន​ដំឡើង (គ្មាន​ភាព​ធ្វើ​ឲ្យ​ប្រសើរ​ឡើង​ទេ) ។"
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "md5 checksum"
+
+msgid "Search"
+msgstr "ស្វែងរក"
+
+msgid "Select Your Operating System"
+msgstr "ជ្រើស​ប្រព័ន្ធ​ប្រតិបត្តិការ​របស់​អ្នក"
+
+msgid "Select the image type"
+msgstr "ជ្រើស​ប្រភេទ​រូបភាព"
+
+#, fuzzy
+msgid "Show"
+msgstr "បង្ហាញ ៖"
+
+msgid "Show development, language and debug packages"
+msgstr "បង្ហាញ​កញ្ចប់​អភិវឌ្ឍន៍ ភាសា និង​បំបាត់​កំហុស"
+
+msgid "Show distribution:"
+msgstr "បង្ហាញ​ការ​ចែកចាយ ៖"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "បង្ហាញ​កញ្ចប់​ជាច្រើន​ទៀត​សម្រាប់​ការ​ចែកចាយ​ដែល​គ្មាន​ការ​គាំទ្រ"
+
+msgid "Show more..."
+msgstr "បង្ហាញ​ច្រើនទៀត..."
+
+msgid "Show other versions"
+msgstr "បង្ហាញ​កំណែ​ផ្សេងទៀត"
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "បង្ហាញ​កញ្ចប់​ដែល​បាន​ដំឡើង"
+
+msgid "Show unsupported packages"
+msgstr "បង្ហាញ​កញ្ចប់​ដែល​មិន​គាំទ្រ"
+
+msgid "Silver Sponsor"
+msgstr "អ្នកឧបត្ថម្ភ Silver​"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"ការ​ចែកចាយ​ផ្ទាល់​មួយ​ចំនួន​ត្រូវ​បាន​ធ្វើឡើង​ដោយ​ផ្អែកលើ​អូផឹន​ស៊ូស៊ី ។ អ្នក​ដែល​ចាប់​អារម្មណ៍​ក្នុង​ការស្ថាបនា​គំរូ​"
+"អ្វីមួយ​តាម​គេ អាច​មើល​តាមវិបសាយ​ <a href=\"http://susestudio.com/\">SUSE Studio</a> ។"
+
+msgid "Source"
+msgstr "ប្រភព"
+
+msgid "Sponsored by"
+msgstr "​ឧបត្ថម្ភ​ដោយ"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "ឧបត្ថម្ភ​ដោយ AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "ឧបត្ថម្ភ​ដោយ ៖ ប្រព័ន្ធ B1"
+
+#, fuzzy
+msgid "Sponsored by: Heinlein"
+msgstr "​ឧបត្ថម្ភ​ដោយ"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "ឧបត្ថម្ភ​ដោយ​ ៖ ផ្លាស់ប្ដូរ IP"
+
+#, fuzzy
+msgid "Sub-Packages"
+msgstr "កញ្ចប់​រង ៖"
+
+msgid "Support"
+msgstr "គាំទ្រ"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "Then run the following as <strong>root</strong>"
+msgstr "សម្រាប់​ <strong>%s</strong> ដំណើរការ​អ្វី​ៗ​ដូច​ខាងក្រោម​ជា <strong>root</strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"ស៊ីឌី​នេះ​មាន​កម្មវិធី​ដែល​ចែកចាយ​ដោយ​សេរី ដោយ​ស្ថិត​នៅ​ក្រោម​អាជ្ញាប័ណ្ណ​មាន​កម្មសិទ្ធិ ប៉ុន្តែ​មិន​អនុញ្ញាត​ឲ្យ​រួម​"
+"បញ្ចូល​ទៅ​ក្នុង​មេឌៀ​ដំឡើង​ចម្បង​ជាមួយ​នឹង​កម្មវិធី​ប្រភព​កូដចំហ​ដែល​ឥត​គិត​ថ្លៃ​នោះ​ទេ ។​ គ្រប់​កម្មវិធី​​ដែល​នៅ​ក្នុង​ស៊ីឌី​"
+"នេះ អាច​នឹង​ត្រូវ​បាន​ទាញ​យក​ពី​ឃ្លាំង​របស់ NON-OSS ។"
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"កំណែ​នេះ​រត់​លើ​កុំព្យូទ័រ​ទាំងអស់ រួមមាន​កុំព្យូទ័រ​​ដែល​គាំទ្រ ៦៤ ប៊ីត ។ ប្រសិនបើ​ អ្នក​មាន​ RAM ​ធំជាង ៣ "
+"ជីកាបៃ ​អ្នក​គួរ​តែ​ប្រើ​កុំព្យូទ័រ​ ៦៤ ប៊ីត ។ អូផឹន​ស៊ូស៊ី មិន​គាំទ្រ​ប្រព័ន្ធ​ដំណើរការ​មុន​​ Pentium ទេ - ស៊ីឌី​បន្ត​"
+"ផ្ទាល់​គាំទ្រ​តែ i686 (មុន និង​ក្រោយ Pentium នេះ​តែ​ប៉ុណ្ណោះ) ។"
+
+msgid "Type of Computer"
+msgstr "ប្រភេទ​កុំព្យូទ័រ"
+
+msgid "Unsupported distributions:"
+msgstr "ការ​ចែកចាយ​ដែល​គ្មាន​ការ​គាំទ្រ ៖"
+
+#, fuzzy
+#| msgid ""
+#| "User manuals are available from <a href=\"http://doc.opensuse.org\">doc."
+#| "opensuse.org</a>, for example the <a href=\"http://doc.opensuse.org/"
+#| "products/opensuse/openSUSE/opensuse-startup/\">Official Start-Up Guide</"
+#| "a>."
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"សៀវភៅ​អ្នក​ប្រើ​អាច​រក​បាន​ពី <a href=\"http://doc.opensuse.org\">doc.opensuse.org</"
+"a> ឧទាហរណ៍ <a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/"
+"opensuse-startup/\">​ចាប់ផ្ដើម​មគ្គុទ្ទេសក៍​ផ្លូវការ​</a> ។"
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"ការ​ប្រើប្រាស់ <a href=\"http://en.opensuse.org/index.php?title=SDB:"
+"BitTorrent_and_openSUSE\">BitTorrent</a> ត្រូវ​បាន​ផ្ដល់​អនុសាសន៍​នៅ​លើ​តំណ​យឺត ជាពិសេស​ នៅ​ពេល​"
+"ដែល​ទាញ​យក​រូបភាព​ឌីវីឌី ។ ការ​ទាញ​យក​តាម BitTorrent មាន​ផលប្រយោជន៍​ច្រើន​យ៉ាង​ ម៉ាស៊ីន​ភ្ញៀវ​ការពារ​មិន​"
+"ឲ្យ​ខូច​ទិន្នន័យ និង​ជួយ​បន្ធូរ​ទំហំ​ផ្ទុក​នៅ​លើ​ម៉ាស៊ីន​បម្រើ ដោយ​ការ​ចូលរួម​ក្នុង​ការ​ផ្ទុក​ឡើង - ប្រសិនបើ មាន​មនុស្ស​"
+"ចូលរួម​ច្រើន​គ្នា​ វា​នឹង​ជួយ​ធ្វើឲ្យ​មាន​លក្ខណៈ​កាន់​តែ​លឿន​ជាង​ម៉ាស៊ីន​បម្រើ​កណ្ដាល ។ លើស​ពី​នេះ​ទៀត វា​អនុញ្ញាត​"
+"ឲ្យ​អ្នក​បញ្ឈប់​ការ​ទាញ​យក​នៅ​ពេល​ណាមួយ ឬ​បន្ត​វា​នៅ​ពេល​ក្រោយ​បាន​ទៀត​ផង ។"
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "ផ្ទៀងផ្ទាត់​ការ​ទាញ​យក​របស់​អ្នក (ជា​ជម្រើស សម្រាប់​អ្នក​ជំនាញ)"
+
+msgid "Version"
+msgstr "កំណែ"
+
+msgid "We offer three different checksums:"
+msgstr "យើង​បាន​ផ្ដល់​ឆេកសាំ​បី​ខុស​ៗ​គ្នា​ ៖​"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"នៅ​ពេល​ទាញ​យក​រូបភាព​ផ្សេង​ ក្រៅ​ពី​ស៊ីឌី​សម្រាប់​ការ​ដំឡើង​តាម​បណ្ដាញ អ្នក​ត្រូវ​បាន​ <i>ណែនាំ</i> ឲ្យ​ប្រើ​"
+"កម្មវិធី​ទាញ​យក​ដ៏​ត្រឹមត្រូវ​ ដើម្បី​កាត់​បន្ថយ​ការ​ខូចខាត​ទិន្នន័យ ។"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"អ្នក​អាច​ផ្ទៀងផ្ទាត់​ឯកសារ​នៅ​ក្នុង​ពេល​កំពុង​ដំណើរការ​ទាញ​យក​បាន ។ ឧទាហរណ៍ ឆេកសាំ (SHA256) នឹង​ត្រូវ​"
+"បាន​ប្រើ​ដោយ​ស្វ័យប្រវត្តិ​ ប្រសិនបើ អ្នក​ជ្រើស​យក​ <a href='http://en.opensuse.org/SDB:"
+"Metalink'>Metalink</a> នៅ​ក្នុង​វាល​ខាង​លើ ហើយ​ប្រើ​កម្មវិធី​បន្ថែម DownThemAll! នៅ​ក្នុង <a "
+"href='http://en.opensuse.org/Firefox'>Firefox</a> ។"
+
+msgid "gpg signature"
+msgstr "ហត្ថលេខា​ gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.2/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"នៅ​តែ​ជា​ឆេកសាំ​ដែល​ត្រូវ​បាន​ប្រើប្រាស់​ទូទៅ​ដដែល ។ កម្មវិធី​ដុត ISO ជាច្រើន​បង្ហាញ​វា​នៅ​ខាង​ស្ដាំ​ មុន​នឹង​"
+"ដុត ។"
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "ត្រូវ​បាន​ដឹង​បន្តិចបន្តួច ប៉ុន្តែ​ឆេកសាំ​មាន​សុវត្ថិភាព​ជាង​ md5 ។"
+
+msgid "md5 checksum"
+msgstr "md5 checksum"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"ផ្ដល់​នូវ​សុវត្ថិភាព​បំផុត​ ព្រោះ​អ្នក​អាច​ផ្ទៀងផ្ទាត់​ថា​អ្នក​ណា​បាន​ចុះហត្ថលេខា​លើ​វា ។ វា​គួរតែ​ជា <tt>%s</"
+"tt> ។"
+
+msgid "openSUSE Countdown"
+msgstr "ការ​រាប់​ថយ​ក្រោយ​របស់​អូផឹនស៊ូស៊ី​"
+
+msgid "openSUSE Derivatives"
+msgstr "ដែល​ចម្លង​តាម​អូផឹន​ស៊ូស៊ី"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"អូផឹន​ស៊ូស៊ី​អាច​មាន​​តាមរយៈ http (តំណ​ផ្ទាល់) ឬ BitTorrent ។ ស៊ីឌី​សម្រាប់​ការ​ដំឡើង​តាម​បណ្ដាញ​គឺ​អាច​ប្រើ​"
+"បាន​តែ​តាម​រយៈ http ។"
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "អូផឹន​ស៊ូស៊ី​គាំទ្រ​តែកុំព្យូទ័រ​ ៣២ ប៊ីត និង​ ៦៤ ប៊ីត ។"
+
+msgid "see Derivatives on wiki"
+msgstr "មើល​ការ​ចម្លង​តាម​នៅ​​​លើ​វិគី"
+
+msgid "sha1 checksum"
+msgstr "sha1 checksum"
+
+msgid "switch to"
+msgstr "ប្ដូរ​ទៅជា"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "កំហុស​ខាងក្នុង​បាន​កើតឡើង :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "សូម​វាយ​បញ្ចូល​តួអក្សរ​លើស​ពី ២"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#~ msgid "Last searches:"
+#~ msgstr "ស្វែងរក​ច្រើន ៖​"
+
+#~ msgid "Statistics"
+#~ msgstr "ស្ថិតិ"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "ចុច​ម្ដង ដើម្បី​ទាញ​យក ៖"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "ស្វែងរក​ច្រើន​ដោយ​មិន​ចុច ៖"
+
+#~ msgid "Top searches:"
+#~ msgstr "ស្វែងរក​ច្រើន ៖​"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "បច្ចុប្បន្ន​នេះ យើង​មិន​ទាន់​មាន​រូបថត​ដើម​ ដែល​ថ្មី​ជាង​ឯកសារ​​ចេញ​ផ្សាយចុង​ក្រោយ​របស់​អូផឹន​ស៊ូស៊ី​ទេ ។ ចំពោះ​"
+#~ "ព័ត៌មាន​លម្អិត <br/>សូម​មើល​ <a href='http://en.opensuse.org/Portal:"
+#~ "Factory'>http://en.opensuse.org/Portal:Factory</a> ។"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "ស៊ីឌី​បន្ត​ផ្ទាល់​នេះ​មាន​តែ​ភាសា​បួន​ប៉ុណ្ណោះ (អង់គ្លេស អាល្លឺម៉ង់ រុស្ស៊ី និង​អ៊ីតាលី) ។ ប្រសិនបើ​អ្នក​ចង់​ឲ្យ​មាន​"
+#~ "ការ​គាំទ្រ​សម្រាប់​ភាសា​ផ្សេង​ទៀត​ អ្នក​ចាំបាច់​​ត្រូវ​តែ​ទាញ​វា​យក​ពី​អ៊ីនធឺណិត​​ក្នុង​អំឡុង​ពេល​ដំឡើង ឬ​ពេល​ណាមួយ​"
+#~ "បន្ទាប់​នោះ ។ ប្រសិនបើ ​អ្នក​ចូល​ដំណើរការ​អ៊ីនធឺណិត​យ៉ាង​ងាយស្រួល ឬ​ប្រសិន​បើ​អ្នក​ប្រើ​ឌីវីឌី​ដែល​មាន​គ្រប់​"
+#~ "ភាសា អ្នក​មិន​ចាំបាច់ប្រើ​ស៊ីឌី​នេះ​ទេ ។"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "បន្ទាប់ពី​បាន​ទាញ​យក​រូបភាព ISO ដោយ​ជោគជ័យ​ហើយ ​ដុត​រូបភាព​ដោយ​ប្រើ​កម្មវិធី​ដុត​ស៊ីឌី ឬ​ឌីវីឌី ​ដែល​អ្នក​ពេញ​"
+#~ "ចិត្ត ។ សូម​ <em>កុំ</em> ដុត​ស៊ីឌី/ឌីវីឌី​ទិន្នន័យ​ឲ្យ​សោះ ប៉ុន្តែ​យក​ល្អ​គួរ​តែ​ជ្រើស​ ជម្រើស​ដុត​រូបភាព​ ISO ។"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "សូម​ប្រើ​ខ្សែ​អក្សរ​ស្វែង​រក​យ៉ាង​ហោច​ណាស់​ ២ ​តួអក្សរ"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "បាន​ប្ដូរ​ទៅ​ការ​ផ្គូផ្គង​ជាក់លាក់ ដោយ​សារ​តែ​ចុច​ច្រើន​នៅ​លើ​ការ​ស្វែងរក​ខ្សែអក្សរ​រង ។"
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "សូម​ប្រាកដ​នៅ​ក្នុង​ការ​ស្វែងរក​ ការ​ស្វែងរក​បាន​ឈាន​ដល់​កម្រិត​កំណត់​ហើយ ។"
+
+#~ msgid "Could not perform search: "
+#~ msgstr "មិន​អាច​អនុវត្ត​ការ​ស្វែងរក​បាន​ទេ ៖ "
+
+#~ msgid "Popular Software"
+#~ msgstr "កម្មវិធី​ដែល​គេ​និយម​"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "ទិញ​អូផឹន​ស៊ូស៊ី"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "ដំឡើង​តាមរយៈ​ចុច​ម្ដង"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "ទាញយក​កញ្ចប់​ដោយ​ដៃ"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "ទៅកាន់​គម្រោង OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[បណ្ដុំ​កម្មវិធី]"
+
+#~ msgid "Search Results"
+#~ msgstr "លទ្ធផល​ស្វែងរក"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "រក​មិន​ឃើញ​កញ្ចប់​នៅ​ក្នុង​សេវា​ស្ថាបនា​អូផឹន​ស៊ូស៊ី​ ដែល​ផ្គូផ្គង​នឹង​សំណួររបស់​អ្នក​ទេ ។"
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "សម្រាំង %d និង​គោល​ពីរ %d ពី​កញ្ចប់​ប្រភព %d"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "រូបថត​អេក្រង់​របស់"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "ស្ថិតិ​ស្វែងរក ៖"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "ស្ថិតិ​ទាញយក ៖"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "ស្វែងរក ហើយ​​ដំឡើង​កញ្ចប់​កម្មវិធី​​ពី <a href=\"http://build.opensuse.org\">សេវា​ស្ថាបនា​"
+#~ "អូផឹន​ស៊ូស៊ី​</a> ៖​"
+
+#~ msgid "Search options"
+#~ msgstr "ជម្រើស​ស្វែងរក​"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "រួម​គម្រោង​ផ្ទះ​អ្នក​ប្រើ"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "មិន​រាប់​បញ្ចូល​កញ្ចប់​បំបាត់​កំហុស​ឡើយ​"
+
+#~ msgid "Additional Information"
+#~ msgstr "ព័ត៌មាន​បន្ថែម"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">ចាប់ផ្ដើម​ការ​ដំឡើង​រហ័ស</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "ទិញ​អូផឹន​ស៊ូស៊ី ១១.៣"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "ទិញ​អូផឹន​ស៊ូស៊ី ១១.៣ !"

--- a/locale/ko/software.po
+++ b/locale/ko/software.po
@@ -1,0 +1,1193 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.ko\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2010-08-31 02:22+0900\n"
+"Last-Translator: Yunseok Choi <xein@naver.com>\n"
+"Language-Team: Korean <xein@naver.com>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Poedit-Language: Korean\n"
+"X-Poedit-Country: KOREA, REPUBLIC OF\n"
+"X-Poedit-SourceCharset: utf-8\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr ""
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "64 비트 PC"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE_License\">사용권</a>"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">메타링크</a>는 FTP/HTTP/비트토런"
+"트 같은 다양한 다운로드 방법을 쉽고 간단하게하기 위해 만들어진 오픈 스텐다드 "
+"입니다. 이것은 ISP나 기관, 단체 등에 의해 P2P가 제한되는 환경에서 ISO 파일을 "
+"다운로드 할 수 있게 해줍니다. 클라이언트는 다수의 미러 사이트에 각각 동시에 "
+"접속할 수 있고, 빠른 전송속도를 자랑합니다. 거기다 자동으로 오류/데이터 깨짐 "
+"감지 기능도 있습니다. 단, 메타링크를 처리하기 위한 특별한 프로그램이 필요합니"
+"다."
+
+#, fuzzy
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE_License\">사용권</a>"
+
+#, fuzzy
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>출시 정보</a> (최신판)"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "공식 설명서"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "중요하지 않은 업데이트"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"CD나 USB 스틱으로 구동 할 수 있는 그놈 데스크탑 입니다.<br/> 구동한 뒤에는 설"
+"치할 수도 있습니다.(업그레이드 불가)"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"CD나 USB 스틱으로 구동 할 수 있는 KDE 데스크탑 입니다.<br/> 구동한 뒤에는 설"
+"치할 수도 있습니다.(업그레이드 불가)"
+
+msgid "Add repository and install manually"
+msgstr ""
+
+msgid "Add-On Downloads (optional)"
+msgstr "Add-On 다운로드 (옵션)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+#  frame
+#, fuzzy
+msgid "App Browser"
+msgstr "응용프로그램 탐색기"
+
+#, fuzzy
+msgid "Available Images"
+msgstr "사용 가능한 업데이트"
+
+msgid "BitTorrent"
+msgstr "비트토런트"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"DVD 또는 CD로 부팅합니다. 사용자의 컴퓨터에 따라 자동으로 CD/DVD로 부팅될 수"
+"도 있습니다. 그렇지 않은경우 BIOS 설정(CMOS)에서 CD/DVD 로 먼저 부팅할 수 있"
+"도록 설정을 조정하세요."
+
+msgid "Bronze Sponsor"
+msgstr "브론즈 스폰서"
+
+#, fuzzy
+msgid "Browser incompatibility"
+msgstr "호환되지 않는 해시"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "CD/DVD이미지 굽기"
+
+#, fuzzy
+msgid "Categories"
+msgstr "범주"
+
+msgid "Category"
+msgstr "범주"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"설치 미디어를 선택하고, 다운로드 버튼을 누르면 다운로드가 시작됩니다. 또, 사"
+"용하고 있는 컴퓨터 종류나 다른 다운로드 방법을 선택할 수도 있습니다."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "클릭하여 다운로드"
+
+msgid "Community"
+msgstr "커뮤니티"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"데스크탑 및 서버용으로 사용할 수 있는 용량이 큰 설치 매체 입니다.<br/> 이것"
+"을 사용하여 설치 또는 업그레이드를 할 수 있습니다."
+
+#, fuzzy
+msgid "Countdown"
+msgstr "종료"
+
+#, fuzzy
+msgid "Country"
+msgstr "종료"
+
+msgid "Development"
+msgstr "개발"
+
+msgid "Development Version"
+msgstr "개발 버전"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "KDE 개발 꾸러미"
+
+#, fuzzy
+msgid "Development-"
+msgstr "개발"
+
+#, fuzzy
+msgid "Direct Install"
+msgstr "원클릭 설치"
+
+msgid "Direct Link"
+msgstr "직접 다운"
+
+msgid "Documentation"
+msgstr "설명서"
+
+#, fuzzy
+msgid "Don't show this warning the next time"
+msgstr "이 메시지를 다시 보이지 않습니다."
+
+msgid "Download"
+msgstr "다운로드"
+
+msgid "Download %s"
+msgstr "%s 다운로드"
+
+msgid "Download Help"
+msgstr "다운로드 도움말"
+
+msgid "Download Method"
+msgstr "다운로드 방법"
+
+#, fuzzy
+msgid "Download appliance from %s"
+msgstr "그룹 다운로드 중"
+
+msgid "Download&nbsp;DVD"
+msgstr "DVD&nbsp;다운로드"
+
+msgid "Download&nbsp;GNOME"
+msgstr "그놈&nbsp;다운로드"
+
+msgid "Download&nbsp;KDE"
+msgstr "KDE&nbsp;다운로드"
+
+msgid "Download&nbsp;Network"
+msgstr "네트워크&nbsp;다운로드"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "KDE&nbsp;다운로드"
+
+msgid "Downloads"
+msgstr "다운로드"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"온라인 저장소로부터 설치 시스템과 모든 꾸러미를 다운로드하여 설치 합니다.<br/"
+"> 설치 또는 업그레이드가 가능합니다."
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "언어 확장"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "언어 확장 (32비트)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "언어 확장 (64비트)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"은 서명을 검증하는 기능으로 보안 유지에 최적의 방법입니다. 지문은 <tt>%s</"
+"tt> 입니다."
+
+msgid "Games"
+msgstr "게임"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+
+msgid "Getting Help"
+msgstr "도움말 보기"
+
+msgid "Gold Sponsor"
+msgstr "골드 스폰서"
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr "헤더 로고"
+
+msgid "Help on Download Method"
+msgstr "다운로드 방법 도움말"
+
+# src/config/routing.y2cc:11
+msgid "Help on Type of Computer"
+msgstr "컴퓨터 종류 도움말"
+
+msgid "How to Proceed"
+msgstr "실행 방법"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"직접 다운로드를 할 때, 가장 빠른 미러 사이트에서 다운로드 하기 위해 다운로드 "
+"리다이렉터가 사이트를 감지하지 못할때 직접 미러를 선택하여 다운로드 할 수 있"
+"습니다."
+
+msgid "Image:"
+msgstr ""
+
+#, fuzzy
+msgid "Install package %s / %s"
+msgstr "꾸러미 설치"
+
+#, fuzzy
+msgid "Install pattern %s / %s"
+msgstr "꾸러미 설치"
+
+msgid "Install using One Click Install"
+msgstr ""
+
+# /usr/share/applications/YaST2/sw_source.desktop
+msgid "Installation Guides"
+msgstr "설치 길잡이"
+
+msgid "Installation Medium"
+msgstr "설치 미디어"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"유감스럽게도 KDE3의 컹커러는 지원하지 않습니다. KDE3로는 이 페이지를 이용할 "
+"수 없는 것처럼 자바스크립트 구현에도 버그가 있습니다. <a href='%s'>계속</a>하"
+"기 전에 꼭 자바스크립트를 비활성화 하시기 바랍니다."
+
+# label for language selection
+msgid "Language"
+msgstr "언어"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "32 비트 PC"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32&nbsp;비트&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "그놈 라이브"
+
+msgid "Live KDE"
+msgstr "KDE 라이브"
+
+#, fuzzy
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"대부분의 응용프로그램은 다운로드 체크섬을 검사 할 수 있습니다. 파일이 깨지면 "
+"정상적인 설치를 할 수 없으므로 다운로드한 ISO 파일이 깨지지 않고 제대로 받아"
+"졌는지 확인하는것은 매우 중요합니다. 오픈수세에서는 3개의 각각 다른 체크섬을 "
+"제공합니다:"
+
+msgid "Metalink"
+msgstr "메타링크"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"오픈수세 다운로드에 관한 기타 정보는 <a href=\"http://en.opensuse.org/"
+"Download_Help\">다운로드 도움말</a>을 참조하세요."
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"최근 나오는 대부분의 새 컴퓨터(AMD64, 인텔64)는  <a href=\"http://en."
+"wikipedia.org/wiki/X86-64\">x86-64</a>를 지원하지만, 일부 노트북, 넷북 CPU는 "
+"이를 지원하지 않을 수도 있습니다. 따라서 위키피디아 같은 사이트를 참조하여 사"
+"용자의 컴퓨터가 x86_64를 지원하는지 확인 하는것이 좋습니다."
+
+msgid "Multimedia"
+msgstr "멀티미디어"
+
+msgid "Need help?"
+msgstr "도움이 필요하신가요?"
+
+msgid "Network"
+msgstr "네트워크"
+
+#, fuzzy
+msgid "No appliance data for %s"
+msgstr "%s %s에 대한 정보:"
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+#, fuzzy
+msgid "No data for %s / %s"
+msgstr "%s %s에 대한 정보:"
+
+#, fuzzy
+msgid "No description found..."
+msgstr "저장소가 없습니다."
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+#, fuzzy
+msgid "No packages found matching your search. "
+msgstr "'%s' 에 해당하는 꾸러미는 설치되고 있지 않습니다."
+
+msgid "NonOSS CD"
+msgstr "NonOSS(비 오픈소스 소프트웨어) CD"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "scdb 사용 할 수 없음"
+
+msgid "Official Manuals"
+msgstr "공식 설명서"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+#, fuzzy
+msgid "Package %s not found..."
+msgstr "'%s' 패치를 찾을 수 없습니다."
+
+msgid "Package Repositories"
+msgstr "꾸러미 저장소"
+
+msgid "Package Search"
+msgstr "꾸러미 검색"
+
+#, fuzzy
+msgid "Packages for %s:"
+msgstr "Cleaning packages for '%s' 에 대한 꾸러미를 청소 중입니다."
+
+msgid "Pick Mirror"
+msgstr "미러 가져오기"
+
+msgid "Platinum Sponsor"
+msgstr "플래티넘 스폰서"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+#, fuzzy
+msgid "Related categories:"
+msgstr "범주"
+
+msgid "Released Version"
+msgstr "출시 버전"
+
+msgid "Reporting Bugs"
+msgstr "버그 보고"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "시스템 복구(콘솔)"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"CD나 USB 스틱으로 구동 할 수 있는 KDE 데스크탑 입니다.<br/> 구동한 뒤에는 설"
+"치할 수도 있습니다.(업그레이드 불가)"
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "md5 체크섬"
+
+msgid "Search"
+msgstr "검색"
+
+#, fuzzy
+msgid "Select Your Operating System"
+msgstr "운영체제 시작"
+
+#, fuzzy
+msgid "Select the image type"
+msgstr "화면 타입을 선택하세요."
+
+msgid "Show"
+msgstr ""
+
+#, fuzzy
+msgid "Show development, language and debug packages"
+msgstr "KDE 개발 꾸러미"
+
+#, fuzzy
+msgid "Show distribution:"
+msgstr "알 수 없는 배포판"
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+msgid "Show more..."
+msgstr ""
+
+#, fuzzy
+msgid "Show other versions"
+msgstr "기타 버전"
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "설치된 꾸러미 표시"
+
+#, fuzzy
+msgid "Show unsupported packages"
+msgstr "설치된 꾸러미 표시"
+
+msgid "Silver Sponsor"
+msgstr "실버 스폰서"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+
+msgid "Source"
+msgstr "소스"
+
+msgid "Sponsored by"
+msgstr "스폰서"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "스폰서 AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "스폰서: B1 Systems"
+
+#, fuzzy
+msgid "Sponsored by: Heinlein"
+msgstr "스폰서"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "스폰서: IP Exchange"
+
+#, fuzzy
+msgid "Sub-Packages"
+msgstr "부가꾸러미 숨김(_H)"
+
+msgid "Support"
+msgstr "지원"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr "이 CD에는 자유 소프트웨어 배포본 "
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"이 버전은 모든 32비트 PC에서 실행할 수 있습니다(64비트도 가능). 만약 64비트 "
+"컴퓨터를 사용하고 있는데 램이 3GB가 넘는다면 64비트 버전을 사용하는것이 좋습"
+"니다. 오픈수세는 펜티엄 이전 버전은 지원하지 않습니다. 특히 라이브CD는 "
+"i686(펜티엄 프로 및 그 이후에 나온 프로세서)을 지원합니다."
+
+# src/config/routing.y2cc:11
+msgid "Type of Computer"
+msgstr "컴퓨터 종류"
+
+#, fuzzy
+msgid "Unsupported distributions:"
+msgstr "알 수 없는 배포판"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"다운로드 속도가 느리면 비트토런트 이용을 권장합니다. 대게 용량이 큰 DVD 버전"
+"을 다운로드 받을 때 유리합니다. 비트토런트는 클라이언트에서 데이터를 올바르"
+"게 받았는지 확인 할 수 있고, 다운로드 하는 동시에 다른 사용자에게 업로드 하"
+"는 구조로 되어 있기 때문에 서버의 부하를 줄일 수 있는 장점이 있습니다. 사용"
+"자 수가 많아지면 많아질수록 중앙서버로부터 직접 다운로드 하는것보다 훨씬 빠르"
+"게 다운로드 할 수 있습니다. 특히 다운로드 일시 정지가 가능하고, 필요할 때 다"
+"운로드를 재개 할 수도 있습니다. 자세한 내용은 <a href=\"http://en.opensuse."
+"org/BitTorrent_and_openSUSE\">비트트런트와 오픈수세</a>를 참조하세요."
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "다운로드된것 확인 (전문가용 옵션)"
+
+msgid "Version"
+msgstr "버전"
+
+msgid "We offer three different checksums:"
+msgstr ""
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"네트워크 설치 CD 이외 이미지의 다운로드는 다운로드 할 때 데이터가 깨지는 경우"
+"를 피하기 위해 다운로드 관리자 프로그램을 사용하여 다운로드할 것을 <i>권장</"
+"i>합니다. 용량이 큰 파일은 다운로드시에 데이터가 깨지는 경우가 자주 발생합니"
+"다."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+
+msgid "gpg signature"
+msgstr "gpg 서명"
+
+#, fuzzy
+msgid "http://doc.opensuse.org/"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"은 일반적으로 사용되고 있는 체크섬입니다. 많은 ISO(이미지)굽기 소프트웨어는 "
+"굽기 전에 이 체크섬 값을 표시합니다."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "은 유명하지는 않지만 md5 보다 엄밀한 검증을 할 수 있습니다."
+
+msgid "md5 checksum"
+msgstr "md5 체크섬"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"은 서명을 검증하는 기능으로 보안 유지에 최적의 방법입니다. 지문은 <tt>%s</"
+"tt> 입니다."
+
+#, fuzzy
+msgid "openSUSE Countdown"
+msgstr "오픈수세 11.3 카운터"
+
+msgid "openSUSE Derivatives"
+msgstr "오픈수세 계열"
+
+#, fuzzy
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"오픈수세는 http 직접 다운로드나 비트토런트를 이용하여 다운로드 할 수 있습니"
+"다. 네트워크 설치 CD는 http에서만 받을 수 있습니다."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "오픈수세는 32비트와 64비트 컴퓨터를 지원합니다."
+
+#, fuzzy
+msgid "see Derivatives on wiki"
+msgstr "오픈수세 계열"
+
+msgid "sha1 checksum"
+msgstr "sha1 체크섬"
+
+msgid "switch to"
+msgstr "전환"
+
+#, fuzzy
+#~ msgid "An internal error happened :-("
+#~ msgstr "내부 시스템 오류 발생"
+
+#, fuzzy
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "암호가 너무 짧습니다(최소 8자로 해야 합니다)."
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~ msgid "Last searches:"
+#~ msgstr "모든 검색에 대해"
+
+#, fuzzy
+#~ msgid "Statistics"
+#~ msgstr "고정"
+
+#, fuzzy
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "다운로드"
+
+#, fuzzy
+#~ msgid "Top searches:"
+#~ msgstr "모든 검색에 대해"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "라이브 CD는 4개의 언어(영어, 독일어, 러시아어, 이탈리아어)만 포함되어 있습"
+#~ "니다. 다른 언어 지원이 필요하다면 설치하는 동안이나 나중에 다운로드 받을 "
+#~ "수 있습니다. 인터넷에 쉽게 접속 할 수 있거나, DVD에 포함된 언어를 사용할 "
+#~ "수 있으면 이 CD가 필요 없습니다."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "ISO 이미지를 다 다운로드한 뒤에 자주 사용하는 이미지 굽기 프로그램으로 CD"
+#~ "이미지는 공 CD에, DVD이미지는 공 DVD에 굽습니다. <em>이미지 안의 데이터를 "
+#~ "CD/DVD에 굽지 마세요.</em>"
+
+#, fuzzy
+#~| msgid "Password is too short (must have at least 8 characters)."
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "암호가 너무 짧습니다(최소 8자로 해야 합니다)."
+
+#, fuzzy
+#~| msgid "Could not find %s"
+#~ msgid "Could not perform search: "
+#~ msgstr "%s 를 찾을 수 없음"
+
+#~ msgid "Popular Software"
+#~ msgstr "일반 소프트웨어"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "오픈수세 구입"
+
+#~ msgid "1-Click Install"
+#~ msgstr "원클릭 설치"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "직접 꾸러미 다운로드"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "OBS 프로젝트에 가기"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[소프트웨어 모음]"
+
+#~ msgid "Search Results"
+#~ msgstr "검색 결과"
+
+#, fuzzy
+#~| msgid "No packages found that matched your query."
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "검색에 일치하는 꾸러미가 없습니다."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d 모음 및 %d 바이너리(%d 소스 꾸러미로부터)"
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "와인 CVS의 스냅샷"
+
+#, fuzzy
+#~| msgid "Search Domains:"
+#~ msgid "Search Statistics:"
+#~ msgstr "도메인 검색:"
+
+#, fuzzy
+#~| msgid "Download size"
+#~ msgid "Download Statistics:"
+#~ msgstr "다운로드 크기"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "<a href=\"http://build.opensuse.org\">오픈수세 빌드 서비스</a>로부터 소프"
+#~ "트웨어 꾸러미를 검색하고 설치:"
+
+#~ msgid "Search options"
+#~ msgstr "검색 옵션"
+
+#~ msgid "Additional Information"
+#~ msgstr "추가 정보"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "오픈수세 11.3 구입"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "오픈수세 11.3 을 구입!"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "오픈수세 다운로드에 관한 기타 정보는 <a href=\"http://en.opensuse.org/"
+#~ "Download_Help\">다운로드 도움말</a>을 참조하세요."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "이후 순서는 아래를 참고하세요:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "DVD/CD로 설치:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "공식 %s 시작 길잡이"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "단계별 설치 길잡이"
+
+#~ msgid "Network Installation"
+#~ msgstr "네트워크 설치"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Internet Installation"
+#~ msgstr "인터넷 설치"
+
+#~ msgid "More information"
+#~ msgstr "기타 정보"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "소프트웨어 다운"
+
+#~ msgid "Wiki"
+#~ msgstr "위키"
+
+#~ msgid "Build Software"
+#~ msgstr "소프트웨어 빌드"
+
+#~ msgid "User Directory"
+#~ msgstr "사용자 디렉터리"
+
+#~ msgid "Features"
+#~ msgstr "기능"
+
+#~ msgid "News"
+#~ msgstr "뉴스"
+
+#~ msgid "Forums"
+#~ msgstr "포럼"
+
+#~ msgid "Shop"
+#~ msgstr "쇼핑"
+
+#~ msgid "Software"
+#~ msgstr "소프트웨어"
+
+#~ msgid "Software Search"
+#~ msgstr "소프트웨어 검색"
+
+#~ msgid "Update Repositories"
+#~ msgstr "저장소 업데이트"
+
+#~ msgid "Source Repository"
+#~ msgstr "저장소 소스"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "기타 옵션"
+
+#~ msgid "Mirrors"
+#~ msgstr "미러"
+
+#~ msgid "In other languages"
+#~ msgstr "기타 언어"
+
+#~ msgid "Get it"
+#~ msgstr "무료 다운"
+
+#~ msgid "Search Build Service"
+#~ msgstr "빌드 서비스 검색"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "오픈수세 빌드 서비스로부터 추가 소프트웨어 꾸러미를 검색 및 설치 합니다."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "오픈수세 다운로드"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "이 결과로 계속 링크"
+
+#~ msgid "Nothing found"
+#~ msgstr "아무것도 없음"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "오픈수세 빌드 서비스로부터 소프트웨어 검색/설치"
+
+#~ msgid "Searching"
+#~ msgstr "검색"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "데스크탑 및 서버용으로 사용할 수 있는 용량이 큰 설치 매체 입니다. 이것을 "
+#~ "사용하여 설치 또는 업그레이드를 할 수 있습니다."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "CD나 USB 스틱으로 구동 할 수 있는 그놈 데스크탑 입니다. 구동한 뒤에는 설치"
+#~ "할 수도 있습니다.(업그레이드 불가)"
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "CD나 USB 스틱으로 구동 할 수 있는 KDE 데스크탑 입니다. 구동한 뒤에는 설치"
+#~ "할 수도 있습니다.(업그레이드 불가)"
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "온라인 저장소로부터 설치 시스템과 모든 꾸러미를 다운로드하여 설치 합니다. "
+#~ "설치와 업그레이드가 가능합니다."
+
+#~ msgid "Metalinks"
+#~ msgstr "메타링크"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "오픈수세 11.1을 준비해보세요!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "리눅스 뉴비를 위한 최고의 선택! 오픈수세 입니다. &mdash; 아주 쉽고, 자세하"
+#~ "게 기술된 설명서와 32비트 64비트에 설치할 수 있는 미디어가 들어있고, 90일"
+#~ "동안 설치를 지원받을 수 있습니다."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "오픈수세 11.1은 <a href=\"http://en.opensuse.org/Buy_openSUSE\">온라인</"
+#~ "a> 쇼핑이나 지역 구매처에서 구할 수 있습니다."

--- a/locale/lt/software.po
+++ b/locale/lt/software.po
@@ -1,0 +1,1178 @@
+# translation of software-opensuse-org.po to Lietuvių
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# Mindaugas Baranauskas <opensuse.lietuviu.kalba@gmail.com>, 2009, 2010, 2011, 2012, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-09 15:53+0200\n"
+"Last-Translator: Mindaugas Baranauskas <opensuse.lietuviu.kalba@gmail.com>\n"
+"Language-Team: Lithuanian <opensuse-translation@opensuse.org>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n%10>=2 && (n%100<10 || n"
+"%100>=20) ? 1 : n%10==0 || (n%100>10 && n%100<20) ? 2 : 3);\n"
+"X-Generator: Lokalize 1.5\n"
+
+msgid " and "
+msgstr " ir "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} nėra palaikoma.\""
+
+msgid "(hide)"
+msgstr "(slėpti)"
+
+msgid "(show)"
+msgstr "(rodyti)"
+
+msgid "... and keep us informed"
+msgstr "... ir visuomet perspėti"
+
+msgid "... get other marketing stuff"
+msgstr "... įsigykite kitų prekių"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4,7GB DVD (tinka ir USB atmintukui)"
+
+msgid "64 Bit PC"
+msgstr "64 bitų AK"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"pradžiamokslis</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> yra atviras "
+"standartas, kuris apjungia įvairius rinkmenų siuntimosi būdus (FTP/HTTP/"
+"BitTorrent) į vieną formatą, leidžiantį paprasčiau siųstis iš interneto. Tai "
+"naudinga siunčiantis ISO atvaizdžius; ypač žmonėms, kurie negali naudoti P2P "
+"dėl jų ISP ar universiteto apribojimų. Kadangi klientai sudaro daugybę "
+"ryšius su daugybe veidrodžių, galima pasiekti didžiulę siuntimosi spartą. Be "
+"to, tai leidžia automatiškai aptikti klaidą ir ją ištaisyti. Tam reikia "
+"specialios parsisiuntimo programos."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licencija</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Laidos informacija</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>oficiali laida</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>oficialus atnaujinimas</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"GNOME darbalaukį galite paleisti iš %s ar USB atmintuko.<br/>Gali būti "
+"įdiegtas toks, koks yra (neskirtas naujovinimui)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"KDE darbalaukį galite paleisti iš %s ar USB atmintuko.<br/>Gali būti "
+"įdiegtas toks, koks yra (neskirtas naujovinimui)."
+
+msgid "Add repository and install manually"
+msgstr "Pridėti saugyklą ir diegti rankiniu būdu"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Papildomų produktų siuntimasis (pasirinktinai)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Parsiuntę ISO atvaizdį(-džius), sukurkite iš USB atmintuko paleidžiamą "
+"sistemą arba atvaizdį įrašykite į DVD diską (ar CD, jei atvaizdis telpa)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Visi duomenys naudojami tik  siunčiant openSUSE reklaminę medžiagą\n"
+"          ir nebus perduoti trečiosioms šalims. Duomenis\n"
+"          saugome tam, kad  galėtume naudotojus informuoti apie naujai\n"
+"          pasirodžiusią versiją. Prašymai peržiūri atsižvelgiant į JAV\n"
+"          eksporto draudimus. Daugiau informacijos apie draudimus ir šalių "
+"sąrašą <a href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://"
+"en.wikipedia.org/wiki/United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Programų paieška"
+
+msgid "Available Images"
+msgstr "Galimi parsisiųsti atvaizdžiai"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Paleiskite iš DVD, CD ar USB atmintuko. Jei kompiuteris savaime "
+"nepasileidžia iš pasirinkto kaupiklio, įeikite į BIOS nuostatas ir "
+"įgalinkite paleidimą iš to kaupiklio."
+
+msgid "Bronze Sponsor"
+msgstr "Bronzinis rėmėjas"
+
+msgid "Browser incompatibility"
+msgstr "Nesuderinama saityno naršyklė"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "CD/DVD atvaizdžių įrašymas"
+
+msgid "Categories"
+msgstr "Kategorijos"
+
+msgid "Category"
+msgstr "Kategorija"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Diegimo laikmeną pasirinksite ją spragtelėdami, o norėdami pradėti siųstis, "
+"nuspauskite mygtuką „Siųstis“. Savo nuožiūra pasirinkite kompiuterio tipą "
+"arba kitą siuntimosi būdą."
+
+msgid "Click here to display these alternative versions."
+msgstr "Norėdami matyti šias alternatyvas, spustelėkite šią nuorodą."
+
+msgid "Click to Download"
+msgstr "Spragtelėk ir siųskis"
+
+msgid "Community"
+msgstr "Bendruomenė"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Tai didžiulė programinės įrangos kolekcija, skirta naudojimui darbalaukiuose "
+"ar serveriuose.<br/>Tinka diegimui ir naujovinimui."
+
+msgid "Countdown"
+msgstr "Laikmatis"
+
+msgid "Country"
+msgstr "Šalis"
+
+msgid "Development"
+msgstr "Plėtojimas"
+
+msgid "Development Version"
+msgstr "vystoma versija"
+
+msgid "Development packages"
+msgstr "Paketai programavimui"
+
+msgid "Development-"
+msgstr "Plėtojimas "
+
+msgid "Direct Install"
+msgstr "Diegti tuoj pat"
+
+msgid "Direct Link"
+msgstr "Tiesioginė nuoroda"
+
+msgid "Documentation"
+msgstr "Dokumentacija"
+
+msgid "Don't show this warning the next time"
+msgstr "Pranešimo neberodyti"
+
+msgid "Download"
+msgstr "Parsisiųsti"
+
+msgid "Download %s"
+msgstr "Parsisiųsti %s"
+
+msgid "Download Help"
+msgstr "Parsisiuntimo pagalba"
+
+msgid "Download Method"
+msgstr "Parsiuntimo būdas"
+
+msgid "Download appliance from %s"
+msgstr "Parsisiųsti vedinį iš %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Siųstis&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Siųstis&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Siųstis&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Siųstis&nbsp;tinklui"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Siųstis&nbsp;įrankį"
+
+msgid "Downloads"
+msgstr "Parsisiuntimas"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Parsiunčia diegimo sistemą ir visus paketus iš nuotolinių saugyklų.<br/"
+">Tinka diegimui arba naujovinimui."
+
+msgid "Expand all sections ('e')"
+msgstr "Viską išplėsti („e“)"
+
+msgid "Extra Languages"
+msgstr "Papildomos kalbos"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Papildomos kalbos (32 bitų)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Papildomos kalbos (64 bitų)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "<strong>%s</strong>. Įvykdykite <strong>root</strong> teisėmis:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "<strong>%s</strong>. Įvykdykite:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"<strong>Arch Linux</strong>. Atverkite /etc/pacman.conf ir prirašykite "
+"(atminkite, kad pacman.conf saugyklų tvarka yra svarbi, nes pacman "
+"parsiunčia pirmą surastą paketą):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "Kiekvienam ISO atvaizdžiui pateikiame jos SHA256 kontrolinę sumą."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Naudodami GPG raktą, galite patikrinti, kas pasirašė .sha256 rinkmenas – tai "
+"užtikrina didelį saugumą. Turėtų būti <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Žaidimai"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Parsisiųskite openSUSE pagrindu sukurtus platinamuosius paketus."
+
+msgid "Getting Help"
+msgstr "Pagalba žinynuose"
+
+msgid "Gold Sponsor"
+msgstr "Auksinis rėmėjas"
+
+msgid "Grab binary packages directly"
+msgstr "Siųstis dvejetainius paketus"
+
+msgid "Header Logo"
+msgstr "Logotipas"
+
+msgid "Help on Download Method"
+msgstr "Pagalba renkantis parsisiuntimo būdą"
+
+msgid "Help on Type of Computer"
+msgstr "Pagalba nustatant kompiuterio tipą"
+
+msgid "How to Proceed"
+msgstr "Ką daryti toliau"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Jei norite naudoti tiesioginę nuorodą, bet šiuo metu mūsų parsiuntimų "
+"nukreipėjas neturi pakankamai informacijos tam, kad būtų nukreipta į "
+"greičiausią veidrodį, tuomet galite patys išsirinkti veidrodį."
+
+msgid "Image:"
+msgstr "Atvaizdis:"
+
+msgid "Install package %s / %s"
+msgstr "Diegti paketą %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Diegti šabloną %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Diegti tuoj pat"
+
+msgid "Installation Guides"
+msgstr "Diegimo vedikliai"
+
+# dialog title for hard disk installation
+msgid "Installation Medium"
+msgstr "Diegimo laikmena"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Prisijunkite prie greitai augančios bendruomenės, padovanokite naujausią \n"
+"        openSUSE PromoDVD savo grupei, pelno nesiekiančiai organizacijai, "
+"mokyklai,\n"
+"        universitetui ar tiesiog renginiui, diegimo šventei, konferencijai.\n"
+"        Promo DVDs leidžia matyti ir geriau pažinti openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Deja, KDE 3 Konqueror naršyklė nepalaikoma, nes jos javascript priemonė turi "
+"ydų, kurios ir neleidžia tinkamai parodyti šio puslapio. Prieš <a "
+"href='%s'>tęsdami</a>, išjunkite javascript."
+
+# label for language selection
+msgid "Language"
+msgstr "Kalba"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Senas 32 bitų AK"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Senas 32&nbsp;bitų&nbsp;AK"
+
+msgid "Live GNOME"
+msgstr "Demonstracinis GNOME (LiveCD/LiveUSB)"
+
+msgid "Live KDE"
+msgstr "Demonstracinis KDE (LiveCD/LiveUSB)"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Daugybė programų gali patikrinti siuntinių kontrolines sumas. Patikrinti "
+"savo siuntinius gali būti svarbu, nes nustatoma, ar jūs iš tiesų "
+"atsisiuntėte norimą ISO atvaizdį ir ar jo versiją nėra sugadinta."
+
+msgid "Metalink"
+msgstr "Meta nuoroda"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Daugiau apie ISO atvaizdžio įrašymą į CD ar DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Daugiau apie <a href='http://en.opensuse.org/Live_USB_stick'>paleidžiamos iš "
+"USB atmintuko</a> sistemos kūrimą"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Daugiau informacijos apie openSUSE parsisiuntimą rasite <a href=\"http://en."
+"opensuse.org/SDB:Download_help\">parsiuntimo pagalboje</a> ir <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">diegimo per tinklą "
+"pagalboje</a> <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">dokumentacijos vikyje</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Paprastai dauguma naujų kompiuterių palaiko <a href=\"http://lt.wikipedia."
+"org/wiki/X86-64\">x86-64</a> (dar žinomą kaip AMD64 ar Intel64), bet kai "
+"kurių nešiojamųjų kompiuterių procesoriai ir nepalaiko. Taigi jei norite "
+"būti tikri, ar architektūrą palaiko jūsų kompiuteris, reikėtų pasižiūrėti "
+"vikipedijoje."
+
+msgid "Multimedia"
+msgstr "Įvairialypė terpė"
+
+msgid "Need help?"
+msgstr "Reikia pagalbos?"
+
+msgid "Network"
+msgstr "Tinklas"
+
+msgid "No appliance data for %s"
+msgstr "Nėra %s duomenų"
+
+msgid "No appliances found in project %s"
+msgstr "Vedinių %s projekte rasti nepavyko"
+
+msgid "No data for %s / %s"
+msgstr "Nėra %s / %s duomenų"
+
+msgid "No description found..."
+msgstr "Aprašas nerastas..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Nieko nerasta %s parsisiuntimui iš %s projekto"
+
+msgid "No packages found matching your search. "
+msgstr "Paketų, kurie atitiktų paieškos kriterijų, nerasta. "
+
+msgid "NonOSS CD"
+msgstr "Nelaisvų programų CD"
+
+msgid "OBS Backend not available"
+msgstr "OBS variklis nepasiekiamas"
+
+msgid "Official Manuals"
+msgstr "Oficialūs žinynai"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Kruopščiai išbandyti yra tik DVD ir diegimui per tinklą skirti atvaizdžiai. "
+"Kiti atvaizdžiai, pavyzdžiui demonstracinės sistemos ir avarinės sistemos, "
+"skirti ribotam naudojimui."
+
+msgid "Package %s not found..."
+msgstr "Paketo, kurio pavadinimas „%s“, rasti nepavyko ..."
+
+msgid "Package Repositories"
+msgstr "Paketų saugyklos"
+
+msgid "Package Search"
+msgstr "Paketų paieška"
+
+msgid "Packages for %s:"
+msgstr "%s paketai:"
+
+msgid "Pick Mirror"
+msgstr "Išsirinkti veidrodį"
+
+msgid "Platinum Sponsor"
+msgstr "Platininis rėmėjas"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Pastaba: žemiau pateikti paketai nepriklauso oficialioms saugyklos.\n"
+"    Tai reiškia, kad openSUSE šios programinės įrangos netikrina, tad ji "
+"gali būti nestabili ir eksperimentinė."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"<b>Trumpai</b> paaiškinkite (angliškai!), kodėl Jums reikia DVD diskų ir "
+"pateikite internetinę nuorodą į tą renginį/tikslą/įstaigą."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Pastaba: tai nėra naujausia openSUSE versija. Naujausią versiją rasite <a "
+"href='/'>čia</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo DVD ir jų laikmenų apipavidalinimo paveiksliukai patalpinti \n"
+"         <a href=\"http://download.opensuse.org/promodvd/\">promodvd\n"
+"        siuntinių kataloge %s</a>. Atminkite, kad tai speciali openSUSE\n"
+"        versija, specialiai sukurta reklamavimui."
+
+msgid "Related categories:"
+msgstr "Susijusios kategorijos:"
+
+msgid "Released Version"
+msgstr "stabili versija"
+
+msgid "Reporting Bugs"
+msgstr "Pranešti apie klaidą"
+
+msgid "Rescue"
+msgstr "Avarinė sistema"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Avarinę sistemą galite paleisti iš CD ar USB atmintuko.<br/>Jos negalima nei "
+"diegti, nei naudoti kaip atnaujinimo."
+
+msgid "SHA256 checksum"
+msgstr "SHA256 kontrolinė suma"
+
+msgid "Search"
+msgstr "Ieškoti"
+
+msgid "Select Your Operating System"
+msgstr "Pasirinkite operacinę sistemą"
+
+msgid "Select the image type"
+msgstr "Pasirinkite atvaizdžio tipą"
+
+msgid "Show"
+msgstr "Rodyti"
+
+msgid "Show development, language and debug packages"
+msgstr ""
+"Rodyti kalbos, derinimo (-debug) ir programavimui skirtus (-devel) paketus"
+
+msgid "Show distribution:"
+msgstr "Platinamasis paketas:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Rodyti paketus, skirtus nepalaikomoms platinamųjų paketų versijoms"
+
+msgid "Show more..."
+msgstr "Daugiau..."
+
+msgid "Show other versions"
+msgstr "Rodyti kitas versijas"
+
+msgid "Show unstable packages"
+msgstr "Rodyti neoficialius paketus"
+
+msgid "Show unsupported packages"
+msgstr "Rodyti paketus, kurie nėra oficialiai palaikomi"
+
+msgid "Silver Sponsor"
+msgstr "Sidabrinis rėmėjas"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Kai kurie kiti atvaizdžiai (pavyzdžiui, demonstracinės sistemos ir avarinės "
+"sistemos) taip pat paruošti, tačiau jie mažiau išbandyti ir skirti tik "
+"ribotam naudojimui."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Kai kurie demonstracinėje (angl. live) veiksenoje veikiantys platinamieji "
+"paketai sukurti openSUSE pagrindu. Jei norite patys pabandyti sukurti savo "
+"platinamąjį paketą, siūlome apsilankyti <a href=\"http://susestudio.com/"
+"\">SUSE Studio</a> svetainėje."
+
+msgid "Source"
+msgstr "Šaltinis"
+
+msgid "Sponsored by"
+msgstr "Remia"
+
+msgid "Sponsored by: AMD"
+msgstr "Remia: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Remia: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Remia: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Remia: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Sudedamosios dalys"
+
+msgid "Support"
+msgstr "Palaikymas"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Diegimo metu galima pasirinkti daug kalbų, bet daugeliu atveju programų "
+"vertimai nėra įtraukti į diegimo laikmeną. Jei norite, kad jūsiškė openSUSE "
+"sistema palaikytų papildomą kalbą, jums reikės parsisiųsti ją internetu "
+"diegimo metu arba bet kada vėliau. Jei turite gerą priėjimą prie interneto, "
+"tuomet jums šio CD nereikia. Bet jei openSUSE sistemą ketinate diegti į "
+"kompiuterį be interneto ryšio, tuomet šiame CD rasite visus vertimus."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Įvykdykite <strong>root</strong> teisėmis"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Šiuo metu nėra bandymui paruoštų openSUSE versijų. <br/> Jei norite naudoti "
+"pačią šviežiausią programinę įrangą, informacijos ieškokite <a href='http://"
+"en.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Šiame CD yra nemokama programinė įranga, tačiau platinama pagal nuosavybinę "
+"licenciją, kuri neleidžia jos įterpti į pagrindinę diegimo laikmeną kartu su "
+"nemokama atviro kodo programine įranga. Visą programinę įrangą, kuri yra "
+"šiame CD, galite parsisiųsti iš  NON-OSS (ne atviro kodo PĮ) saugyklos."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Ši versija veikia visuose kompiuteriuose, įskaitant ir palaikančiuosius 64 "
+"bitų sistemas. Jei turite daugiau kaip 3 GB RAM, turėtumėte rinktis 64 bitų "
+"versiją. openSUSE nepalaiko prieš Pentium sukurtų procesorių – "
+"demonstraciniai atvaizdžiai (LiveCD/LiveUSB) dar palaiko i668 (Pentium Pro "
+"ir vėlesnius)."
+
+msgid "Type of Computer"
+msgstr "Kompiuterio tipas"
+
+msgid "Unsupported distributions:"
+msgstr "Nepalaikomos platinamųjų paketų versijos:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org\">activedoc.opensuse.org</a> adresu "
+"rasite naudotojų žinynus, tarp kurių yra <a href=\"http://activedoc.opensuse."
+"org/book/opensuse-start-up/\">oficialus pradžiamokslis</a>. "
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> patariame "
+"naudoti su lėtomis nuorodomis, ypač kai siunčiamasi DVD atvaizdį. BitTorrent "
+"siuntimasis turi keletą pranašumų, klientai apsaugoti nuo duomenų "
+"sugadinimo, o jūs padedate mažiau apkraudami serverį dalyvaudami laikmenos "
+"platinime - jei pakankamai žmonių dalyvauja, bus atsiunčiama greičiau nei iš "
+"pagrindinių serverių - kiekvienam. Be to, tai leidžia jums bet kada "
+"sustabdyti siuntimąsi ir jį tęsti vėliau."
+
+# dialog title for nfs installation
+msgid "Verify your download before use"
+msgstr "Parsisiųstųjų rinkmenų tikrinimas"
+
+msgid "Version"
+msgstr "Versija"
+
+msgid "We offer three different checksums:"
+msgstr "Mes siūlome tris kontrolinių sumų tipus:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Norėtume, kad praneštumėte apie tai, kaip sekėsi panaudoti DVD diskus, tad\n"
+"        gali pareklamuoti savo įstaigą, įvykį ar mokyklą mūsų\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>naujienų puslapyje</a>\n"
+"        ar kaip nors kitaip. (Užuomina! Mums patinka nuotraukos. "
+"Fotografuokite!). Rašykite adresu\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        ir paremsime."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Tam, kad būtų kuo mažesnė klaidų tikimybė parsiųstuose duomenyse, <i>labai</"
+"i> patariame naudoti gerą siuntinių tvarkytuvę, o ypač jei siunčiatės ne "
+"diegimui per tinklą skirtą atvaizdį."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Galite į apt įtraukti saugyklos raktą. Atminkite, kad rakto savininkas gali "
+"platinti atnaujinimus, paketus ir saugyklas, kuriomis jūsų sistema pasitikės "
+"(<a href=\"%s\">daugiau informacijos</a>). Raktą pridėsite įvykdę:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Mėginkite išplėsti paiešką įtraukdami tebetobulinamus paketus arba ieškodami "
+"kitame platinamajame pakete (dabartiniame)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Rinkmeną galimą tikrinti ir siuntimosi metu. Pavyzdžiui, aukščiau pasirinkus "
+"<a href='http://en.opensuse.org/SDB:Metalink'>metanuorodą</a> ir naudojant "
+"<a href='http://en.opensuse.org/Firefox'>Firefox</a> papildinį "
+"„DownThemAll!“, automatiškai bus naudojama kontrolinė suma (SHA256)."
+
+msgid "gpg signature"
+msgstr "gpg parašas"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"yra dažniausiai naudojama kontrolinė suma. Dauguma ISO įrašymo programų ją "
+"rodo prieš įrašant."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "mažiau žinoma, bet saugesnė nei md5."
+
+msgid "md5 checksum"
+msgstr "md5 kontrolinė suma"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"užtikrina didžiausią saugumą, nes tikrinama, kas jį pasirašė. Jis turėtų "
+"būti <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE laikmatis"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE vediniai"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE pasiekiama per http (tiesioginė nuoroda) arba per BitTorrent. "
+"Kompaktinio disko atvaizdis diegimui per tinklą prieinamas tik per http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE palaikoma tik 32 bitų ir 64 bitų kompiuteriuose."
+
+msgid "see Derivatives on wiki"
+msgstr "vikyje apie openSUSE vedinius"
+
+msgid "sha1 checksum"
+msgstr "sha1 kontrolinė suma"
+
+msgid "switch to"
+msgstr "Yra ir"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Vidinė klaida :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Įveskite bent du rašmenis"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Paskiausiai ieškota:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistika"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Dažniausiai parsisiųsta nuspaudus „diegti tuoj pat“:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Dažniausiai ieškota, bet nespausta:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Dažniausiai ieškota:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Dar nėra vystomos versijos momentinės kopijos tokios, kuri būtų naujesnė "
+#~ "už naujausią stabilią openSUSE versiją. <br/>Daugiau informacijos rasite "
+#~ "<a href='http://en.opensuse.org/Portal:Factory'>http://en.opensuse.org/"
+#~ "Portal:Factory</a>."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Saugyklos raktą prie „apt“ galite pridėti taip: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4,7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Demonstraciniuose CD yra tik keturios kalbos (anglų, vokiečių, rusų ir "
+#~ "italų). Jei norite kitokios kalbos, turite parsisiųsti ją iš interneto "
+#~ "diegimo metu arba bet kada po diegimo. Jei turite gerą priėjimą prie "
+#~ "interneto arba naudojate DVD, turintį visas kalbas, jums šis CD "
+#~ "nereikalingas."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Sėkmingai parsisiuntę ISO atvaizdį(-us), įrašykite jį(-uos) su norima "
+#~ "įrašymo programa į DVD ar CD. <em>Neįrašykite</em> jo kaip duomenų, o "
+#~ "rinkitės parinktį, įrašančią ISO atvaizdį."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.lt.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.lt.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Užklausos eilutę turi sudaryti bent du rašmenys"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "Ieškota tikslaus atitikmens, nes yra per daug susijusių elementų."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Tiksliau nurodykite raktažodžius, paieška pasiekė ribą."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Paieškos atlikti nepavyko: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Populiari programinė įranga"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Pirkti openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Diegti tuoj pat"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Paketo parsiuntimas rankiniu būdu"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Eiti į OBS projektą"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Programinės įrangos kolekcija]"
+
+#~ msgid "Search Results"
+#~ msgstr "Paieškos rezultatai"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "openSUSE kūrimo paslaugoje nerasta paketų, atitinkančių užklausą."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "kolekcijų: %d; dvejetainių rinkmenų: %d (iš paketų šaltinių: %d)"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Paveiksliukas:  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Paieškos statistika:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Atsisiuntimų statistika:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "<a href=\"http://build.opensuse.org\">openSUSE Kūrimo Paslaugos</a> "
+#~ "paketų paieška ir diegimas"
+
+#~ msgid "Search options"
+#~ msgstr "Paieškos parinktys"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "įtraukti naudotojų namų projektų"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "neįtraukti derinimo paketų"
+
+#~ msgid "Additional Information"
+#~ msgstr "Papildoma informacija"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Diegimo vediklis</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Pirkti openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Pirkti openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Daugiau apie openSUSE parsiuntimą sužinosite apsilankę <a href=\"http://"
+#~ "en.opensuse.org/SDB:Download_help\">Parsisiuntimo pagalboje.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Nurodymus rasite čia:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Diegimas iš DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Oficialus %s paleidimo vediklis"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Pažingsninio diegimo vediklis"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Diegimas per tinklą"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Diegimas per internetą"
+
+#~ msgid "More information"
+#~ msgstr "Daugiau informacijos"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Parsisiųsti"
+
+#~ msgid "Wiki"
+#~ msgstr "Vikis"
+
+#~ msgid "Build Software"
+#~ msgstr "Kūrimas"
+
+#~ msgid "User Directory"
+#~ msgstr "Naudotojo aplankas"
+
+#~ msgid "Features"
+#~ msgstr "Pageid. savybės"
+
+#~ msgid "News"
+#~ msgstr "Naujienos"
+
+#~ msgid "Forums"
+#~ msgstr "Diskusijos"
+
+#~ msgid "Shop"
+#~ msgstr "Parduotuvė"
+
+#~ msgid "Software"
+#~ msgstr "Programinė įranga"
+
+#~ msgid "Software Search"
+#~ msgstr "Programinės įrangos paieška"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Atnaujinimų saugyklos"
+
+#~ msgid "Source Repository"
+#~ msgstr "Šaltinių saugyklos"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Kitos parinktys"
+
+#~ msgid "Mirrors"
+#~ msgstr "Veidrodžiai"
+
+#~ msgid "In other languages"
+#~ msgstr "Kitomis kalbomis"
+
+#~ msgid "Get it"
+#~ msgstr "Atsisiųsti"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Ieškoti kūrimo paslaugos"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr "openSUSE Kūrimo Paslaugos papildomų paketų paieška ir diegimas."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Parsisiųsti openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Ilgalaikė nuorodą į šį rezultatą"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Gauti programinę įrangą iš openSUSE Kūrimo Paslaugos"
+
+#~ msgid "Searching"
+#~ msgstr "Ieškoma"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Turi didžiulę programinės įrangos kolekciją, skirtą naudojimui "
+#~ "darbastaliuose ar serveriuose. Tinkama diegimui ar atnaujinimui."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "GNOME darbastalį galite paleisti iš CD ar USB atmintinės. Gali būti "
+#~ "įdiegtas toks, koks yra (neskirta atnaujinimui)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "KDE darbastalį galite paleisti iš CD ar USB atmintinės. Gali būti "
+#~ "įdiegtas toks, koks yra (neskirta atnaujinimui)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Parsiunčia diegimo sistemą ir visus paketus iš nuotolinių saugyklų.  "
+#~ "Tinka diegimui arba atnaujinimui."

--- a/locale/nb/software.po
+++ b/locale/nb/software.po
@@ -1,0 +1,1311 @@
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+# Olav Pettershagen <olav.pet@gmail.com>, 2009, 2010, 2011, 2013.
+# olav Pettershagen <olpetter@bbnett.no>, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2014-01-09 19:07+0100\n"
+"Last-Translator: olav Pettershagen <olpetter@bbnett.no>\n"
+"Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid " and "
+msgstr " og "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} er ikke en støttet versjon.»"
+
+msgid "(hide)"
+msgstr "(skjul)"
+
+msgid "(show)"
+msgstr "(vis)"
+
+msgid "... and keep us informed"
+msgstr "... og holder oss informert"
+
+msgid "... get other marketing stuff"
+msgstr "... få annet markedsføringsmateriell"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4,7 GB DVD (også for USB-pinne)"
+
+msgid "64 Bit PC"
+msgstr "64 bit PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Komme i "
+"gang med openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> er en åpen "
+"standard som samler ulike protokoller (FTP/HTTP/BitTorrent) til ett format "
+"for å forenkle nedlastinger. Dette egner seg bra for nedlasting av ISO-er, "
+"spesielt for dem som ikke kan bruke P2P på grunn av begrensninger fra "
+"internettleverandøren eller universitetet. Metoden kan øke "
+"nedlastingshastigheten betraktelig ettersom de fleste klienter automatisk "
+"støtter flere forbindelser til flere speilservere. Dessuten vil eventuelle "
+"feil automatisk bli oppdaget og korrigert. Det kreves imidlertid en spesiell "
+"klient for å bruke denne metoden."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE:License\">Lisens</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Versjonsmerknader</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>offisiell versjon</b>"
+
+# shown if driver update succeeded
+msgid "<b>official update</b>"
+msgstr "<b>offisiell oppdatering</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Et GNOME-skrivebord som kan kjøres fra %s eller en USB-pinne.<br/>Kan også "
+"installeres på maskinen (ikke oppgradering)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Et KDE-skrivebord som kan kjøres fra %s eller en USB-pinne.<br/>Kan også "
+"installeres på maskinen (ikke oppgradering)."
+
+msgid "Add repository and install manually"
+msgstr "Legg til pakkebrønn og installer manuelt"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Tilleggsnedlastinger (valgfritt)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Når du har lastet ned et ISO-diskbilde, kan du lage en USB-pinne å "
+"installere fra eller brenne det på en DVD (eller en CD hvis diskbildet får "
+"plass på den)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"All informasjon brukes utelukkende for å sende markedsføringsmateriell for "
+"openSUSE\n"
+"      og vil ikke bli formidlet til tredjeparter. Vi lagrer data for å\n"
+"      informere brukere når en ny versjon er tilgjengelig. Alle forespørsler "
+"må\n"
+"      granskes for å oppfylle eksportreglene i USA. Mer informasjon\n"
+"      om disse eksportreglene og en oversikt over land det er eksportforbud "
+"til finnes på wikipedia <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Bla gjennom programmer"
+
+msgid "Available Images"
+msgstr "Tilgjengelige diskbilder"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Start maskinen fra DVD-en, CD-en eller USB-pinnen. Hvis datamaskinen ikke "
+"starter automatisk, må du gå til BIOS-oppsettet og aktivere oppstart fra fra "
+"den aktuelle enheten."
+
+msgid "Bronze Sponsor"
+msgstr "Bronze-sponsor"
+
+msgid "Browser incompatibility"
+msgstr "Nettleseren er ikke kompatibel"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Brenn CD/DVD-diskbilde"
+
+msgid "Categories"
+msgstr "Kategorier"
+
+msgid "Category"
+msgstr "Kategori"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Velg et installasjonsmedium ved å klikke på det. Klikk deretter på Last ned-"
+"knappen for å starte nedlastingen. Velg eventuelt datamaskintype eller en "
+"annen nedlastingsmetode."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Klikk for å laste ned"
+
+msgid "Community"
+msgstr "OpenSUSE-fellesskapet"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Inneholder et bredt utvalg av programvare for skrivebordsmaskiner eller "
+"servere.<br/>Egner seg for installasjon eller oppgradering."
+
+msgid "Countdown"
+msgstr "Nedtelling"
+
+msgid "Country"
+msgstr "Land"
+
+msgid "Development"
+msgstr "Utvikling"
+
+msgid "Development Version"
+msgstr "Utviklingsversjon"
+
+msgid "Development packages"
+msgstr "Utviklingspakker"
+
+msgid "Development-"
+msgstr "Utviklings-"
+
+msgid "Direct Install"
+msgstr "Direkte installasjon"
+
+msgid "Direct Link"
+msgstr "Direkte forbindelse"
+
+msgid "Documentation"
+msgstr "Dokumentasjon"
+
+msgid "Don't show this warning the next time"
+msgstr "Ikke vis denne advarselen igjen"
+
+msgid "Download"
+msgstr "Last ned"
+
+msgid "Download %s"
+msgstr "Last ned %s"
+
+msgid "Download Help"
+msgstr "Hjelp til nedlasting"
+
+msgid "Download Method"
+msgstr "Nedlastingsmetode"
+
+msgid "Download appliance from %s"
+msgstr "Last ned fra %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Last ned&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Last ned&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Last ned&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Last ned&nbsp;Nettverk"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Last ned&nbsp;Redningssystem"
+
+msgid "Downloads"
+msgstr "Last ned"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Laster ned installasjonssystemet og alle pakker fra pakkebrønner på nettet."
+"<br/>Egner seg for installasjon eller oppgradering."
+
+msgid "Expand all sections ('e')"
+msgstr "Utvid alle seksjoner ('e')"
+
+msgid "Extra Languages"
+msgstr "Ekstra språk"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Ekstra språk (32 bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Ekstra språk (64 bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "For <strong>%s</strong>, kjør følgende som <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "For <strong>%s</strong>, kjør følgende som:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"For <strong>Arch Linux</strong>, rediger /etc/pacman.conf og legg til "
+"følgende (husk at pakkebrønnrekkefølgen i pacman.conf er viktig ettersom "
+"pacman alltid laster ned først pakke som blir funnet):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be"
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"tilbyr best sikkerhet fordi du kan verifisere hvem som har signert den. Den "
+"skal være"
+
+msgid "Games"
+msgstr "Spill"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Last ned en av de spesialiserte distribusjonene som bygger på openSUSE."
+
+msgid "Getting Help"
+msgstr "Hjelp og støtte"
+
+msgid "Gold Sponsor"
+msgstr "Gold-sponsor"
+
+msgid "Grab binary packages directly"
+msgstr "Hent binære pakker direkte"
+
+msgid "Header Logo"
+msgstr "Header Logo"
+
+msgid "Help on Download Method"
+msgstr "Hjelp om nedlastingsmetoder"
+
+msgid "Help on Type of Computer"
+msgstr "Hjelp om datamaskintype"
+
+msgid "How to Proceed"
+msgstr "Fremgangsmåte"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Hvis du vil laste ned direkte fra et sted i verden der vårt "
+"omdirigeringssystem ikke har nok informasjon til å finne den raskeste "
+"speilserveren, kan du velge en nedlastingsserver selv."
+
+msgid "Image:"
+msgstr "Diskbilde:"
+
+msgid "Install package %s / %s"
+msgstr "Installer pakken %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Installer mønsteret %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Installer med ett klikk"
+
+msgid "Installation Guides"
+msgstr "Installasjonsveiledninger"
+
+msgid "Installation Medium"
+msgstr "Installasjonsmedium"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Bli med i det raskt voksende fellesskapet og få flere med på openSUSE-laget "
+"ved å\n"
+"        bestille den siste Promo-DVD-en til din gruppe, ideelle "
+"organisasjon, skole,\n"
+"        universitet eller arrangementer som LUG-møter, installasjonsfester "
+"og konferanser.\n"
+"        Promo DVD-er bidrar til å skape oppmerksomhet og gjøre openSUSE mer "
+"synlig!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror for KDE 3 vedlikeholdes dessverre ikke lenger, og "
+"javaskriptimplementeringen inneholder feil som kan gjøre det umulig å bruke "
+"netteleseren på denne siden. Kontroller at  javaskript er deaktivert før du "
+"<a href='%s'>fortsetter</a>."
+
+msgid "Language"
+msgstr "Språk"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "32 bit PC"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32&nbsp;bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Mange programmer kan bekrefte kontrollsummen for en nedlasting. Dette kan "
+"være viktig fordi det bekrefter at du har valgt riktig ISO-fil og at den "
+"ikke er skadet."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Mer informasjon om å brenne ISO-filen på CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Mer informasjon om å lage en <a href='http://en.opensuse.org/"
+"Live_USB_stick'>USB-pinne å installere fra</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Mer informasjon om nedlasting av openSUSE er tilgjengelig på wiki-sidene <a "
+"href=\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> og <a "
+"href=\"http://en.opensuse.org/SDB:Network_installation\">Network "
+"Installation</a> under <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"De fleste nye datamaskiner støtter <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (også kalt AMD64 og Intel64), men noen prosessorer for "
+"bærbare maskiner støtter ikke dette. Du bør derfor undersøke dette i "
+"wikipedia for å være sikker på hva som støttes av din datamaskin."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Trenger du hjelp?"
+
+msgid "Network"
+msgstr "Nettverk"
+
+msgid "No appliance data for %s"
+msgstr "Ingen programdata for %s"
+
+msgid "No appliances found in project %s"
+msgstr "Ingen programvare funnet i prosjektet %s"
+
+msgid "No data for %s / %s"
+msgstr "Ingen informasjon for %s / %s"
+
+msgid "No description found..."
+msgstr "Ingen beskrivelse funnet..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Ingen nedlastinger funnet for %s i prosjektet %s"
+
+msgid "No packages found matching your search. "
+msgstr "Det ble ikke funnet noen pakker som samsvarer med søket. "
+
+msgid "NonOSS CD"
+msgstr "Ikke-OSS CD"
+
+msgid "OBS Backend not available"
+msgstr "NB! Grunnsystem ikke tilgjengelig"
+
+msgid "Official Manuals"
+msgstr "Offisielle håndbøker"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr "Pakken %s ikke funnet..."
+
+msgid "Package Repositories"
+msgstr "Pakkebrønner"
+
+msgid "Package Search"
+msgstr "Pakkesøk"
+
+msgid "Packages for %s:"
+msgstr "Pakker for %s:"
+
+msgid "Pick Mirror"
+msgstr "Velg en speilserver"
+
+msgid "Platinum Sponsor"
+msgstr "Platinum-sponsor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Vær oppmerksom på at disse pakkene kommer fra uoffisielle pakkebrønner.\n"
+"  Det betyr at de ikke er kontrollert av openSUSE og kan inneholde ustabil "
+"eller eksperimentell programvare."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Oppgi en <b>kortfattet</b> grunn (på engelsk!) til at du trenger DVD-ene og "
+"en lenke til arrangementet/formålet."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Dette er ikke den nyeste openSUSE-versjonen. Den nyeste versjonen får du <a "
+"href='/'>her</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo-DVD-er og relatert materielle -etiketter og omslag- kan\n"
+"        lastes ned fra <a href=\"http://download.opensuse.org/promodvd/\">\n"
+"        nedlastingskatalogen %s</a>. Husk at dette er en spesialversjon av "
+"openSUSE,\n"
+"        som er beregnet på utdeling i forbindelse med markedsføring."
+
+msgid "Related categories:"
+msgstr "Beslektede kategorier:"
+
+msgid "Released Version"
+msgstr "Utgitt versjon"
+
+msgid "Reporting Bugs"
+msgstr "Rapporter feil"
+
+msgid "Rescue"
+msgstr "Redningssystem"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Et redningssystem som kan kjøres fra en CD eller USB-pinne.<br/>Kan verken "
+"installeres på maskinen eller brukes til oppgradering."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "md5-kontrollsum"
+
+msgid "Search"
+msgstr "Søk"
+
+msgid "Select Your Operating System"
+msgstr "Velg operativsystem"
+
+msgid "Select the image type"
+msgstr "Velg diskbildetype"
+
+msgid "Show"
+msgstr "Vis"
+
+msgid "Show development, language and debug packages"
+msgstr "Vis utviklings-, språk- og feilsøkingspakker"
+
+msgid "Show distribution:"
+msgstr "Vis distribusjon:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Vis flere pakker for distribusjoner som ikke støttes"
+
+msgid "Show more..."
+msgstr "Vis mer..."
+
+msgid "Show other versions"
+msgstr "Vis andre versjoner"
+
+msgid "Show unstable packages"
+msgstr "Vis utviklingspakker"
+
+msgid "Show unsupported packages"
+msgstr "Vis uoffisielle pakker"
+
+msgid "Silver Sponsor"
+msgstr "Silver-sponsor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Noen live-distribusjoner som er basert på openSUSE. De som er interessert i "
+"å bygge egne derivater, kan ta en kikk på <a href=\"http://susestudio.com/"
+"\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Kilde"
+
+msgid "Sponsored by"
+msgstr "Støttes av:"
+
+msgid "Sponsored by: AMD"
+msgstr "Støttes av: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Støttes av: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Støttes av: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Støttes av: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Underpakker"
+
+msgid "Support"
+msgstr "Brukerstøtte"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Installasjonsprosessen finnes på mange språk, men for de fleste av dem er "
+"ikke oversettelser av programvaren med på installasjonsmediet. Hvis du vil "
+"at openSUSE-systemet skal støtt flere språk, må du laste dem ned fra "
+"Internett under installasjonen eller når som helst etterpå. Hvis du har "
+"tilgang til Internett, trenger du ikke denne CD-en, men hvis du skal "
+"installere openSUSE på en maskin uten internettilgang, kan du installere "
+"flere språk fra den."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Kjør deretter følgende som <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Denne CD-en inneholder gratis programvare som distribueres under proprietære "
+"lisenser, og som derfor ikke kan inkluderes på hovedinstallasjonsmediene "
+"sammen med gratis programvare som har åpen kildekode. All programvare på "
+"denne CD-en kan også lastes ned fra NON-OSS-pakkebrønnen."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Denne versjonen kjører på alle PC-er, også maskiner som støtter 64 bit. Hvis "
+"du har mer enn 3 GB RAM, bør du velge 64 bit-versjonen. openSUSE støtter "
+"ikke eldre prosessorer enn Pentium, og live CD-ene støtter kun i686 (Pentium "
+"Pro og senere)."
+
+msgid "Type of Computer"
+msgstr "Datamaskintype"
+
+msgid "Unsupported distributions:"
+msgstr "Distribusjoner som ikke støttes:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Brukerveiledninger er tilgjengelige på <a href=\"http://activedoc.opensuse."
+"org\">activedoc.opensuse.org</a>, for eksempel <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">den offisielle "
+"innføringsveiledningen</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Det anbefales å bruke <a href=\"http://en.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent</a> hvis forbindelsen er langsomt, spesielt ved nedlasting av "
+"DVD-diskbildet. BitTorrent-nedlasting har flere fordeler. Klienten hindrer "
+"at data blir ødelagt, og du bidrar til å redusere belastningen på serverne "
+"ved å delta i opplastingen. Hvis mange deltar, vil det også være raskere enn "
+"å bruke hovedserverne - for alle. Du kan dessuten når som helst stoppe "
+"nedlastingen og starte den igjen senere."
+
+msgid "Verify your download before use"
+msgstr "Verifiser nedlastingen før bruk"
+
+msgid "Version"
+msgstr "Versjon"
+
+msgid "We offer three different checksums:"
+msgstr "Vi tilbyre tre forskjellige kontrollsumtyper:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Vi vil gjerne at du forteller oss om om hvordan du bruker DVD-ene, slik at "
+"vi\n"
+"        kan bidra til å promotere organisasjonen, arrangementet eller skolen "
+"din på vår\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>nyhetsside</a>\n"
+"        eller gjennom andre kanaler. (Hint! Vi elsker bilder, så bruk "
+"kameraet flittig!). Kontakt oss på\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"         for å diskutere promotering eller andre måter vi kan hjelpe til på."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Når andre diskbilder enn CD-en for nettverksinstallasjon lastets ned, "
+"anbefaler vi <i>absolutt</i> å bruke et egnet nedlastingsprogram for å "
+"redusere risikoen for ødelagte data."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Du kan legge til pakkebrønnøkkelen i apt. Husk at nøkkelens eier kan "
+"distribuere oppdateringer, pakker og pakkebrønner som systemet vil stole (<a "
+"href=\"%s\">mer informasjon</a>). For å legge til nøkkelen, kjør:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Du kan forsøke å utvide søket til utviklingspakker eller søke etter pakker "
+"for en annen grunndistribusjon (oppdatert)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Du kan verifisere filen under nedlastingsprosessen. En kontrollsum (SHA256) "
+"vil for eksempel bli brukt automatisk hvis du velger <a href='http://en."
+"opensuse.org/SDB:Metalink'>Metalink</a> i feltet ovenfor og bruker "
+"tilleggsprogrammet DownThemAll! i <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "gpg-signatur"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"er fremdeles den mest brukte kontrollsumtypen. Mange ISO-brenneprogrammer "
+"viser denne rett før brenningen starter."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "er mindre kjent, men sikrere enn md5."
+
+msgid "md5 checksum"
+msgstr "md5-kontrollsum"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"tilbyr best sikkerhet fordi du kan verifisere hvem som signerte den. Det "
+"skal være <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE-nedtelling"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE-derivater"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE er tilgjengelig via http (direkte nedlasting) eller BitTorrent. CD-"
+"en for nettverksinstallasjon er bare tilgjengelig via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE støtter bare PC-er med 32 og 64 bit-arkitektur."
+
+msgid "see Derivatives on wiki"
+msgstr "les om derivater på wikien"
+
+msgid "sha1 checksum"
+msgstr "sha1-kontrollsum"
+
+msgid "switch to"
+msgstr "bytt til"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Det har oppstått en intern feil :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Bruk mer enn 2 tegn"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Siste søk:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistikk"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Mest populære 1-klikk-nedlastinger:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Hyppigste søk uten treff:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Hyppigste søk:"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Vi har for øyeblikket ikke noe Factory-øyeblikksbilde som er nyere enn "
+#~ "siste openSUSE-versjon. <br/>Se <a href='http://en.opensuse.org/Portal:"
+#~ "Factory'>http://en.opensuse.org/Portal:Factory</a> for mer informasjon."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Du kan legge til pakkebrønnøkkelen i apt på denne måten: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4,7 GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD-er inneholder bare fire språk (engelsk, tysk, russisk og "
+#~ "italiensk). Hvis du vil har støtte for andre språk, må du laste dem ned "
+#~ "fra Internett under installasjonen eller når som helst senere. Hvis du "
+#~ "har enkel tilgang til Internett eller hvis du bruker en DVD som "
+#~ "inneholder alle språk, trenger du ikke denne CD-en."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Etter vellykket nedlasting av ISO-diskbilde(r), brenn diskbildet eller "
+#~ "diskbildene på en DVD eller CD med et brenneprogram. Husk at du <em>ikke</"
+#~ "em> skal velge å brenne en data-DVD/CD, men et ISO-diskbilde."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Søkestrengen må bestå av minst 8 tegn"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Byttet til nøyaktig treff på grunn for mange treff på undersøkestreng."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Bruk mer presise søkekriterier. Grensen for søkeresultater er nådd."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Kunne ikke utføre søk: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Populære programmer"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Kjøp openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Installer med 1 klikk"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Last ned pakker manuelt"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Gå til OBS-prosjekt"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Programvaresamling]"
+
+#~ msgid "Search Results"
+#~ msgstr "Søkeresultater"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Det ble ikke funnet noen pakker på openSUSE Build Service som samsvarer "
+#~ "med søket."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d samlinger og %d binære filer fra %d kildepakker"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Øyeblikksbilde av  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Søkestatistikk:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Nedlastingsstatistikk:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Søk etter og installer programvarepakker fra <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Søkevalg"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Ta med private brukerprosjekter"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Ikke ta med feilsøkingspakker"
+
+#~ msgid "Additional Information"
+#~ msgstr "Mer informasjon"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Kjøp openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Kjøp openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Du finner mer informasjon om nedlasting av openSUSE under <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Hjelp til nedlasting.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Du finner mer informasjon her:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Installasjon fra DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Offisiell oppstartsveiledning for %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Trinnvis installasjonsveiledning"
+
+#~ msgid "Network Installation"
+#~ msgstr "Nettverksinstallasjon"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Installasjon fra Internett"
+
+#~ msgid "More information"
+#~ msgstr "Mer informasjon"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Hent programvare"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Bygg programvare"
+
+#~ msgid "User Directory"
+#~ msgstr "Brukerkatalog"
+
+#~ msgid "Features"
+#~ msgstr "Innhold"
+
+#~ msgid "News"
+#~ msgstr "Nyheter"
+
+#~ msgid "Forums"
+#~ msgstr "Forum"
+
+#~ msgid "Shop"
+#~ msgstr "Butikk"
+
+#~ msgid "Software"
+#~ msgstr "Programvare"
+
+#~ msgid "Software Search"
+#~ msgstr "Programvaresøk"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Oppdateringspakkebrønner"
+
+#~ msgid "Source Repository"
+#~ msgstr "Kildekodepakkebrønn"
+
+#~ msgid "Other Options"
+#~ msgstr "Andre valg"
+
+#~ msgid "Mirrors"
+#~ msgstr "Speilservere"
+
+#~ msgid "In other languages"
+#~ msgstr "På andre språk"
+
+#~ msgid "Get it"
+#~ msgstr "Hent openSUSE"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Søk i Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Søk etter og installer flere programvarepakker fra openSUSE Build Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Hent openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Permanent kobling til dette resultatet"
+
+#~ msgid "Nothing found"
+#~ msgstr "Ingenting funnet"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Hent programvare fra openSUSE Build Service"
+
+#~ msgid "Searching"
+#~ msgstr "Søker"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Inneholder et bredt utvalg av programvare for skrivebordsmaskiner eller "
+#~ "servere. Egner seg for installasjon eller oppgradering."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Et GNOME-skrivebord som kan kjøres fra en CD eller USB-pinne. Kan også "
+#~ "installeres på maskinen (ikke oppgradering)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Et KDE-skrivebord som kan kjøres fra en CD eller USB-pinne. Kan også "
+#~ "installeres på maskinen (ikke oppgradering)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Laster ned installasjonssystemet og alle pakker fra pakkebrønner på "
+#~ "nettet. Egner seg for installasjon eller oppgradering."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metakoblinger"
+
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Kjøp openSUSE 11.2!<br /> "
+
+#~ msgid "Only available for german speaking countries."
+#~ msgstr "Kun tilgjengelig for tysktalende land."
+
+#~ msgid ""
+#~ "<p style='font-size: 12px;'>F&uuml;r alle Linux-Benutzer, die Hilfe bei "
+#~ "der Installation\n"
+#~ "               sch&auml;tzen.</p><p style='font-size: 12px;'> Die Version "
+#~ "beinhaltet ein vollst&auml;ndiges Handbuch sowie alle\n"
+#~ "               Installationsmedien f&uuml;r intel-kompatible Rechner (x86 "
+#~ "und x86_64).</p><p style='font-size: 12px;'>Mit\n"
+#~ "               kostenlosem  Installationssupport f&uuml;r 90 Tage.</p>"
+#~ msgstr ""
+#~ "<p style='font-size: 12px;'>F&uuml;r alle Linux-Benutzer, die Hilfe bei "
+#~ "der Installation\n"
+#~ "               sch&auml;tzen.</p><p style='font-size: 12px;'> Die Version "
+#~ "beinhaltet ein vollst&auml;ndiges Handbuch sowie alle\n"
+#~ "               Installationsmedien f&uuml;r intel-kompatible Rechner (x86 "
+#~ "und x86_64).</p><p style='font-size: 12px;'>Mit\n"
+#~ "               kostenlosem  Installationssupport f&uuml;r 90 Tage.</p>"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "For nye Linux-brukere kan det hende at openSUSE-versjonen med "
+#~ "brukerstøtte er det beste valget &mdash; du får fullstendig "
+#~ "sluttbrukerdokumentasjon, installerbare medier for 32- og 64 bit-systemer "
+#~ "pluss 90 dagers installasjonsstøtte for sluttbrukere."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 er tilgjengelig fra flere <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">nettbutikker</a> og lokale forhandlere."
+
+#~ msgid "Expert view"
+#~ msgstr "Avansert visning"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Datamaskiner med f.eks. AMD&reg; Sempron eller Intel&reg; "
+#~ "Celeron&trade;, nesten alle skrivebordsmaskiner fra 2004 eller tidligere. "
+#~ "Denne versjonen kan også kjøres på 64 bit-maskiner."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: De fleste nye datamaskiner med f.eks. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64 eller Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPU-er."
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr ""
+#~ "Dette er det minste mediet (ca. 100 MB), som laster ned "
+#~ "installasjonssystemet og programvare fra arkiver på nettet."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "For å laste ned et medium, velg en installasjonsmetode, endre eventuelt "
+#~ "arkitektur og nedlastingsmåte og klikk på «Lagre fil»."
+
+#~ msgid ""
+#~ "This CD contains a live session of the GNOME desktop. It can be installed "
+#~ "as is and also works when deployed on an USB stick."
+#~ msgstr ""
+#~ "CD-en inneholder en live-økt med GNOME-skrivebordet. Den kan eventuelt "
+#~ "installeres og kan også kjøres fra en USB-pinne."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Popup: Hjelp om nedlastingsmedier"
+
+#~ msgid "Help"
+#~ msgstr "Hjelp"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "DVD er standardmediet for de fleste"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Live-CD med GNOME-skrivebord"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Live CD med KDE-skrivebord"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "Nettverksinstallasjon for eksperter"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "er fremdeles den mest brukte kontrollsumtypen. Mange ISO-brenneprogrammer "
+#~ "viser den rett før brenningen starter."
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr "er mindre kjent, men en sikrere kontrollsum enn md5.."

--- a/locale/nl/software.po
+++ b/locale/nl/software.po
@@ -1,0 +1,1300 @@
+# translation of software-opensuse-org.nl.po to Dutch
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# Freek de Kruijf <freek@opensuse.org>, 2009, 2010, 2011, 2012, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.nl\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-12 21:31+0100\n"
+"Last-Translator: Freek de Kruijf <freek@opensuse.org>\n"
+"Language-Team: Dutch <opensuse-nl@opensuse.org>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural= n != 1;\n"
+
+msgid " and "
+msgstr " en "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} is geen ondersteunde uitgave.\""
+
+msgid "(hide)"
+msgstr "(verbergen)"
+
+msgid "(show)"
+msgstr "(tonen)"
+
+msgid "... and keep us informed"
+msgstr "... en houdt ons geïnformeerd"
+
+msgid "... get other marketing stuff"
+msgstr "... haal andere zaken voor marketing op"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB dvd (ook te gebruiken voor USB-stick)"
+
+msgid "64 Bit PC"
+msgstr "64&nbsp;bit&nbsp;PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-startup/\">openSUSE "
+"handleiding voor opstarten (Engels)</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://nl.opensuse.org/SDB:Metalink\">Metalink</a> is een open "
+"standaard die de verschillende manieren (FTP/HTTP/BitTorrent) om bestanden "
+"te verkrijgen bundelt in één formaat voor gemakkelijker downloaden. Dit "
+"maakt het geschikt voor het downloaden van ISO's; speciaal voor mensen die "
+"geen P2P kunnen gebruiken vanwege beperkingen van hun ISP of universiteit. "
+"het kan hoge downloadsnelheden leveren omdat de meeste clients automatisch "
+"meervoudige verbindingen ondersteunen naar meervoudige mirrors. Bovendien, "
+"kan het automatische foutdetectie doen en corrigeren. Er is echter een "
+"speciale client voor nodig."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://nl.opensuse.org/openSUSE:License\">Licentie</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Uitgavenotities</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>officiële uitgave</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>officiële uitgave voor bijwerken</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Een GNOME-bureaublad waarop u vanaf %s of van een USB stick kan werken.<br/"
+">Kan ook zo geïnstalleerd worden (geen opwaarderen)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Een KDE-bureaublad waarop u vanaf %s of van een USB stick kan werken.<br/"
+">Kan ook zo geïnstalleerd worden (geen opwaarderen)."
+
+msgid "Add repository and install manually"
+msgstr "Installatiebron toevoegen en handmatig installeren"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Downloads van addon (optioneel)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Maak, na het met succes downloaden van de ISO-image(s), een te booten USB-"
+"stick aan of brand de image(s) op een dvd (of een cd als de gekozen image "
+"past)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Alle gegevens worden alleen gebruikt voor het verzenden van "
+"promotiemateriaal\n"
+"       van openSUSE en zal niet verspreidt worden onder derden. Wij slaan "
+"de\n"
+"       gegevens op om de gebruikers te informeren als er een nieuwe versie\n"
+"       beschikbaar is. Alle verzoeken moeten gescreend worden om te voldoen\n"
+"       aan het exportembargo van de VS. Meer informatie over het embargo en "
+"een\n"
+"       lijst met landen is beschikbaar op wikipedia <a href='http://en."
+"wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Toepassingsbrowser"
+
+msgid "Available Images"
+msgstr "Beschikbare images"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Start vanaf de dvd, cd of USB-stick. Als uw computer dat niet automatisch "
+"doet, open dan de BIOS instellingen om het starten hier vanaf toe te staan."
+
+msgid "Bronze Sponsor"
+msgstr "Brons Sponsor"
+
+msgid "Browser incompatibility"
+msgstr "Browser is niet compatibel"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Cd/dvd-image(s) branden"
+
+msgid "Categories"
+msgstr "Categorieën"
+
+msgid "Category"
+msgstr "Categorie"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Kies een installatiemedium door er op te klikken en klik op de knop Download "
+"om het downloaden te starten. Kies als optie het type computer of een "
+"alternatieve manier van downloaden."
+
+msgid "Click here to display these alternative versions."
+msgstr "Klik hier om deze alternatieve versies te tonen."
+
+msgid "Click to Download"
+msgstr "Klik om te downloaden"
+
+msgid "Community"
+msgstr "Gemeenschap"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Bevat een grote collectie software voor gebruik op het bureaublad en of op "
+"een server.<br/>Geschikt voor eerste installatie of opwaarderen."
+
+msgid "Countdown"
+msgstr "Aftellen"
+
+msgid "Country"
+msgstr "Land"
+
+msgid "Development"
+msgstr "Ontwikkeling"
+
+msgid "Development Version"
+msgstr "Ontwikkelversie"
+
+msgid "Development packages"
+msgstr "Pakketten voor ontwikkeling"
+
+msgid "Development-"
+msgstr "Ontwikkeling-"
+
+msgid "Direct Install"
+msgstr "Directe installatie"
+
+msgid "Direct Link"
+msgstr "Directe verbinding"
+
+msgid "Documentation"
+msgstr "Documentatie"
+
+msgid "Don't show this warning the next time"
+msgstr "Deze waarschuwing de volgende keer niet meer tonen"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Download %s"
+msgstr "Download %s"
+
+msgid "Download Help"
+msgstr "Hulp bij downloaden"
+
+msgid "Download Method"
+msgstr "Downloadmethode"
+
+msgid "Download appliance from %s"
+msgstr "Appliance downloaden vanaf %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Download&nbsp;dvd"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Download&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Download&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Download&nbsp;netwerk"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Download&nbsp;Rescue&nbsp;(Reddingssysteem)"
+
+msgid "Downloads"
+msgstr "Downloads"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Doet een download van het installatiesysteem en alle pakketten vanaf een "
+"online installatiebron.<br/>Geschikt voor installatie en opwaarderen."
+
+msgid "Expand all sections ('e')"
+msgstr "Alle secties expanderen ('e')"
+
+msgid "Extra Languages"
+msgstr "Extra talen"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Extra talen (32 bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Extra talen (64 bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Voor <strong>%s</strong> voer het volgende als <strong>root</strong> uit:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Voor <strong>%s</strong> voer het volgende uit:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Voor <strong>Arch Linux</strong>, edit /etc/pacman.conf en voeg het volgende "
+"toe (merk op dat de volgorde van installatiebronnen in pacman.conf "
+"belangrijk is, omdat pacman altijd het eerst gevonden pakket downloadt):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Voor elk ISO-bestand bieden we een bestand met de overeenkomstige SHA256 "
+"controlesom."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Voor extra beveiliging kunt u GPG gebruiken om te verifiëren wie die .sha256-"
+"bestanden heeft getekend. Het zou %s moeten zijn."
+
+msgid "Games"
+msgstr "Spellen"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Verkrijg een van de gespecialiseerde distributies die gebouwd zijn op "
+"openSUSE"
+
+msgid "Getting Help"
+msgstr "Hulp verkrijgen"
+
+msgid "Gold Sponsor"
+msgstr "Gold Sponsor"
+
+msgid "Grab binary packages directly"
+msgstr "Direct binaire pakketten pakken"
+
+msgid "Header Logo"
+msgstr "Logo in de kop"
+
+msgid "Help on Download Method"
+msgstr "Hulp bij downloadmethoden"
+
+msgid "Help on Type of Computer"
+msgstr "Hulp bij het type computer"
+
+msgid "How to Proceed"
+msgstr "Hoe verder te gaan"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Als u een directe link wilt gebruiken, maar op een plaats op de wereld leeft "
+"waar onze download verwijzing niet genoeg informatie heeft om naar de "
+"snelste mirror te verwijzen, dan kunt u zelf een mirror kiezen."
+
+msgid "Image:"
+msgstr "Image:"
+
+msgid "Install package %s / %s"
+msgstr "Pakket %s / %s installeren"
+
+msgid "Install pattern %s / %s"
+msgstr "Patroon %s / %s installeren"
+
+msgid "Install using One Click Install"
+msgstr "Met Eén-klik installeren"
+
+msgid "Installation Guides"
+msgstr "Installatiehandleidingen"
+
+msgid "Installation Medium"
+msgstr "Installatiemedium"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Doe mee met de snel groeiende gemeenschap, stop openSUSE in meer handen "
+"door\n"
+"        de laatste Promo-dvd voor uw groep, non-profit organisatie, school\n"
+"        universiteit of evenement zoals LUG-meetings, installatie "
+"bijeenkomsten\n"
+"        en conferenties.\n"
+"        Promotie-dvd's helpen de bekendheid en zichtbaarheid van openSUSE te "
+"verhogen!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror uit KDE 3 is helaas niet onderhouden en zijn javascript-"
+"implementatie bevat bugs die het onmogelijk maken om het met deze pagina te "
+"gebruiken. Verzeker u ervan dat javascript is uitgeschakeld alvorens u <a "
+"href='%s'>doorgaat</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Taal"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Ouderwetse 32 bit PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Ouderwetse 32&nbsp;bit&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live-GNOME"
+
+msgid "Live KDE"
+msgstr "Live-KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Veel programma's kunnen de controlesom van een download verifiëren. Dit doen "
+"kan belangrijk zijn omdat het echt verifieert of u het ISO-bestand hebt "
+"verkregen dat u wilde downloaden en niet een gebroken versie."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Meer informatie over het branden van het ISO-bestand naar cd/dvd"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Meer informatie over het aanmaken van een <a href='http://nl.opensuse.org/"
+"SDB:Live_USB_stick'>te booten USB-stick.</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Meer informatie over downloaden van openSUSE is beschikbaar op <a href="
+"\"http://nl.opensuse.org/SDB:Download_help\">Hulp bij downloaden.</a> en <a "
+"href=\"http://nl.opensuse.org/SDB:Network_installation\">Networkinstallatie</"
+"a> pagina's in onze <a href=\"http://nl.opensuse.org/Portal:Documentation"
+"\">Wiki met documentatie</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"De meeste nieuwe computers ondersteunen <a href=\"http://en.wikipedia.org/"
+"wiki/X86-64\">x86-64</a> (ook bekend als AMD64 en Intel64), echter sommige "
+"laptop-processors en netbook-processors ondersteunen het niet. U zult dus "
+"wikipedia moeten raadplegen als u er zeker van wilt zijn dat uw computer het "
+"ondersteund."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Hulp nodig?"
+
+msgid "Network"
+msgstr "Netwerk"
+
+msgid "No appliance data for %s"
+msgstr "Geen appliance-gegevens voor %s"
+
+msgid "No appliances found in project %s"
+msgstr "Geen appliances gevonden in project %s"
+
+msgid "No data for %s / %s"
+msgstr "Geen gegevens voor %s / %s"
+
+msgid "No description found..."
+msgstr "Geen beschrijving gevonden..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Geen downloads gevonden voor %s in project %s"
+
+msgid "No packages found matching your search. "
+msgstr "Er zijn geen pakketten gevonden die overeenkomen met uw zoekopdracht. "
+
+msgid "NonOSS CD"
+msgstr "Niet-OSS-cd"
+
+msgid "OBS Backend not available"
+msgstr "OBS-backend is niet beschikbaar"
+
+msgid "Official Manuals"
+msgstr "Officiële handleidingen"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Alleen de dvd- en netwerkmedia zijn volledig getest. Alternatieven, zoals "
+"live of rescue-systemen, zijn alleen aanbevolen voor beperkt gebruik."
+
+msgid "Package %s not found..."
+msgstr "Pakket %s is niet gevonden..."
+
+msgid "Package Repositories"
+msgstr "Installatiebronnen van pakketten"
+
+msgid "Package Search"
+msgstr "Pakket zoeken"
+
+msgid "Packages for %s:"
+msgstr "Pakketten voor %s:"
+
+msgid "Pick Mirror"
+msgstr "Mirror selecteren"
+
+msgid "Platinum Sponsor"
+msgstr "Platina Sponsor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Wees u ervan bewust dat de volgende pakketten uit niet-officiële "
+"installatiebronnen komen.\n"
+"  Dit betekent dat ze niet door openSUSE zijn bekeken en onstabiele of "
+"experimentele software kunnen bevatten."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Voer een <b>korte</b> reden in (in het Engels!) waarom u de dvd's nodig hebt "
+"en lever een koppeling van het evenement/doel."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Merk op dat dit niet de nieuwste uitgave van openSUSE is. De nieuwste versie "
+"is <a href='/'>hier</a> te verkrijgen. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promotie-dvd's en alle gerelateerde illustraties -labels en zakjes- kunnen "
+"gedownload\n"
+"        worden vanaf de <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd-downloadmap %s</a>.\n"
+"        Bedenk dat dit een speciale versie van openSUSE is, namelijk "
+"ontworpen voor promotiedoelen."
+
+msgid "Related categories:"
+msgstr "Gerelateerde categorieën:"
+
+msgid "Released Version"
+msgstr "Vrijgegeven versie"
+
+msgid "Reporting Bugs"
+msgstr "Bugs/fouten rapporteren"
+
+msgid "Rescue"
+msgstr "Reddingssysteem"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Een reddingssysteem waarmee u vanaf een cd of een USB stick kan werken.<br/"
+">Kan niet gebruikt worden om mee te installeren of op te waarderen."
+
+msgid "SHA256 checksum"
+msgstr "SHA256-controlesom"
+
+msgid "Search"
+msgstr "Zoeken"
+
+msgid "Select Your Operating System"
+msgstr "Kies uw besturingssysteem"
+
+msgid "Select the image type"
+msgstr "Selecteer het type image"
+
+msgid "Show"
+msgstr "Tonen"
+
+msgid "Show development, language and debug packages"
+msgstr "Pakketten voor ontwikkeling, talen en debuggen tonen"
+
+msgid "Show distribution:"
+msgstr "Distributie tonen:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Meer pakketten voor niet ondersteunde distributies tonen"
+
+msgid "Show more..."
+msgstr "Meer tonen..."
+
+msgid "Show other versions"
+msgstr "Andere versies tonen"
+
+msgid "Show unstable packages"
+msgstr "Toon onstabiele pakketten"
+
+msgid "Show unsupported packages"
+msgstr "Niet ondersteunde pakketten tonen"
+
+msgid "Silver Sponsor"
+msgstr "Silver Sponsor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Sommige alternatieve media (bijv. live- en rescue-systemen) zijn ook "
+"beschikbaar, hoewel ze minder zijn getest en alleen aanbevolen voor beperkt "
+"gebruik."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Enkele van de live-distributies gebaseerd op openSUSE. Wie geïnteresseerd is "
+"om eigen afgeleiden te bouwen kunnen een kijkje nemen op <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Bron"
+
+msgid "Sponsored by"
+msgstr "Gesponsord door"
+
+msgid "Sponsored by: AMD"
+msgstr "Gesponsord door: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Gesponsord door B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Gesponsord door: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Gesponsord door: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Subpakketten"
+
+msgid "Support"
+msgstr "Ondersteuning"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Het installatieproces is beschikbaar in vele talen maar, voor de meesten zit "
+"de vertaling van de applicaties niet in de image. Als u wilt dat uw openSUSE-"
+"systeem enkele additionele talen ondersteunt, dan moet u deze van het "
+"internet tijdens de installatie of elk moment later downloaden. Als u "
+"gemakkelijk toegang hebt tot het internet dan hebt u deze cd niet nodig, "
+"maar als u van plan bent om openSUSE te installeren op een machine zonder "
+"internetverbinding, dan biedt het toegang tot alle beschikbare vertalingen."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Voer dan het volgende als <strong>root</strong> uit"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Er is op dit moment geen openSUSE uitgave in een testfase. <br/> Als u de "
+"allernieuwste software wilt, gebruik dan <a href='http://nl.opensuse.org/"
+"Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Deze cd bevat vrije software gedistribueerd onder propiëtaire licentie die "
+"niet toestaat het in te voegen op het hoofdinstallatiemedium samen met vrije "
+"opensource software. Alle software op deze cd kan worden gedownload vanaf "
+"een NON-OSS-installatiebron."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Deze versie draait op alle PC's inclusief die 64 bit ondersteunen. Als u "
+"meer dan 3 GB RAM hebt dan zou u echter de voorkeur moeten geven aan de 64 "
+"bit versie. openSUSE ondersteunt geen processors voor de Pentium - de live-"
+"cd's ondersteunen zelfs alleen i686 (Pentium Pro en later)."
+
+msgid "Type of Computer"
+msgstr "Type computer"
+
+msgid "Unsupported distributions:"
+msgstr "Niet ondersteunde distributies:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Handleidingen voor gebruikers zijn beschikbaar op <a href=\"http://activedoc."
+"opensuse.org\">activedoc.opensuse.org</a>, bijvoorbeeld de <a href=\"http://"
+"activedoc.opensuse.org/book/opensuse-start-up/\">Officiële handleiding voor "
+"opstarten (Engels)</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Het gebruik van <a href=\"http://nl.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent</a> wordt aangeraden op langzame links, speciaal bij het "
+"downloaden van de dvd-image. Downloaden met BitTorrent heeft verschillende "
+"voordelen, de client beschermt tegen datacorruptie en u helpt de load van de "
+"servers te verlichten door deel te nemen in het uploaden - als genoeg mensen "
+"deelnemen zal het ook voor iedereen sneller zijn dan met de gecentraliseerde "
+"servers. Bovendien staat het toe het downloaden op elk moment te stoppen en "
+"het later te hervatten."
+
+msgid "Verify your download before use"
+msgstr "Verifieer uw download alvorens deze te gebruiken"
+
+msgid "Version"
+msgstr "Versie"
+
+msgid "We offer three different checksums:"
+msgstr "Wij bieden drie verschillende controlesommen:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"We willen graag dat u ons geïnformeerd houdt over uw gebruik van de dvd's, "
+"zodat we\n"
+"        u kunnen helpen om uw organisatie, evenement of school op onze\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>nieuwspagina</a>\n"
+"        of op andere bronnen te promoten. (Hint! We ontvangen graag foto's. "
+"Maak er veel!).\n"
+"        Neem contact met ons op op <a href='mailto:opensuse-"
+"marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>\n"
+"        om over promotie te praten en/of over andere manieren waarop we u "
+"kunnen assisteren."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Bij het downloaden van images anders dan de CD voor netwerkinstallatie, "
+"wordt het gebruik van een goede download-manager <i>sterk</i> aangeraden om "
+"het risico van corrupte data te verminderen."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"U kunt de repository-key aan apt toevoegen. Bedenk dat de eigenaar van de "
+"key updates, pakketten en repositories kan distribueren die uw systeem zal "
+"vertrouwen (<a href=\"%s\">meer informatie</a>). Om de key toe te voegen, "
+"voer uit:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"U zou uw zoekopdracht naar pakketten in ontwikkeling kunnen uitbreiden of "
+"zoeken naar een andere basisdistributie (nu )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"U kunt het downloadproces verifiëren. Een controlesom (SHA256) zal "
+"automatisch worden gebruikt als u <a href='http://nl.opensuse.org/SDB:"
+"Metalink'>Metalink</a> in de het bovenstaande veld gebruikt en de addon "
+"DownThemAll! in <a href='http://nl.opensuse.org/Firefox'>Firefox</a> "
+"gebruikt."
+
+msgid "gpg signature"
+msgstr "gpg-ondertekening"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://nl.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://nl.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://nl.opensuse.org/Portal:Installatie"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://nl.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://nl.opensuse.org/SDB:Download_help#De_ISO_image.28s.29_branden"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://nl.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://docs.opensuse.org/releasenotes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/releasenotes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/releasenotes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/releasenotes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/releasenotes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"is nog steeds de meest algemeen gebruikte controlesom. Veel ISO-branders "
+"tonen het direct voor het branden."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "is de minst bekende, maar veiliger dan de controlesom van md5."
+
+msgid "md5 checksum"
+msgstr "MD5-controlesom"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"biedt de meeste veiligheid omdat u kunt verifiëren wie het heeft "
+"ondertekend. Het zou moeten zijn <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Aftellen voor openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE afgeleiden"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE is beschikbaar via http (met een directe koppeling) of via "
+"BitTorrent. De cd voor netwerkinstallatie is alleen beschikbaar via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE ondersteunt alleen PC's met 32 en 64 bits."
+
+msgid "see Derivatives on wiki"
+msgstr "Kijk op Afgeleiden op de wiki"
+
+msgid "sha1 checksum"
+msgstr "sha1-controlesom"
+
+msgid "switch to"
+msgstr "omschakelen naar"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Er deed zich een interne fout voor :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Gaarne een meer dan 2 lettertekens invoeren"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://docs.opensuse.org/releasenotes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://docs.opensuse.org/releasenotes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Laatste zoekopdrachten:"
+
+# /usr/lib/YaST2/clients/lan_inetd_custom.ycp:754
+#~ msgid "Statistics"
+#~ msgstr "Statistieken"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Top 1-kliksdownloads:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Meest gebruikte zoekopdrachten zonder hits:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Meest gebruikte zoekopdrachten:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Op dit moment is er geen \"Factory Snapshot\" die recenter is dan onze "
+#~ "laatste openSUSE uitgave. <br/>Controleer aub <a href='http://en.opensuse."
+#~ "org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> voor meer "
+#~ "informatie."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr ""
+#~ "U kunt de sleutel van de installatiebron aan apt op de volgende manier "
+#~ "toevoegen: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4,7GB dvd"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live-cd's bevatten alleen vier talen (Engels, Duits, Russisch en "
+#~ "Italiaans). Als u ondersteuning wilt voor de overblijvende talen dan "
+#~ "dient u dat te downloaden vanaf het internet tijdens de installatie of "
+#~ "enige tijd later. Als u gemakkelijk toegang hebt tot het internet of als "
+#~ "u de dvd gebruikt met alle talen, dan heeft u deze cd niet nodig."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Na het met succes downloaden van de ISO-images, brandt u deze met uw "
+#~ "favoriete branderprogramma op een dvd of cd. U dient <em>geen</em> data "
+#~ "dvd/cd te branden, maar u kiest de optie om een ISO-image te branden."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.nl.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.nl.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Gaarne een zoektekst van minstens 2 lettertekens gebruiken"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Omgeschakeld naar een exacte overeenkomst vanwege te veel hits op zoeken "
+#~ "naar een gedeelte van een tekenreeks."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Gaarne de zoekopdracht verfijnen, zoeklimiet is bereikt."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Kon zoekopdracht niet uitvoeren: "
+
+# /usr/lib/YaST2/clients/lan_finish.ycp:62
+# /usr/lib/YaST2/clients/lan_finish.ycp:102
+# /usr/lib/YaST2/clients/lan_finish.ycp:184
+#~ msgid "Popular Software"
+#~ msgstr "Populaire software"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "openSUSE kopen"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://nl.opensuse.org/OpenSUSE_kopen"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Eénklik-installeren"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Handmatig pakketten downloaden"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Ga naar OBS-project"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Software verzameling]"
+
+#~ msgid "Search Results"
+#~ msgstr "Zoekresultaten"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Geen pakketten in de openSUSE-buildservice gevonden die overeenkomen met "
+#~ "uw zoekopdracht."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d verzamelingen en %d binaries uit %d bronpakketten"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Schermafdruk van  "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Zoekstatistieken:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Downloadstatistieken"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Zoek en installeer software pakketten uit de <a href=\"http://build."
+#~ "opensuse.org\">openSUSE build-service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Zoekopties"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "De home-projecten van de gebruikers insluiten"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Debug-pakketten uitsluiten"
+
+#~ msgid "Additional Information"
+#~ msgstr "Extra informatie"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Snel starten met de installatie (Engels)</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "openSUSE 11.3 kopen"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "openSUSE 11.3 kopen!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Meer informatie over downloaden van openSUSE is beschikbaar op <a href="
+#~ "\"http://nl.opensuse.org/SDB:Hulp_bij_downloaden\">Hulp bij downloaden.</"
+#~ "a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "De volgende instructies zijn beschikbaar:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Installatie vanaf dvd/cd:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Officiële %s Start-Up handleiding"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Stap-voor-stap installatiehandleiding"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Netwerkinstallatie"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://nl.opensuse.org/SDB:Netwerkinstallatie"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Installatie vanaf het internet"
+
+#~ msgid "More information"
+#~ msgstr "Meer informatie"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://nl.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://nl.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Software verkrijgen"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Software bouwen"
+
+#~ msgid "User Directory"
+#~ msgstr "Gebruikersmap"
+
+#~ msgid "Features"
+#~ msgstr "Functies"
+
+#~ msgid "News"
+#~ msgstr "Nieuws"
+
+#~ msgid "Forums"
+#~ msgstr "Forums"
+
+#~ msgid "Shop"
+#~ msgstr "Winkel"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Sofware zoeken"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Installatiebron voor bijwerken"
+
+#~ msgid "Source Repository"
+#~ msgstr "Installatiebron voor broncode"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Andere opties"
+
+#~ msgid "Mirrors"
+#~ msgstr "Mirrors"
+
+#~ msgid "In other languages"
+#~ msgstr "In andere talen"
+
+#~ msgid "Get it"
+#~ msgstr "Verkrijg het"
+
+#~ msgid "Search Build Service"
+#~ msgstr "In build-service zoeken"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Zoek naar en installeer additionele software pakketten uit de openSUSE "
+#~ "build-service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "openSUSE verkrijgen"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Een permanente koppeling maken naar dit resultaat"
+
+#~ msgid "Nothing found"
+#~ msgstr "Niets gevonden"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Verkrijg software uit de openSUSE build-service"
+
+#~ msgid "Searching"
+#~ msgstr "Zoeken"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Bevat een grote collectie software voor gebruik op het bureaublad en of "
+#~ "op een server. Geschikt voor eerste installatie of opwaarderen."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Een GNOME-bureaublad die u vanaf de cd of van een USB stick kan draaien. "
+#~ "Kan ook zo geïnstalleerd worden (kan niet opwaarderen)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Een KDE-bureaublad die u vanaf de cd of van een USB stick kan draaien. "
+#~ "Kan ook zo geïnstalleerd worden (kan niet opwaarderen)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Doet een download van het installatiesysteem en alle pakketten vanaf een "
+#~ "online installatiebron. Geschikt voor installatie en opwaarderen."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinks"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Koop openSUSE 11.1!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Voor gebruikers die nieuw zijn in Linux, is de ondersteunde versie van "
+#~ "openSUSE de beste keuze&mdash;u krijgt complete "
+#~ "eindgebruikerdocumentatie, installeerbare media voor 32- en 64-bit "
+#~ "systemen plus 90 dagen installatieondersteuning."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 is verkrijgbaar in verschillende <a href=\"http://nl."
+#~ "opensuse.org/Buy_openSUSE\">online</a>-winkels of bij locale winkeliers."
+
+#~ msgid "Expert view"
+#~ msgstr "Expert weergave"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Computers met bijv. AMD&reg; Sempron of Intel&reg; Celeron&trade;, "
+#~ "bijna alle bureaubladcomputers uit 2004 of eerder. Deze versie draait ook "
+#~ "op 64-bit PC's."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: De meeste nieuwe computers met bijv. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, of Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPU's."
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr ""
+#~ "Het kleinste medium (ongeveer 100MB) doet een download van het "
+#~ "installatiesysteem en software uit de online installatiebronnen."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "Om een medium te downloaden kiest u uit de manieren van installatie, "
+#~ "mogelijk met wijziging van de architectuur en de manier van downloaden en "
+#~ "kiest daarna \"Bestand opslaan\"."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Popup: Hulp bij downloaden media"
+
+#~ msgid "Help"
+#~ msgstr "Help"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "DVD is het standaard medium voor het meeste"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Live-CD met GNOME-bureaublad"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Live-CD met KDE-bureaublad"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "Netwerkinstallatie voor experts"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "is nog steeds de meest algemeen gebruikte controlesom. Veel ISO-branders "
+#~ "tonen het direct voor het branden.."
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr "is de minder bekende, maar veiliger dan de controlesom van md5.."

--- a/locale/pl/software.po
+++ b/locale/pl/software.po
@@ -1,0 +1,1316 @@
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# Przemysław Bojczuk <pbojczuk@opensuse.org>, 2009, 2013.
+# Mariusz Fik <fisiu@opensuse.org>, 2010, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2013-10-20 01:57+0100\n"
+"Last-Translator: Przemyslaw Bojczuk <pbojczuk@opensuse.org>\n"
+"Language-Team: Polish <opensuse-pl@opensuse.org>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+
+msgid " and "
+msgstr " oraz"
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} nie jest wspieranym wydaniem.\""
+
+msgid "(hide)"
+msgstr "(ukryj)"
+
+msgid "(show)"
+msgstr "(pokaż)"
+
+msgid "... and keep us informed"
+msgstr "... oraz informuj nas na bieżąco"
+
+msgid "... get other marketing stuff"
+msgstr "... zdobądź pozostałe materiały marketingowe"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (obraz również dla pamięci USB)"
+
+msgid "64 Bit PC"
+msgstr "64 bitowy PC"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+"startup/\">pierwsze kroki w openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">Metalink</a> to otwarty "
+"standard, który łączy różne technologie (FTP/HTTP/BitTorrent) aby uzyskać "
+"jeden format w celu łatwiejszego pobierania plików. To czyni go dobrym "
+"narzędziem do pobierania obrazów płyt ISO; szczególnie dla osób, które nie "
+"mogą korzystać z sieci P2P w wyniku ograniczeń nałożonych przez ich "
+"dostawców Internetu lub uczelnie. Może on zapewnić wysoką prędkość "
+"pobierania, gdyż większość klientów zapewnia jednoczesne i równoległe "
+"połączenia do wielu serwerów w sposób automatyczny. Dodatkowo zapewnia "
+"automatyczne wykrywanie i korekcję błędów. Wymaga jednak użycia "
+"odpowiedniego klienta."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licencja</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Informacje o wydaniu</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>wydanie oficjalne</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>oficjalna aktualizacja</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Środowisko GNOME, które można uruchomić z %s lub pamięci USB.<br/>Można "
+"zainstalować na zasadzie \"as is\" (bez możliwości aktualizacji). "
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Środowisko KDE, które można uruchomić z %s lub pamięci USB.<br/>Można "
+"zainstalować na zasadzie \"as is\" (bez możliwości aktualizacji)."
+
+msgid "Add repository and install manually"
+msgstr "Dodaj repozytorium i zainstaluj ręcznie"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Pobieranie dodatków (opcjonalne) "
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Po pobraniu obrazów płyt, należy wypalić je na płytach lub przygotować na "
+"pamięci USB bootowalny system. "
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Wszelkie dane są używane jedynie w celu przesyłania materiałów\n"
+"          promocyjnych dotyczących openSUSE i nie zostaną przekazane "
+"stronom\n"
+"          trzecim. Przechowujemy dane, aby informować użytkowników o nowych\n"
+"          wersjach oprogramowania. Wszystkie żądania muszą zostać sprawdzone "
+"pod\n"
+"          kątem nienaruszania przepisów embarga eksportowego Stanów "
+"Zjednoczonych.\n"
+"          Więcej informacji na temat embarga oraz listy krajów nim objętych "
+"można znaleźć\n"
+"          w Wikipedii: <a href='http://en.wikipedia.org/wiki/"
+"United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Przeglądarka aplikacji"
+
+msgid "Available Images"
+msgstr "Dostępne obrazy"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Uruchom komputer z płyty lub pamięci przenośnej USB. W przypadku problemów z "
+"uruchomieniem z wybranego urządzenia, należy je wskazać w opcjach "
+"uruchamiania w biosie komputera. "
+
+msgid "Bronze Sponsor"
+msgstr "Brązowy Sponsor"
+
+msgid "Browser incompatibility"
+msgstr "Niekompatybilność przeglądarki"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Nagrywanie obrazów CD/DVD"
+
+msgid "Categories"
+msgstr "Kategorie"
+
+msgid "Category"
+msgstr "Kategoria"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Proszę wybrać źródło instalacji poprzez zaznaczenie go (kliknięciem), a "
+"następnie kliknięcie przycisku Pobierz (Download), by rozpocząć pobieranie. "
+"Dodatkowo można wybrać rodzaj komputera oraz inną metodę pobrania. "
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Kliknij by pobrać"
+
+msgid "Community"
+msgstr "Społeczność"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Zawiera bogatą kolekcję oprogramowania dla systemu klasy desktop lub serwer."
+"<br/>Zalecane w przypadku instalacji lub aktualizacji."
+
+msgid "Countdown"
+msgstr "Odliczanie"
+
+msgid "Country"
+msgstr "Kraj"
+
+msgid "Development"
+msgstr "Wersja rozwojowa"
+
+msgid "Development Version"
+msgstr "Wersja rozwojowa"
+
+msgid "Development packages"
+msgstr "Pakiety w wersji rozwojowej:"
+
+msgid "Development-"
+msgstr "Wersja rozwojowa"
+
+msgid "Direct Install"
+msgstr "Bezpośrednia instalacja"
+
+msgid "Direct Link"
+msgstr "Bezpośredni odnośnik"
+
+msgid "Documentation"
+msgstr "Dokumentacja"
+
+msgid "Don't show this warning the next time"
+msgstr "Nie wyświetlaj tego ostrzeżenia następnym razem"
+
+msgid "Download"
+msgstr "Pobierz"
+
+msgid "Download %s"
+msgstr "Pobierz %s"
+
+msgid "Download Help"
+msgstr "Informacje o pobieraniu"
+
+msgid "Download Method"
+msgstr "Sposób pobierania"
+
+msgid "Download appliance from %s"
+msgstr "Pobierz dystrybucję pochodną z %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Pobierz&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Pobierz LiveCD z&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Pobierz LiveCD z&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Pobierz obraz instalacji sieciowej"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Pobierz&nbsp;system ratunkowy"
+
+msgid "Downloads"
+msgstr "Pobieranie"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"System do instalacji wraz ze wszystkimi pakietami zostanie pobrany z "
+"repozytoriów online.<br/>Zalecane w przypadku instalacji lub aktualizacji."
+
+msgid "Expand all sections ('e')"
+msgstr "Rozwiń wszystkie rozdziały ('e')"
+
+msgid "Extra Languages"
+msgstr "Dodatkowe języki"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Dodatkowe języki (32 Bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Dodatkowe języki (64 Bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Dla <strong>%s</strong> uruchom następujący program jako <strong>root</"
+"strong>:"
+
+#, fuzzy
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+"Dla <strong>%s</strong> uruchom następujący program jako <strong>root</"
+"strong>:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be"
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"daje możliwość sprawdzenia przez kogo plik został podpisany (najbardziej "
+"bezpieczne). Wartość pgp powinna wynosić"
+
+msgid "Games"
+msgstr "Gry"
+
+#, fuzzy
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Pobierz jedną z specjalnie zbudowanych dystrybucji openSUSE"
+
+msgid "Getting Help"
+msgstr "Jak uzyskać pomoc"
+
+msgid "Gold Sponsor"
+msgstr "Złoty sponsor"
+
+msgid "Grab binary packages directly"
+msgstr "Pobierz pakiety binarne bezpośrednio"
+
+msgid "Header Logo"
+msgstr "Logo nagłówka"
+
+msgid "Help on Download Method"
+msgstr "Pomoc dotycząca sposobu pobierania"
+
+msgid "Help on Type of Computer"
+msgstr "Pomoc dotycząca rodzaju komputera"
+
+msgid "How to Proceed"
+msgstr "Jak postępować"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Osoby, które chciałyby użyć bezpośredniego łącza, ale mieszkają w rejonie, w "
+"którym podczas przekierowania nie można uzyskać informacji, który serwer "
+"lustrzany będzie najszybszy, powinny wybrać serwer samodzielnie. "
+
+msgid "Image:"
+msgstr "Grafika:"
+
+msgid "Install package %s / %s"
+msgstr "Instalacja pakietu %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Instalacja wzorca %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Zainstaluj używając Instalacji Jednym Kliknięciem"
+
+msgid "Installation Guides"
+msgstr "Przewodniki instalacji "
+
+msgid "Installation Medium"
+msgstr "Źródło instalacji"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Dołącz do rosnącej społeczności i pokaż innym najnowsze\n"
+"        openSUSE PromoDVD swojemu zespołowi, organizacji non-profit,\n"
+"        szkole, uniwersytetowi. Zabierz je na spotkania i konferencje grup "
+"Linuksa.\n"
+"        PromoDVD pomaga zwiększyć świadomość innych związaną\n"
+"        z openSUSE oraz jego rozpoznawalność!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Przeglądarka Konqueror w wersji z KDE3 nie jest już wspierana. Zawarty w "
+"niej kod JavaScript zawiera błędy sprawiające, że nie da się jej używać z tą "
+"stroną. Należy upewnić się, że obsługa JavaScript została zablokowana przed "
+"<a href='%s'>kontynuacją</a>."
+
+msgid "Language"
+msgstr "Język"
+
+#, fuzzy
+msgid "Legacy 32 Bit PC"
+msgstr "32 bitowy PC"
+
+#, fuzzy
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32&nbsp;bitowy &nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Wiele programów może sprawdzić sumy kontrolne pobranych plików. Sprawdzenie "
+"pobranych plików może być istotne, ponieważ potwierdzi, że pobrano żądane "
+"obrazy ISO i nie zostały one uszkodzone."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Więcej informacji na temat nagrywania plików ISO na płyty CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Więcej informacji o <a href='http://en.opensuse.org/"
+"Live_USB_stick'>botowalnym pendrive</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Więcej informacji na temat pobierania openSUSE jest dostępne na stronach <a "
+"href=\"http://en.opensuse.org/SDB:Download_help\">Pomoc przy pobieraniu</a> "
+"oraz <a href=\"http://en.opensuse.org/SDB:Network_installation\">Instalacja "
+"sieciowa</a> w <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Portalu dokumentacji</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Większość współczesnych komputerów oferuje obsługę architektury <a href="
+"\"http://en.wikipedia.org/wiki/X86-64\">x86-64</a> (znaną również jako AMD64 "
+"czy Intel64), jednak niektóre procesory w laptopach, czy netbookach mogą nie "
+"być z nią zgodne. By się upewnić, czy dany komputer obsługuje architekturę "
+"x86-64 należy poszukać odpowiednich informacji na Wikipedii."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Potrzebna pomoc?"
+
+msgid "Network"
+msgstr "Sieć"
+
+msgid "No appliance data for %s"
+msgstr "Brak danych dla dystrybucji pochodnej %s"
+
+msgid "No appliances found in project %s"
+msgstr "Żadne dystrybucje pochodne nie zostały znalezione w projekcie %s"
+
+msgid "No data for %s / %s"
+msgstr "Brak danych dla %s / %s"
+
+msgid "No description found..."
+msgstr "Nie znaleziono opisu..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Nie odnaleziono niczego do pobrania dla %s w projekcie %s"
+
+msgid "No packages found matching your search. "
+msgstr "Nie znaleziono pasujących pakietów."
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+msgid "OBS Backend not available"
+msgstr "Moduł OBS jest niedostępny"
+
+msgid "Official Manuals"
+msgstr "Oficjalne podręczniki"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr "Pakiet %s nie został znaleziony..."
+
+msgid "Package Repositories"
+msgstr "Repozytoria pakietów"
+
+msgid "Package Search"
+msgstr "Wyszukiwanie pakietów"
+
+msgid "Packages for %s:"
+msgstr "Pakiety dla %s:"
+
+msgid "Pick Mirror"
+msgstr "Wybierz serwer lustrzany"
+
+msgid "Platinum Sponsor"
+msgstr "Platynowy sponsor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Należy pamiętać, że następujące pakiety pochodzą z nieoficjalnych "
+"repozytoriów.\n"
+"   Oznacza to, że nie zostały zweryfikowane przez openSUSE i mogą zawierać "
+"niestabilne lub eksperymentalne oprogramowanie."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Proszę <b>krótko</b> uzasadnić (w języku angielskim), do czego potrzebne "
+"jest DVD oraz zamieścić link opisujący cel lub wydarzenie."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Należy pamiętać, że to nie jest najnowsze wydanie openSUSE. Najnowszą wersję "
+"można pobrać <a href='/'>stąd</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Obrazy płyt DVD w wersjach promocyjnych wraz z elemantami graficznymi\n"
+"        jak etykiety, czy wkładki,  można pobrać ze strony: <a href=\"http://"
+"download.opensuse.org/promodvd/\">promodvd\n"
+"        z katalogu %s</a>. Należy zwrócić uwagę, że ta wersja openSUSE,\n"
+"        jest przeznaczona do celów promocyjnych."
+
+msgid "Related categories:"
+msgstr "Powiązane kategorie:"
+
+msgid "Released Version"
+msgstr "Numer wersji"
+
+msgid "Reporting Bugs"
+msgstr "Zgłaszanie błędów"
+
+msgid "Rescue"
+msgstr "System ratunkowy"
+
+#, fuzzy
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"System ratunkowy, który można uruchomić z płyty CD lub pamięci USB.</br>Brak "
+"możliwości instalacji i aktualizacji."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "suma kontrolna md5"
+
+msgid "Search"
+msgstr "Wyszukiwanie"
+
+msgid "Select Your Operating System"
+msgstr "Proszę wybrać system operacyjny"
+
+msgid "Select the image type"
+msgstr "Proszę wybrać rodzaj obrazu"
+
+msgid "Show"
+msgstr "Pokaż"
+
+msgid "Show development, language and debug packages"
+msgstr "Wyświetl pakiety dla deweloperów, językowe i debugowania"
+
+msgid "Show distribution:"
+msgstr "Wyświetl dystrybucję:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Wyświetl więcej pakietów dla niewspieranych dystrybucji"
+
+msgid "Show more..."
+msgstr "Wyświetl więcej..."
+
+msgid "Show other versions"
+msgstr "Wyświetl pozostałe wersje"
+
+msgid "Show unstable packages"
+msgstr "Wyświetl niestabilne pakiety"
+
+msgid "Show unsupported packages"
+msgstr "Wyświetl niewspierane pakiety"
+
+msgid "Silver Sponsor"
+msgstr "Srebrny sponsor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Niektóre z dystrybucji typu live bazujących na openSUSE. Osoby "
+"zainteresowane zbudowaniem własnej dystrybucji pochodnej mogą odwiedzić "
+"stronę <a href=\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Źródło"
+
+msgid "Sponsored by"
+msgstr "Sponsorowany przez"
+
+msgid "Sponsored by: AMD"
+msgstr "Sponsorowane przez: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponsorowany przez: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponsorowane przez: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponsorowane przez: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Pakiety podrzędne:"
+
+msgid "Support"
+msgstr "Wsparcie"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Instalacja została przetłumaczona na wiele języków, jednak tłumaczenia "
+"wszystkich programów mogły się nie zmieścić na tym nośniku. Wsparcie dla "
+"innych języków w openSUSE jest dostępne podczas instalacji - odpowiednie "
+"pakiety zostaną pobrane z Internetu. Można też je dodać w dowolnym momencie "
+"po instalacji. Jeżeli masz dostęp do Internetu, ten nośnik nie jest "
+"konieczny. Jeżeli jednak instalacja ma zostać wykonana na komputerze bez "
+"dostępu do Internetu, to ułatwi on dostęp do wszystkich tłumaczeń."
+
+#, fuzzy
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+"Dla <strong>%s</strong> uruchom następujący program jako <strong>root</"
+"strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Ten nośnik zawiera oprogramowanie objęte licencją własnościową, nie "
+"pozwalającą na umieszczenie go razem z oprogramowaniem open-source na "
+"nośniku instalacyjnym. Oprogramowanie to jest dostępne także w repozytorium "
+"NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Ta wersja może być uruchomiona na wszystkich 64 bitowych komputerach. Jeżeli "
+"system posiada więcej niż 3 GB pamięci, powinno się jednak rozważyć "
+"zastosowanie 64 bitowej wersji. Ta wersja openSUSE nie wspiera procesorów "
+"starszych niż Pentium - wersje LiveCD obsługują wyłącznie architekturę i686 "
+"(procesory Pentium Pro i nowsze)  "
+
+msgid "Type of Computer"
+msgstr "Rodzaj komputera"
+
+msgid "Unsupported distributions:"
+msgstr "Niewspierane dystrybucje:"
+
+#, fuzzy
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Instrukcje są dostępne na stronie <a href=\"http://doc.opensuse.org\">doc."
+"opensuse.org</a>, na przykład <a href=\"http://doc.opensuse.org/products/"
+"opensuse/openSUSE/opensuse-startup/\">Oficjalny przewodnik - pierwsze kroki</"
+"a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Użycie <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> jest "
+"zalecane szczególnie w przypadku pobierania obrazów płyt DVD przez wolne "
+"połączenia internetowe. Pobieranie przez BitTorrent ma kilka zalet, "
+"zabezpiecza przed uszkodzeniem plików podczas pobierania oraz pomaga "
+"odciążyć serwery poprzez współdzielenie pobieranego pliku - jeżeli "
+"wystarczająco dużo osób będzie udostępniać plik, BitTorrent będzie szybszy "
+"od serwerów centralnych - dla każdego. Ponadto proces pobierania można "
+"przerwać w dowolnym momencie i wznowić go w późniejszym czasie."
+
+msgid "Verify your download before use"
+msgstr "Sprawdzenie pobranych danych przed instalacją"
+
+msgid "Version"
+msgstr "Wersja"
+
+msgid "We offer three different checksums:"
+msgstr "Proponujemy trzy różne sumy kontrolne:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Powiedz nam, jak korzystasz z płyt, by podnieść skuteczność promocji\n"
+"        Twojej organizacji, szkoły, czy eventu na naszej stronie\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse."
+"org'>wiadomości</a>\n"
+"        lub innych miejscach (mała podpowiedź: uwielbiamy zdjęcia! Dużo "
+"zdjęć!).\n"
+"        Napisz na adres:\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        w celu omówienia sposobów promocji oraz innych pomysłów byśmy mogli "
+"pomóc."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"W przypadku pobierania obrazów płyt innych niż do instalacji sieciowej, "
+"zaleca się używać odpowiedniego programu do pobierania, który pomoże obniżyć "
+"ryzyko uszkodzenia pobieranego pliku."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Można spróbować rozszerzyć wyniki wyszukiwania o pakiety deweloperskie lub "
+"przeszukać inną dystrybucję bazową (aktualnie)."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Można zweryfikować plik w trakcie jego pobierania. Dla przykładu suma "
+"kontrolna (SHA256) będzie użyta domyślnie, jeśli wybrana zostanie opcja <a "
+"href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> w powyższym polu, a "
+"do pobierania używany będzie dodatek DownThemAll! dla przeglądarki <a "
+"href='http://en.opensuse.org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "podpis gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/RELEASE-NOTES.pl.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"https://www.suse.com/releasenotes/x86_64/openSUSE/12.2/RELEASE-NOTES.pl.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/12.3/"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/13.1"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/13.1"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr ""
+"https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/RELEASE-NOTES.pl.html"
+
+#, fuzzy
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr ""
+"https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/RELEASE-NOTES.pl.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"jest najczęściej używanym rodzajem sumy kontrolnej. Wiele programów do "
+"nagrywania płyt wyświetla jej wartość przed nagraniem płyty."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr ""
+"jest mniej popularna, lecz dająca większą pewność poprawności plików niż md5."
+
+msgid "md5 checksum"
+msgstr "suma kontrolna md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"daje największe bezpieczeństwo poprzez możliwość sprawdzenia, kto podpisał "
+"plik. Wartość powinna wynosić <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Odliczanie openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Pochodne openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE można pobrać bezpośrednio ze strony internetowej (bezpośrednie "
+"łącze http) lub przez BitTorrent. Wersja do instalacji sieciowej (obraz CD) "
+"jest dostępna wyłącznie do pobrania ze strony internetowej. "
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr ""
+"Tylko systemy 32 i 64 bitowe systemy są wspierane przez tę wersję openSUSE"
+
+msgid "see Derivatives on wiki"
+msgstr "zobacz pochodne openSUSE na wiki"
+
+msgid "sha1 checksum"
+msgstr "suma kontrolna sha1"
+
+msgid "switch to"
+msgstr "przełącz do"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Wystąpił błąd wewnętrzny :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Należy wpisać przynajmniej 2 znaki"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr ""
+#~ "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/RELEASE-NOTES.pl."
+#~ "html"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr ""
+#~ "https://www.suse.com/releasenotes/x86_64/openSUSE/12.1/RELEASE-NOTES.pl."
+#~ "html"
+
+#~ msgid "Last searches:"
+#~ msgstr "Ostatnie wyszukiwania:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statystyki"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Najczęściej pobierane:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Najczęściej wyszukiwane bez powodzenia:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Najczęściej wyszukiwane:"
+
+#, fuzzy
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://www.suse.com/releasenotes/x86_64/openSUSE/13.1"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Obecnie nie istnieje wersja systemu bazującego na wersji Factory nowszego "
+#~ "od ostatniego wydania openSUSE. <br/>Więcej informacji na stronie <a "
+#~ "href='http://en.opensuse.org/Portal:Factory'>http://en.opensuse.org/"
+#~ "Portal:Factory</a>."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Klucz repozytorium można dodać do apta w następujący sposób:"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD zawiera tylko cztery języki (angielski, niemiecki, rosyjski i "
+#~ "włoski). W celu zapewnienia wsparcia dla innych języków należy je pobrać "
+#~ "z Internetu w czasie instalacji lub później. Jeśli posiadasz dobre łącze "
+#~ "lub korzystasz z nośnika DVD zawierającego wszystkie języki, to ten "
+#~ "nośnik jest Ci niepotrzebny."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Po prawidłowym pobraniu obrazów ISO, należy wypalić je na płytach CD lub "
+#~ "DVD preferowanym programem do nagrywania. <em>Nie wolno</em> tworzyć "
+#~ "płyty z danymi. Należy wypalić obraz ISO."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr ""
+#~ "Proszę używać zapytań wyszukiwania zawierających co najmniej dwa znaki"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Przełączono na tryb dokładnego dopasowania z powodu zbyt dużej liczby "
+#~ "wyników dla wyszukiwania podciągów."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Proszę doprecyzować zapytanie, osiągnięty został limit wyszukiwania."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Nie można przeprowadzić wyszukiwania:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Popularne oprogramowanie"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Kup openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Instalacja 1-Click"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Ręczne pobieranie pakietów"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Idź do strony Projektu OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Zbiór oprogramowania]"
+
+#~ msgid "Search Results"
+#~ msgstr "Wyniki wyszukiwania"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Nie znaleziono pakietów pasujących do zapytania w usłudze budowania "
+#~ "openSUSE."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d zbiorów oraz %d binariów z pakietów źródłowych %d"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Zrzut ekranu"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Statystyki wyszukiwania:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Statystyki pobierania:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Wyszukiwanie i instalacja pakietów oprogramowania z <a href=\"http://"
+#~ "build.opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opcje wyszukiwania"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Dołącz domowe projekty użytkownika"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Wyklucz pakiety do debugowania"
+
+#~ msgid "Additional Information"
+#~ msgstr "Dodatkowe informacje"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Kup openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Kup openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Więcej informacji na temat pobierania openSUSE można uzyskać na stronie "
+#~ "<a href=\"http://en.opensuse.org/SDB:Download_help\">Download Help</a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Dostępne instrukcje (poniżej):"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Instalacja z płyt DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Oficjalny przewodnik Start-Up Guide dla %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Podręcznik instalacji krop po kroku"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Instalacja sieciowa"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Instalacja przez Internet"
+
+#~ msgid "More information"
+#~ msgstr "Więcej informacji"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Pobierz oprogramowanie"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Twórz oprogramowanie"
+
+#~ msgid "User Directory"
+#~ msgstr "Spis użytkowników"
+
+#~ msgid "Features"
+#~ msgstr "Właściwości openSUSE"
+
+#~ msgid "News"
+#~ msgstr "Wiadomości"
+
+#~ msgid "Forums"
+#~ msgstr "Forum"
+
+#~ msgid "Shop"
+#~ msgstr "Sklep"
+
+#~ msgid "Software"
+#~ msgstr "Oprogramowanie"
+
+#~ msgid "Software Search"
+#~ msgstr "Wyszukiwanie oprogramowania"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Repozytoria aktualizacji"
+
+#~ msgid "Source Repository"
+#~ msgstr "Repozytoria źródeł"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Inne opcje"
+
+#~ msgid "Mirrors"
+#~ msgstr "Serwery lustrzane"
+
+#~ msgid "In other languages"
+#~ msgstr "Dodatkowe języki"
+
+#~ msgid "Get it"
+#~ msgstr "Pobierz"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Wyszukiwanie w Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Wyszukiwanie i instalacja dodatkowych pakietów z oprogramowaniem "
+#~ "pochodzącym z openSUSE Build Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Pobierz openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Permalink do tego wyniku"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Pobierz oprogramowanie z serwisu openSUSE Build Service "
+
+#~ msgid "Searching"
+#~ msgstr "Wyszukiwanie"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Zawiera bogatą kolekcję oprogramowania dla systemu klasy desktop lub "
+#~ "serwer. Zalecane w przypadku instalacji lub aktualizacji."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Środowisko GNOME, które można uruchomić z płyty CD lub pendrive'a.  Można "
+#~ "zainstalować na zasadzie \"as is\" (bez możliwości aktualizacji). "
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Środowisko KDE, które można uruchomić z płyty CD lub pendrive'a.  Można "
+#~ "zainstalować na zasadzie \"as is\" (bez możliwości aktualizacji)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Zostanie pobrany system do instalacji wraz ze wszystkimi pakietami z "
+#~ "repozytoriów online. Zalecane w przypadku instalacji lub aktualizacji."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinki"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Kup openSUSE 11!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Dla nowych użytkowników najlepszym wyborem może być wersja openSUSE ze "
+#~ "wsparciem technicznym. Otrzymają oni dokumentację, płyty instalacyjne dla "
+#~ "systemów 32 i 64 bitowych oraz 90 dni wsparcia technicznego dla "
+#~ "użytkownika końcowego."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 jest dostępne w <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">sklepach online</a> lub u lokalnych sprzedawców."
+
+#~ msgid "Expert view"
+#~ msgstr "Pełny widok"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Komputery z procesorami jak np.: AMD&reg; Sempron lub Intel&reg; "
+#~ "Celeron&trade;, prawie każdy komputer wyprodukowany do 2004 roku. Ta "
+#~ "wersja działa również na komputerach 64 bitowych. "
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: Większość nowych komputerów z procesorami jak np,: AMD&reg;: "
+#~ "Opteron&trade;, Turion&trade; 64, Athlon&trade; 64, czy Intel&reg;: "
+#~ "Core&trade;2, Pentium&reg; 4 6xx, Pentium&reg; D."
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr ""
+#~ "Najmniejszy nośnik (około 100MB) pobiera instalację systemu oraz "
+#~ "oprogramowanie z repozytoriów w sieci."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "By pobrać plik z obrazem instalacyjnym, należy wybrać któryś ze sposobów "
+#~ "instalacji, zaznaczyć architekturę oraz sposób pobierania oraz wybrać "
+#~ "\"Zapisz plik\"."
+
+#~ msgid ""
+#~ "This CD contains a live session of the GNOME desktop. It can be installed "
+#~ "as is and also works when deployed on an USB stick."
+#~ msgstr ""
+#~ "Płyta CD zawiera działającą sesję GNOME. Może być ona zainstalowana, jak "
+#~ "również skopiowana na pendrive."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Popup: Pomoc dotycząca pobierania obrazu instalacyjnego"
+
+#~ msgid "Help"
+#~ msgstr "Pomoc"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "Płyta DVD to standardowy, najczęściej używany nośnik"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Płyta LiveCD wraz se środowiskiem GNOME"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Płyta LiveCD wraz se środowiskiem KDE"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "Instalacja przez sieć (dla zaawansowanych)"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "jest najczęściej używanym rodzajem sumy kontrolnej. Wiele programów do "
+#~ "nagrywania płyt wyświetla ją przed nagraniem płyty.. "
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr ""
+#~ "jest mniej popularn, lecz dająca większą pewność poprawności plików niż "
+#~ "MD5.."

--- a/locale/pt_BR/software.po
+++ b/locale/pt_BR/software.po
@@ -1,0 +1,1332 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Luiz Fernando Ranghetti <elchevive@opensuse.org>, 2009, 2010, 2011, 2012, 2013, 2014, 2015.
+# Isis Binder <isis.binder@gmail.com>, 2010, 2011, 2012.
+msgid ""
+msgstr ""
+"Project-Id-Version: software\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-05 09:07UTC-0300\n"
+"Last-Translator: Luiz Fernando Ranghetti <elchevive68@gmail.com>\n"
+"Language-Team: Portuguese <opensuse-pt@opensuse.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Poedit-Language: Portuguese\n"
+"X-Poedit-Country: BRAZIL\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Generator: Lokalize 2.0\n"
+
+msgid " and "
+msgstr " e "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} não é uma versão suportada.\""
+
+msgid "(hide)"
+msgstr "(ocultar)"
+
+msgid "(show)"
+msgstr "(exibir)"
+
+msgid "... and keep us informed"
+msgstr "... e nos mantenha informado"
+
+msgid "... get other marketing stuff"
+msgstr "... obter outras coisas de marketing"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "DVD de 4.7GB (também adequado para pendrive USB)"
+
+msgid "64 Bit PC"
+msgstr "PC de 64 bits"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Manual de "
+"Inicialização (em inglês)</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> é um padrão "
+"aberto que combina vários modos (FTP/HTTP/BitTorrent) de obter arquivos em "
+"um formato fácil de download. Isto o torna ótimo para baixar ISOs; "
+"principalmente para pessoas que não podem usar P2P por causa de restrições "
+"de seus provedores de Internet ou Universidades. Ele pode ter velocidades de "
+"download altas já que a maioria dos clientes suporta múltiplas conexões, a "
+"múltiplos mirrors, automaticamente. Adicionalmente, ele pode fazer detecção "
+"e correção de erros automaticamente. Ele precisa de um cliente especial para "
+"manejá-lo."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://pt.opensuse.org/Licen%C3%A7a_openSUSE\">Licença</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notas de lançamento</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>versão oficial</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>atualização oficial</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Uma área de trabalho GNOME que você pode executar a partir de %s ou de um "
+"pendrive USB.<br/>Pode ser instalada como é (sem atualização)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Uma área de trabalho KDE que você pode executar a partir de %s ou de um "
+"pendrive USB.<br/>Pode ser instalada como é (sem atualização)."
+
+msgid "Add repository and install manually"
+msgstr "Adicionar repositório e instalar manualmente"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Downloads complementares (opcional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Após ter baixado a imagem ISO com sucesso, crie um pendrive inicializável ou "
+"queime a imagem em um DVD (ou um CD se a imagem escolhida couber)"
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Todos os dados são usados apenas para enviar o material promocional\n"
+"          do openSUSE e não serão repassados a terceiros. Armazenamos os "
+"dados\n"
+"          para informar aos usuários que uma nova versão está disponível. "
+"Todos as requisições\n"
+"          são examinadas para preencherem o embargo de exportação americano. "
+"Mais informação\n"
+"          sobre o embardo e a lista de países na Wikipédia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Navegador de aplicativos"
+
+msgid "Available Images"
+msgstr "Imagens disponíveis"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Inicialize a partir do DVD, CD ou pendrive USB. Caso seu computador não "
+"inicialize automaticamente a partir do dispositivo escolhido, abra a "
+"configuração da BIOS para permitir a inicialização a partir dele."
+
+msgid "Bronze Sponsor"
+msgstr "Patrocinador bronze"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilidade do navegador"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Gravando imagem de CD/DVD"
+
+msgid "Categories"
+msgstr "Categorias"
+
+msgid "Category"
+msgstr "Categoria"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Escolha uma mídia de instalação clicando e apertando o botão Download para "
+"iniciar o download. Opcionalmente, escolha seu tipo de computador ou o "
+"método de download alternativo."
+
+msgid "Click here to display these alternative versions."
+msgstr "Clique aqui para exibir estas versões alternativas."
+
+msgid "Click to Download"
+msgstr "Clique para baixar"
+
+msgid "Community"
+msgstr "Comunidade"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Contém uma grande coleção de softwares para o uso na área de trabalho ou em "
+"servidores.<br/>Adequado para instalação ou atualização."
+
+msgid "Countdown"
+msgstr "Contador"
+
+msgid "Country"
+msgstr "País"
+
+msgid "Development"
+msgstr "Desenvolvimento"
+
+msgid "Development Version"
+msgstr "Versão de desenvolvimento"
+
+msgid "Development packages"
+msgstr "Pacotes de desenvolvimento"
+
+msgid "Development-"
+msgstr "Desenvolvimento-"
+
+msgid "Direct Install"
+msgstr "Instalar diretamente"
+
+msgid "Direct Link"
+msgstr "Link direto"
+
+msgid "Documentation"
+msgstr "Documentação"
+
+msgid "Don't show this warning the next time"
+msgstr "Não exibir este aviso da próxima vez"
+
+msgid "Download"
+msgstr "Baixar"
+
+msgid "Download %s"
+msgstr "Baixe o %s"
+
+msgid "Download Help"
+msgstr "Ajuda de download"
+
+msgid "Download Method"
+msgstr "Método de download"
+
+msgid "Download appliance from %s"
+msgstr "Baixar o appliance apartir de %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Baixe o DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Baixe o GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Baixe o KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Baixe a instalação via rede"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Baixe o CD de recuperação"
+
+msgid "Downloads"
+msgstr "Downloads"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Baixe o sistema de instalação e todos os pacotes de repositórios online.<br/"
+">Adequado para instalação e atualização."
+
+msgid "Expand all sections ('e')"
+msgstr "Expandir todas as seções ('e')"
+
+msgid "Extra Languages"
+msgstr "Idiomas extras"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Idiomas extras (32 bits)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Idiomas extras (64 bits)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"Para <strong>%s</strong> execute o seguinte como <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Para <strong>%s</strong> execute o seguinte:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Para o <strong>Arch Linux</strong>, edite o /etc/pacman.conf e adicione o "
+"seguinte (note que a ordem dos repositórios no pacman.conf é importante, já "
+"que o pacman sempre baixa o primeiro pacote encontrado):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Para cada ISO, oferecemos um arquivo de soma de verificação com a soma "
+"SHA256 correspondente."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Para uma segurança extra, você pode usar o GPG para verificar quem assinou "
+"estes arquivos .sha256. Ele deve ser %s."
+
+msgid "Games"
+msgstr "Jogos"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Baixe uma das distribuições especializadas feitas no openSUSE."
+
+msgid "Getting Help"
+msgstr "Obtendo ajuda"
+
+msgid "Gold Sponsor"
+msgstr "Patrocinador ouro"
+
+msgid "Grab binary packages directly"
+msgstr "Obter pacotes binários diretamente"
+
+msgid "Header Logo"
+msgstr "Logotipo do cabeçalho"
+
+msgid "Help on Download Method"
+msgstr "Ajuda no método de download"
+
+msgid "Help on Type of Computer"
+msgstr "Ajuda no tipo de computador"
+
+msgid "How to Proceed"
+msgstr "Como proceder"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Se você quiser usar um link direto mas vive em um lugar do mundo onde nosso "
+"redirecionador de downloads não tem muitas informações para redirecionar ao "
+"mirror mais rápido, você pode escolher um mirror você mesmo."
+
+msgid "Image:"
+msgstr "Imagem:"
+
+msgid "Install package %s / %s"
+msgstr "Instalar pacote %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Instalar padrão %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instalar usando o One Click Install"
+
+msgid "Installation Guides"
+msgstr "Guias de instalação"
+
+msgid "Installation Medium"
+msgstr "Mídia de instalação"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Junte-se a comunidade que está crescendo rápido, coloque o openSUSE em mais "
+"mãos\n"
+"        obtendo a última versão do PromoDVD para o seu grupo, organização "
+"sem fins lucrativos,\n"
+"        escola, universidade ou evento como encontros Linux, Installfests e "
+"conferências.\n"
+"        Os PromoDVDs ajudam a aumentar a visibilidade do openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Infelizmente, o Konqueror do KDE 3 não é mais continuado e sua implementação "
+"do javascript contém defeitos que a tornam impossível de ser usada com esta "
+"página. Por favor, tenha certeza de que você desabilitou o javascript antes "
+"de <a href='%s'>continuar</a>."
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Legacy 32 Bit PC"
+msgstr "PC de 32 bits (antigo)"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "PC de 32&nbsp;Bit&nbsp;PC (antigo)"
+
+msgid "Live GNOME"
+msgstr "LiveCD GNOME"
+
+msgid "Live KDE"
+msgstr "LiveCD KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Muitos aplicativos podem conferir a soma de verificação de um download. "
+"Verificar o seu download pode ser importante, pois indica que você realmente "
+"tem o arquivo ISO completo, ao invés de uma versão corrompida."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Mais informações sobre gravação de um arquivo ISO em um CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Mais informações sobre a criação de um <a href='http://pt.opensuse.org/"
+"Live_USB'>pendrive USB inicializável</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Mais informação sobre como baixar o openSUSE está disponível nas páginas <a "
+"href=\"http://pt.opensuse.org/SDB:Ajuda_de_download\">Ajuda de download</a> "
+"e <a href=\"http://pt.opensuse.org/SDB:Instala%C3%A7%C3%A3o_pela_Rede"
+"\">Instalação pela rede</a> em nosso <a href=\"http://pt.opensuse.org/Portal:"
+"Documenta%C3%A7%C3%A3o\">portal de documentação</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"A maioria dos novos computadores suporta <a href=\"http://pt.wikipedia.org/"
+"wiki/AMD64\">x86-64</a> (também conhecidos como AMD64 e Intel64), mas alguns "
+"processadores de laptops e netbooks não suportam isso. Você deve verificar "
+"na Wikipédia se quiser ter certeza que seu computador suporta x86-64."
+
+msgid "Multimedia"
+msgstr "Multimídia"
+
+msgid "Need help?"
+msgstr "Necessita ajuda?"
+
+msgid "Network"
+msgstr "Rede"
+
+msgid "No appliance data for %s"
+msgstr "Nenhum dado de appliance para %s"
+
+msgid "No appliances found in project %s"
+msgstr "Nenhum appliance encontrado no projeto %s"
+
+msgid "No data for %s / %s"
+msgstr "Sem dados para %s / %s"
+
+msgid "No description found..."
+msgstr "Nenhuma descrição encontrada..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Nenhum download encontrado para %s no projeto %s"
+
+msgid "No packages found matching your search. "
+msgstr "Nenhum pacote encontrado que corresponda a sua pesquisa. "
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+msgid "OBS Backend not available"
+msgstr "Infraestrutura do OBS não disponível"
+
+msgid "Official Manuals"
+msgstr "Manuais oficiais"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Apenas as mídias de DVD e rede são testadas completamente. As alternativas "
+"como Live, sistema de recuperação são recomendadas apenas para uso limitado."
+
+msgid "Package %s not found..."
+msgstr "Pacote '%s' não encontrado..."
+
+msgid "Package Repositories"
+msgstr "Repositórios de pacotes"
+
+msgid "Package Search"
+msgstr "Pesquisa de pacotes"
+
+msgid "Packages for %s:"
+msgstr "Pacotes para '%s'."
+
+msgid "Pick Mirror"
+msgstr "Escolha um mirror"
+
+msgid "Platinum Sponsor"
+msgstr "Patrocinador platina"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Note que os seguintes pacotes são de repositórios não oficiais.\n"
+"    Isto significa que eles não foram revisados pelo openSUSE e podem conter "
+"software instável e experimental."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Por favor, digite um <b>breve</b> motivo (em inglês) do porque você "
+"necessita dos DVDs e forneça um link do evento/propósito."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Note que esta não é a última versão do openSUSE. Você pode baixar a última "
+"versão <a href='/'>aqui</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Os PromoDVDs e toda a arte relacionada -etiquetes e capas- podem ser\n"
+"        baixadas do diretório de download %s do\n"
+"        <a href=\"http://download.opensuse.org/promodvd/\">promodvd</a>.\n"
+"        Tenha em mente que esta versão especial do openSUSE,\n"
+"        é feita principalmente para a distribuição promocional."
+
+msgid "Related categories:"
+msgstr "Categorias relacionadas:"
+
+msgid "Released Version"
+msgstr "Versão lançada"
+
+msgid "Reporting Bugs"
+msgstr "Relatando falhas"
+
+msgid "Rescue"
+msgstr "Recuperação"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Um sistema de recuperação que você pode executar a partir do CD ou de um "
+"pendrive USB.<br/>Não pode ser usado nem para instalação nem para "
+"atualização."
+
+msgid "SHA256 checksum"
+msgstr "Soma de verificação SHA256"
+
+msgid "Search"
+msgstr "Pesquisar"
+
+msgid "Select Your Operating System"
+msgstr "Selecione seu sistema operacional"
+
+msgid "Select the image type"
+msgstr "Selecione o tipo de imagem"
+
+msgid "Show"
+msgstr "Exibir"
+
+msgid "Show development, language and debug packages"
+msgstr "Exibir pacotes de desenvolvimento, idiomas e depuração"
+
+msgid "Show distribution:"
+msgstr "Exibir distribuição:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Exibir mais pacotes para distribuições não suportadas"
+
+msgid "Show more..."
+msgstr "Exibir mais..."
+
+msgid "Show other versions"
+msgstr "Exibir outras versões"
+
+msgid "Show unstable packages"
+msgstr "Exibir os pacotes instáveis"
+
+msgid "Show unsupported packages"
+msgstr "Exibir pacotes não suportados"
+
+msgid "Silver Sponsor"
+msgstr "Patrocinador prata"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Algumas mídias alternativas (por ex. Live e sistema de resgate) também estão "
+"disponíveis,are also available, embora são menos testadas e recomendadas "
+"apenas para uso limitado."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Algumas das distribuições Live baseadas no openSUSE. Aqueles interessados em "
+"construir suas próprias derivadas, podem dar uma olhada no <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Fonte"
+
+msgid "Sponsored by"
+msgstr "Patrocinado por"
+
+msgid "Sponsored by: AMD"
+msgstr "Patrocinado por: AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Patrocinado por: B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Patrocinado por: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Patrocinado por: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Subpacotes"
+
+msgid "Support"
+msgstr "Suporte"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"O processo de instalação está disponível em vários idiomas mas, para a "
+"maioria deles, a tradução dos aplicativos não está incluído na imagem. Se "
+"você quiser que seu openSUSE suporte algum idioma adicional, você precisa "
+"baixá-lo da Internet durante a instalação ou a qualquer hora após a "
+"instalação. Se você tem fácil acesso à Internet você não precisa deste CD, "
+"mas se você planeja instalar o openSUSE em alguma máquina sem conexão à "
+"Internet, ele fornecerá o acesso a todas as traduções disponíveis."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Então execute o seguinte como <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Não existe versão do openSUSE em fase de testes neste momento. <br/> Se você "
+"quer usar os softwares mais recentes, use o <a href='http://en.opensuse.org/"
+"Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Este CD contém programas gratuitos distribuídos sob licenças proprietárias "
+"que não permitem sua inclusão na mídia de instalação principal junto com "
+"programas livres. Todos os programas deste CD podem ser baixados do "
+"repositório NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Esta versão executa em todos os computadores, incluindo aqueles que suportam "
+"64 bits. Se você tem mais que 3 GB de memória RAM você deve preferir a "
+"versão 64 bits. O openSUSE não suporta processadores mais antigos que o "
+"Pentium - os LiveCDs suportam apenas i686 (Pentium Pro e mais atual)."
+
+msgid "Type of Computer"
+msgstr "Tipo de computador"
+
+msgid "Unsupported distributions:"
+msgstr "Distribuições não suportadas:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Os manuais do usuário estão disponíveis em <a href=\"http://activedoc."
+"opensuse.org\">doc.opensuse.org</a>, por exemplo o <a href=\"http://"
+"activedoc.opensuse.org/book/opensuse-start-up/\">Manual de Inicialização (em "
+"inglês)</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Usar o <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> é o "
+"recomendado em links lentos, especialmente ao baixar a imagem ISO do DVD. O "
+"download via BitTorrent tem muitos benefícios, os clientes protegem contra o "
+"corrompimento de dados e você ajuda a diminuir a carga nos servidores "
+"participando do upload - se várias pessoas participam ele também será mais "
+"rápido que servidores centralizado - para todo mundo.O que é mais "
+"importante, ele permite a você parar o download a qualquer hora e continuar "
+"mais tarde."
+
+msgid "Verify your download before use"
+msgstr "Verifique seu download antes de usar"
+
+msgid "Version"
+msgstr "Versão"
+
+msgid "We offer three different checksums:"
+msgstr ""
+"Oferecemos três diferentes métodos para verificar a integridade de um "
+"arquivo:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Gostaríamos que você nos mantivesse informado sobre o seu uso dos DVDs, "
+"para\n"
+"        podermos ajudar você a promover sua organização, evento ou escola em "
+"nossa\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>página "
+"de notícias</a>\n"
+"        ou outros recursos. (Dica! Amamos fotos. Tire várias delas!). Por "
+"favor, contate-nos (em inglês) em\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        para discutir e promover e/ou outras formas em que possamos ajudar "
+"você."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Ao baixar outras imagens que não o CD para instalação via rede é "
+"<i>altamente</i> recomendado usar um gerenciador de downloads apropriado "
+"para reduzir o risco de dados corrompidos."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Você pode adicionar a chave do repositório no apt. Tenha em mente que o dono "
+"da chave pode distribuir atualizações, pacotes e repositórios que o seu "
+"sistema irá confiar (<a href=\"%s\">mais informação</a>). Para adicionar a "
+"chave execute:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Você pode tentar expandir sua pesquisa para os pacotes de desenvolvimento ou "
+"pesquisar em outra distribuição base (atualmente )."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Você pode verificar o arquivo ao baixar. Por exemplo, uma soma de "
+"verificação (SHA256) será usada automaticamente se você escolher <a "
+"href='http://en.opensuse.org/SDB:Metalink'>Metalink</ a> no campo acima e "
+"usar o plug-in DownThemAll! no <a href='http://pt.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "Assinatura GPG"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://pt.opensuse.org/Derivadas"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://pt.opensuse.org/Package_Repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://pt.opensuse.org/SDB:Ajuda_de_download"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://pt.opensuse.org/SDB:Ajuda_de_download#Gravando_as_imagens_ISO"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://pt.opensuse.org/Submitting_Bug_Reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/RELEASE-NOTES."
+"pt_BR.html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/RELEASE-NOTES."
+"pt_BR.html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/RELEASE-NOTES."
+"pt_BR.html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1/RELEASE-NOTES."
+"pt_BR.html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/RELEASE-NOTES."
+"pt_BR.html"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.pt_BR.html"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr ""
+"http://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/RELEASE-"
+"NOTES.pt_BR.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"ainda é a soma de verificação mais amplamente usada. Muitos gravadores de "
+"ISO a exibem antes da gravação."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "é a menos conhecida, mas é mais segura que o MD5."
+
+msgid "md5 checksum"
+msgstr "Soma de verificação MD5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"oferece a maior segurança já que você pode ver quem o assinou. Ela deve ser "
+"<tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Contador do openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivadas do openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"O openSUSE está disponível via http (link direto) ou BitTorrent. O CD para "
+"instalação via rede está disponível apenas via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "O openSUSE somente suporta PCs de 32 bits e 64 bits."
+
+msgid "see Derivatives on wiki"
+msgstr "veja as derivadas na wiki"
+
+msgid "sha1 checksum"
+msgstr "Soma de verificação SHA1"
+
+msgid "switch to"
+msgstr "alternar para"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Ocorreu um erro interno :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Por favor digite mais de 2 caracteres"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Últimas pesquisas:"
+
+#~ msgid "Statistics"
+#~ msgstr "Estatísticas"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Top downloads 1-click:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Pesquisas mais feitas sem downloads:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Pesquisas mais feitas:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Atualmente não temos uma imagem do Factory que é mais recente que a "
+#~ "última versão do openSUSE. <br/>Por favor veja <a href='http://pt."
+#~ "opensuse.org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> "
+#~ "para mais informação."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Você pode adicionar a chave do repositório ao apt desta forma: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "DVD de 4,7GB"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Os LiveCDs contêm apenas quatro idiomas (inglês, alemão, russo e "
+#~ "italiano). Se você quiser ter suporte para os demais idiomas, você "
+#~ "precisa baixá-los da Internet durante a instalação ou a qualquer momento "
+#~ "após a instalação. Se você tem acesso fácil à Internet ou se você usa o "
+#~ "DVD que contém todos os idiomas, você não precisa deste CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Após ter baixado a imagem ISO com sucesso, grave a imagem com seu "
+#~ "aplicativo de gravação favorito em um DVD ou CD. Por favor,  <em>não</em> "
+#~ "grave um DVD/CD de dados. Escolha gravar uma imagem ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Uma área de trabalho GNOME que você pode executar a partir do CD ou de um "
+#~ "pendrive USB.<br/>Pode ser instalada do jeito que é (sem atualização)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Uma área de trabalho KDE que você pode executar a partir do CD ou de um "
+#~ "pendrive USB.<br/>Pode ser instalada do jeito que é (sem atualização)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "Você pode tentar expandir sua pesquisa para pacotes não suportados ou "
+#~ "pesquisar por outra distribuição base (atualmente )."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Por favor, utilize o texto da pesquisa com pelo menos 2 caracteres"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Alternado para correspondência exata devido a muitas ocorrências na "
+#~ "pesquisa parcial."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Por favor, seja mais preciso em sua pesquisa, pois o limite da pesquisa "
+#~ "foi alcançado."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Não foi possível executar a pesquisa:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Programas populares"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Compre o openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://pt.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click Install"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Download de pacote manual"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Ir para o Projeto OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Coleção de programas]"
+
+#~ msgid "Search Results"
+#~ msgstr "Resultados da pesquisa"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Nenhum pacote encontrado no openSUSE Build Service que corresponda à sua "
+#~ "consulta."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d coleções e %d executáveis de %d pacotes fontes"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Captura de tela do "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Estatísticas da pesquisa:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Estatísticas do download:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Pesquise e instale pacotes de programas do <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opções de pesquisa"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Incluir os projetos pessoais dos usuários"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Excluir os pacotes debug"
+
+#~ msgid "Additional Information"
+#~ msgstr "Informações adicionais"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Guia Rápido de Instalação</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Compre o openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Compre o openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Mais informações sobre o download do openSUSE estão disponíveis na <a "
+#~ "href=\"http://en.opensuse.org/SDB:Download_help\">Ajuda de download.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "As instruções estão disponíveis como a seguir:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Instalação a partir do CD/DVD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Guia de inicialização %s oficial"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Guia de instalação passo-a-passo"
+
+#~ msgid "Network Installation"
+#~ msgstr "Instalação via rede"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Instalação via Internet"
+
+#~ msgid "More information"
+#~ msgstr "Mais informações"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Obtenha software"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Compile software"
+
+#~ msgid "User Directory"
+#~ msgstr "Diretório de usuários"
+
+#~ msgid "Features"
+#~ msgstr "Recursos"
+
+#~ msgid "News"
+#~ msgstr "Notícias"
+
+#~ msgid "Forums"
+#~ msgstr "Fóruns"
+
+#~ msgid "Shop"
+#~ msgstr "Loja"
+
+#~ msgid "Software"
+#~ msgstr "Software"
+
+#~ msgid "Software Search"
+#~ msgstr "Pesquisa de software"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Repositórios de atualização"
+
+#~ msgid "Source Repository"
+#~ msgstr "Repositório fonte"
+
+#~ msgid "Other Options"
+#~ msgstr "Outras opções"
+
+#~ msgid "Mirrors"
+#~ msgstr "Mirrors"
+
+#~ msgid "In other languages"
+#~ msgstr "Em outros idiomas"
+
+#~ msgid "Get it"
+#~ msgstr "Obtenha"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Pesquisa no Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Pesquise e instale pacotes de software adicionais a partir do openSUSE "
+#~ "Build Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Obtenha o openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Link permanente para este resultado"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nada encontrado"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Baixe software a partir do openSUSE Build Service"
+
+#~ msgid "Searching"
+#~ msgstr "Pesquisando"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Contém uma grande coleção de softwares para o uso em áreas de trabalho ou "
+#~ "servidores. Adequado para instalação ou atualização."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Uma área de trabalho GNOME que você pode executar a partir de um CD ou "
+#~ "pendrive USB. Pode ser instalado como é (sem atualização)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Uma área de trabalho KDE que você pode executar a partir de um CD ou "
+#~ "pendrive USB. Pode ser instalado como é (sem atualização)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Baixa o sistema de instalação e todos os pacotes dos repositórios online. "
+#~ "Adequado para instalação ou atualização de versão."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinks"
+
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Compre o openSUSE 11.1!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Para usuários novos no Linux, a versão suportada do openSUSE pode ser a "
+#~ "melhor escolha &mdash; você terá documentação completa, mídia de "
+#~ "instalação para sistemas 32 bits e 64 bits, mais um período de 90 dias de "
+#~ "suporte de instalação."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "O openSUSE 11.1 está disponível em várias lojas <a href=\"http://en."
+#~ "opensuse.org/Buy_openSUSE\">online</a> ou revendedores locais."
+
+#~ msgid "Expert view"
+#~ msgstr "Visualização avançada"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Computadores com, por exemplo, AMD&reg; Sempron ou Intel&reg; "
+#~ "Celeron&trade;, quase todos os computadores datados de 2004 ou anterior. "
+#~ "Esta versão também roda em PCs 64 bit."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: A maioria dos computadores novos com, por exemplo,  CPUs "
+#~ "AMD&reg;: Opteron&trade;, Turion&trade; 64, Athlon&trade; 64, ou "
+#~ "Intel&reg;: Core&trade;2, Pentium&reg; 4 6xx, Pentium&reg; D."
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr ""
+#~ "A menor mídia (aproximadamente 100MB) para baixar o sistema de instalação "
+#~ "e o software dos repositórios online."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "Para baixar uma mídia, escolha a partir do modo de instalação, "
+#~ "possivelmente alterando a arquitetura e o modo de donwload e escolha "
+#~ "\"Salvar arquivo\"."
+
+#~ msgid ""
+#~ "This CD contains a live session of the GNOME desktop. It can be installed "
+#~ "as is and also works when deployed on an USB stick."
+#~ msgstr ""
+#~ "Este CD contém uma sessão \"live\" da área de trabalho GNOME. Ele pode "
+#~ "ser instalado como é e também funciona quando implantado num pendrive USB."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Contexto: Ajuda para baixar mídia"
+
+#~ msgid "Help"
+#~ msgstr "Ajuda"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "DVD é a mídia padrão para a maioria"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "LiveCD com área de trabalho GNOME"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "LiveCD com área de trabalho KDE"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "Instalação via rede para usuários avançados"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "ainda é a soma de verificação mais amplamente usada. Muitos gravadores de "
+#~ "ISO exibem-na após a gravação."
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr ""
+#~ "é menos conhecido mas é uma soma de verificação mais secura que o MD5."

--- a/locale/ro/software.po
+++ b/locale/ro/software.po
@@ -1,0 +1,1127 @@
+# Translator(s):
+#
+# Ursan Marius Bogdan <Creationn@gmail.com>
+# Lucian Oprea <oprea.luci@gmail.com>
+# strainu <narro@strainu.ro>
+# stas <stas@nerd.ro>
+# Alexandru Szasz <alexxed@gmail.com>
+# premamotion <premamotion@yahoo.com>
+# Ilie Robert <ropetili@yahoo.com>
+# manuelciosici <manuelrciosici@gmail.com>
+# raulmalea <raul.malea@gmail.com>
+# xdaiana <xdaiana@yahoo.com>
+# titus0818 <https://www.google.com/accounts/o8/id?id=AItOawnf9Zm3ejVfK7qHc-TpT2ZYnpjRtqHpxXw>
+#
+# Reviewer(s):
+#
+# Lucian Oprea <oprea.luci@gmail.com>
+# strainu <narro@strainu.ro>
+# sharkyalex <oprea.alex@yahoo.com>
+# xdaiana <xdaiana@yahoo.com>
+# Alexandru Szasz <alexxed@gmail.com>
+# raulmalea <raul.malea@gmail.com>
+#
+# Comunitatea romana openSUSE - www.suseromania.ro
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenSUSE\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2012-11-19 15:00+0200\n"
+"Last-Translator: Lucian Oprea <oprea.luci@gmail.com>\n"
+"Language-Team: Romanian <LL@li.org>\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Narro 2.0 on http://tradu.softwareliber.ro\n"
+"Plural-Forms:  nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+"X-Generator: Narro 2.0 on http://tradu.softwareliber.ro\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr "(ascunde)"
+
+msgid "(show)"
+msgstr "(afișează)"
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "Calculator 64 Biți"
+
+#, fuzzy
+#| msgid ""
+#| "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#| "startup/\">openSUSE startup guide</a>"
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+"startup/\">Ghid pornire openSUSE</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> este un "
+"standard deschis care reunește diferite moduri (FTP/HTTP/BitTorrent) de a "
+"converti fișiere într-un format comun pentru a facilita descărcarea "
+"acestora. Este util pentru descărcarea de imagini ISO; în special pentru "
+"utilizatorii care nu pot folosi P2P din cauza restricțiilor ISP-ului sau ale "
+"Universității. Poate oferi o viteză de descărcare ridicată, deoarece "
+"majoritatea clienților suportă implicit conexiuni multiple către diferite "
+"servere oglindă. În plus, poate efectua detecție și corecție automată de "
+"erori. Necesită un client special pentru manipulare."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licența</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Note de publicare</a>"
+
+#, fuzzy
+#| msgid "Official Manuals"
+msgid "<b>official release</b>"
+msgstr "lansarea oficială"
+
+#, fuzzy
+#| msgid "Official Manuals"
+msgid "<b>official update</b>"
+msgstr "actualizarea oficială"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Un mediul de lucru GNOME ce poate fi pornit de pe CD sau un mediu de stocare "
+"USB.<br/>Poate fi instalat așa cum este (fără actualizări)."
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Un mediul de lucru KDE ce poate fi pornit de pe CD sau un mediu de stocare "
+"USB.<br/>Poate fi instalat așa cum este (fără actualizări)."
+
+msgid "Add repository and install manually"
+msgstr "Adaugă sursa de instalare și instalează manual"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Descarcă adaosuri (opțional)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+msgid "App Browser"
+msgstr "Aplicație navigator"
+
+#, fuzzy
+#| msgid "Available Updates"
+msgid "Available Images"
+msgstr "Imagini disponibile"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Porniți de pe DVD sau CD. În caz că sistemul nu pornește automat de pe un CD/"
+"DVD, deschideți setările BIOS și activați pornirea de pe un CD sau DVD."
+
+msgid "Bronze Sponsor"
+msgstr "Sponsor de bronz"
+
+msgid "Browser incompatibility"
+msgstr "Incompatibilitate de navigator"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Scrie imaginea(nile) pe CD/DVD"
+
+#, fuzzy
+#| msgid "Category"
+msgid "Categories"
+msgstr "Categorii"
+
+msgid "Category"
+msgstr "Categorie"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Alegeți un mediu de instalare și apăsați butonul de Descărcare pentru a "
+"începe descărcarea. Opțional se poate alege tipul calculatorului sau o "
+"metodă de descărcare alternativă."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Clic pentru a descărca"
+
+msgid "Community"
+msgstr "Comunitate"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Conține o colecție vastă de programe pentru desktop sau pentru servere.<br/"
+">Potrivit pentru instalare sau actualizare."
+
+msgid "Countdown"
+msgstr "Numărătoare inversă"
+
+#, fuzzy
+#| msgid "Countdown"
+msgid "Country"
+msgstr "Numărătoare inversă"
+
+msgid "Development"
+msgstr "Dezvoltare"
+
+msgid "Development Version"
+msgstr "Versiune de dezvoltare"
+
+#, fuzzy
+#| msgid "Development Version"
+msgid "Development packages"
+msgstr "Pachete de dezvoltare:"
+
+#, fuzzy
+#| msgid "Development"
+msgid "Development-"
+msgstr "Dezvoltare"
+
+#, fuzzy
+#| msgid "1-Click Install"
+msgid "Direct Install"
+msgstr "Instalare directă"
+
+msgid "Direct Link"
+msgstr "Legătură directă"
+
+msgid "Documentation"
+msgstr "Documentație"
+
+#, fuzzy
+#| msgid "Don't show this message again."
+msgid "Don't show this warning the next time"
+msgstr "Nu mai afișa acest avertisment"
+
+msgid "Download"
+msgstr "Descărcați"
+
+msgid "Download %s"
+msgstr "Descarcă %s"
+
+msgid "Download Help"
+msgstr "Descarcă ajutor"
+
+msgid "Download Method"
+msgstr "Metodă de descărcare"
+
+msgid "Download appliance from %s"
+msgstr "Descarcă dispozitiv de la %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Descarcă DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Descarcă GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Descarcă KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Descarcă Rețea"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "Descarcă KDE"
+
+msgid "Downloads"
+msgstr "Descărcări"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Descarcă și sistemul de instalare și toate pachetele dintr-o sursă online."
+"<br/>Potrivit pentru instalare sau actualizare."
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "Limbi suplimentare"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Limbi suplimentare (32 Biți)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Limbi suplimentare (64 Biți)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "Pentru <strong>%s</strong> executați ca <strong>root</strong>:"
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Pentru <strong>%s</strong> executați ca <strong>root</strong>:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"oferă cea mai bună protecție deoarece puteți verifica cine a semnat-o. Ar "
+"trebui să fie <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Jocuri"
+
+#, fuzzy
+#| msgid "Get one of the specialized distribution built on openSUSE."
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+"Obțineți una dintre distribuțiile specializate construite pe baza openSUSE."
+
+msgid "Getting Help"
+msgstr "Obține ajutor"
+
+msgid "Gold Sponsor"
+msgstr "Sponsor de aur"
+
+msgid "Grab binary packages directly"
+msgstr "Obține pachetele binare direct"
+
+msgid "Header Logo"
+msgstr "Logo antet"
+
+msgid "Help on Download Method"
+msgstr "Ajutor privind metoda de descărcare"
+
+msgid "Help on Type of Computer"
+msgstr "Ajutor privind tipul calculatorului"
+
+msgid "How to Proceed"
+msgstr "Cum să continuați"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Dacă doriți să folosiți o legătură directă dar vă aflați într-un loc unde "
+"controlorul descărcării nu are destule informații pentru a vă redirecționa "
+"către cea mai rapidă oglindă, puteți alege o oglindă personal."
+
+msgid "Image:"
+msgstr "Imagine:"
+
+msgid "Install package %s / %s"
+msgstr "Instalează pachetul %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Instalează modelul %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Instalați cu un singur clic"
+
+msgid "Installation Guides"
+msgstr "Ghiduri de instalare"
+
+msgid "Installation Medium"
+msgstr "Mediu de instalare"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Din păcate Konqueror pentru KDE 3 nu mai este întreținut și implementarea "
+"javascript conține erori care  pot face imposibilă redarea acestei pagini. "
+"Vă rugăm să vă asigurați că ați dezactivat javascript înainte să <a "
+"href='%s'>continuați</a>."
+
+msgid "Language"
+msgstr "Limbă"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "Calculator 32 Biți"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Calculator 32 Biți"
+
+msgid "Live GNOME"
+msgstr "GNOME Live"
+
+msgid "Live KDE"
+msgstr "KDE Live"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Multe aplicații pot verifica suma de control a unei descărcări. Verificarea "
+"descărcarii poate fi importantă deoarece verifică dacă veți obține fișierul "
+"ISO dorit și nu o versiune coruptă."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Mai multe informații despre scrierea fișierelor ISO pe CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Mai multe informații despre crearea unui <a href='http://en.opensuse.org/"
+"Live_USB_stick'>stick USB de pornire a sistemului de operare</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Informații suplimentare despre descărcarea openSUSE sunt disponibile la <a "
+"href=\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> (Ajutor "
+"descărcare) și <a href=\"http://en.opensuse.org/SDB:Network_installation"
+"\">Network Installation</a> (instalare prin rețea) de la <a href=\"http://en."
+"opensuse.org/Portal:Documentation\">Documentation Wiki</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Majoritatea noilor calculatoare suportă <a href=\"http://ro.wikipedia.org/"
+"wiki/X86-64\">x86-64</a> (cunoscut și ca AMD64 și Intel64), dar unele "
+"procesoare de laptopuri și netbook-uri nu îl suportă. Așa că trebuie să "
+"verificați pe Wikipedia pentru a fi sigur că este suportat de calculatorul "
+"dumneavoastră."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Aveți nevoie de ajutor?"
+
+msgid "Network"
+msgstr "Rețea"
+
+msgid "No appliance data for %s"
+msgstr ""
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+msgid "No data for %s / %s"
+msgstr "Nu există date pentru %s / %s"
+
+#, fuzzy
+#| msgid "No repository found."
+msgid "No description found..."
+msgstr "Nu a fost găsită nicio descriere..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Nu s-a găsit niciun download pentru %s în proiectul %s"
+
+msgid "No packages found matching your search. "
+msgstr "Nu s-au găsit pachete ce corespund criteriilor dvs. de căutare. "
+
+msgid "NonOSS CD"
+msgstr "CD NonOSS"
+
+#, fuzzy
+#| msgid "scdb not available"
+msgid "OBS Backend not available"
+msgstr "scdb nu e disponibilă"
+
+msgid "Official Manuals"
+msgstr "Manuale oficiale"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+#, fuzzy
+#| msgid "Source package '%s' not found."
+msgid "Package %s not found..."
+msgstr "Pachetul %s nu a fost găsit..."
+
+msgid "Package Repositories"
+msgstr "Depozit de pachete"
+
+msgid "Package Search"
+msgstr "Căutare pachete"
+
+msgid "Packages for %s:"
+msgstr "Pachete pentru %s:"
+
+msgid "Pick Mirror"
+msgstr "Alegeți oglinda"
+
+msgid "Platinum Sponsor"
+msgstr "Sponsor de platină"
+
+#, fuzzy
+#| msgid ""
+#| "Please be aware that the following packages are from unofficial "
+#| "repositories.\n"
+#| "    That means they are not reviewed by openSUSE and may contain unstable "
+#| "or experimental software."
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Vă rugăm să fiți conștient că următoarele pechete sunt din depozite "
+"neoficiale.\n"
+" Asta înseamnă că nu sunt revizuite de openSUSE și pot conține aplicații "
+"instabile sau experimentale."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Atenție, aceasta nu este cea mai nouă versiune openSUSE. Puteți obține "
+"ultima versiune <a href='/'>aici</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+#, fuzzy
+#| msgid "Category"
+msgid "Related categories:"
+msgstr "Categorii relaționate:"
+
+msgid "Released Version"
+msgstr "Versiune lansată"
+
+msgid "Reporting Bugs"
+msgstr "Raportare defecte"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "Sistem de salvare"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Un mediul de lucru KDE ce poate fi pornit de pe CD sau un mediu de stocare "
+"USB.<br/>Poate fi instalat așa cum este (fără actualizări)."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "sumă de verificare md5"
+
+msgid "Search"
+msgstr "Caută"
+
+msgid "Select Your Operating System"
+msgstr "Selectați sistemul dvs. de operare"
+
+#, fuzzy
+#| msgid "Select the display type."
+msgid "Select the image type"
+msgstr "Selectează tipul de imagine"
+
+#, fuzzy
+#| msgid "Show:"
+msgid "Show"
+msgstr "Afişează:"
+
+msgid "Show development, language and debug packages"
+msgstr "Afișează pachetele de dezvoltare, limbă și depanare"
+
+#, fuzzy
+#| msgid "Unknown Distribution"
+msgid "Show distribution:"
+msgstr "Afișează distribuția:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Afișează mai multe pachete pentru distribuții nesuportate"
+
+msgid "Show more..."
+msgstr "Afișează mai multe..."
+
+#, fuzzy
+#| msgid "Other Versions"
+msgid "Show other versions"
+msgstr "Afișează alte versiuni"
+
+#, fuzzy
+#| msgid "unsupported"
+msgid "Show unstable packages"
+msgstr "Afișează pachete nesuportate"
+
+#, fuzzy
+#| msgid "unsupported"
+msgid "Show unsupported packages"
+msgstr "Afișează pachete nesuportate"
+
+msgid "Silver Sponsor"
+msgstr "Sponsor de argint"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Câteva dintre distribuțiile live bazate pe openSUSE. Cei interesați de a "
+"construi derivate pot să citească prima dată aici <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Sursă"
+
+msgid "Sponsored by"
+msgstr "Sponsorizat de"
+
+#, fuzzy
+#| msgid "Sponsored by AMD"
+msgid "Sponsored by: AMD"
+msgstr "Sponsorizat de AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponsorizat de: B1 Systems"
+
+#, fuzzy
+#| msgid "Sponsored by"
+msgid "Sponsored by: Heinlein"
+msgstr "Sponsorizat de"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponsorizat de: IP Exchange"
+
+#, fuzzy
+#| msgid "_Hide subpackages"
+msgid "Sub-Packages"
+msgstr "Subpachete:"
+
+msgid "Support"
+msgstr "Asistență"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+#, fuzzy
+#| msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Pentru <strong>%s</strong> executați ca <strong>root</strong>:"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Acest CD conține programe gratuite distribuite sub o licență proprietară ce "
+"nu permite includerea sa în mediul de instalare principal alături de "
+"programele libere cu sursă deschisă. Toate programele din acest CD pot fi "
+"descărcate de la sursa de instalare NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Această versiune rulează pe toate PC-urile, inclusiv cele pe 64 de biți. "
+"Dacă aveți mai mult de 3 GB de RAM, atunci ar trebui să alegeți versiunea pe "
+"64 de biți. openSUSE nu funcționează cu procesoare ieșite înainte de Pentium "
+"- CD-ul live suportă doar i686 (Pentium Pro sau mai noi)."
+
+msgid "Type of Computer"
+msgstr "Tipul calculatorului"
+
+#, fuzzy
+#| msgid "Unknown Distribution"
+msgid "Unsupported distributions:"
+msgstr "Distribuții nesuportate:"
+
+#, fuzzy
+#| msgid ""
+#| "User manuals are available from <a href=\"http://doc.opensuse.org\">doc."
+#| "opensuse.org</a>, for example the <a href=\"http://doc.opensuse.org/"
+#| "products/opensuse/openSUSE/opensuse-startup/\">Official Start-Up Guide</"
+#| "a>."
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Manualele pentru utilizatori sunt disponibile la <a href=\"http://doc."
+"opensuse.org\">doc.opensuse.org</a>, de exemplu <a href=\"http://doc."
+"opensuse.org/products/opensuse/openSUSE/opensuse-startup/\">Ghidul oficial "
+"pentru pornire</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+
+#, fuzzy
+#| msgid "Verify your download (optional, for experts)"
+msgid "Verify your download before use"
+msgstr "Verificați datele descărcate (opțional, pentru experți)"
+
+msgid "Version"
+msgstr "Versiune"
+
+msgid "We offer three different checksums:"
+msgstr "Vă oferim trei sume de control diferite:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Când descărcați imagini din altă parte decât de pe CD-ul pentru instalarea "
+"de rețea, este <i>de preferat</i> să folosiți un program bun pentru "
+"descărcări, pentru a reduce riscul de a descărca cu erori."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Puteți verifica fișierul aflat în curs de descărcare. De exemplu, o sumă de "
+"control (SHA256) va fi folosită în mod automat în cazul în care alegeți <a "
+"href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> în câmpul de mai sus "
+"și folosiți suplimentul DownThemAll! în <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "semnătură gpg"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Derivatives"
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Derivatives"
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Derivatives"
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Derivatives"
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Derivatives"
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.2/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.2/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#| msgid "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"este în continuare cea mai folosită sumă de verificare. Multe inscriptoare "
+"ISO îl arată înainte de scriere."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr ""
+"este mai puțin cunoscută decât md5 dar este și mai sigură ca sumă de "
+"verificare."
+
+msgid "md5 checksum"
+msgstr "sumă de verificare md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"oferă cea mai bună protecție deoarece puteți verifica cine a semnat-o. Ar "
+"trebui să fie <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Numărătoare inversă openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivate openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE este disponibil via http (legătură directă) sau BitTorrent. CD-ul "
+"pentru instalarea prin rețea este disponibil doar via http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE suportă doar calculatoare pe 32 Biți și pe 64 Biți."
+
+msgid "see Derivatives on wiki"
+msgstr "a se vedea derivatele în wiki"
+
+msgid "sha1 checksum"
+msgstr "sumă de verificare sha1"
+
+msgid "switch to"
+msgstr "comută la"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "A apărut o eroare internă :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Introduceți mai mult de două caractere"
+
+#, fuzzy
+#~| msgid ""
+#~| "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#~| msgid ""
+#~| "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#, fuzzy
+#~| msgid "Top searches:"
+#~ msgid "Last searches:"
+#~ msgstr "Top căutări:"
+
+#~ msgid "Statistics"
+#~ msgstr "Statistici"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Cele mai populare descărcări 1-click:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Top căutări fără rezultate:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Top căutări:"
+
+#, fuzzy
+#~| msgid ""
+#~| "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/12.1/RELEASE-NOTES.en.html"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "Momentan nu există un printscreen pentru Factory care să fie mai recentă "
+#~ "decât ultima versiune openSUSE. <br/>Vă rugăm verificați <a href='http://"
+#~ "en.opensuse.org/Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> "
+#~ "pentru mai multe informații."
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "CD-urile live conțin doar patru limbi (engleză, germană, rusă și "
+#~ "italiană). Dacă doriți să aveți suport pentru alte limbi trebuie să le "
+#~ "descărcați de pe Internet în timpul instalării sau oricând după aceasta. "
+#~ "Dacă aveți acces facil la Internet sau dacă folosiți DVD-ul care conține "
+#~ "toate limbile, nu aveți nevoie de acest CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "După ce ați descărcat cu succes imaginea(nile) ISO, scrieți "
+#~ "imaginea(nile) cu aplicația preferată de scriere pe un DVD sau CD. Vă "
+#~ "rugăm să <em>nu</em> scrieți un CD/DVD cu date, ci mai degrabă alegeți "
+#~ "opțiunea de scriere a unei imagini ISO."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Utilizați șiruri de căutare de minim 2 caractere"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "S-a trecut la o căutare exactă din cauza numărului mare de rezultate "
+#~ "returnate de căutarea după subșiruri."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Vă rugăm să fiți mai precis în căutarea dumneavoastră deoarece s-a ajuns "
+#~ "la limită"
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Nu s-a putut efectua căutarea:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Program popular"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Cumpărați openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Instalare cu un clic"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Descărcare manuală a pachetelor"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Duceți-vă la Proiectul OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Colecție de programe]"
+
+#~ msgid "Search Results"
+#~ msgstr "Rezultatele căutării"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Nu au fost găsit pachete în openSUSE Build Service care să corespundă "
+#~ "interogării dumneavoastră."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d colecții și %d date binare din %d pachete sursă"
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "Captură de ecran pentru "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Statistici căutări:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Statistici descărcări:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Caută și instalează pachete software de la <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Opțiuni de căutare"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Include proiectele utilizatorilor"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Exclude depanarea pachetelor"

--- a/locale/ru/software.po
+++ b/locale/ru/software.po
@@ -1,0 +1,1111 @@
+# Alexander Melentiev <alex239@gmail.com>, 2009, 2010.
+# Alexander Melentiev <minton@opensuse.org>, 2011, 2012, 2013, 2014, 2015.
+# Thomas Schmidt <tom@opensuse.org>, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-05 21:06+0300\n"
+"Last-Translator: Aleksandr Melentev <minton@opensuse.org>\n"
+"Language-Team: Russian <opensuse-translation-ru@opensuse.org>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Lokalize 2.0\n"
+
+msgid " and "
+msgstr " и "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} не поддерживается.\""
+
+msgid "(hide)"
+msgstr "(скрыть)"
+
+msgid "(show)"
+msgstr "(показать)"
+
+msgid "... and keep us informed"
+msgstr "... и уведомлять в дальнейшем"
+
+msgid "... get other marketing stuff"
+msgstr "... получать маркетинговую информацию"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7 ГБ DVD (также подходит для USB-брелка)"
+
+msgid "64 Bit PC"
+msgstr "64-битный&nbsp;PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Руководство "
+"по openSUSE для начинающих</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> — это открытый "
+"стандарт, объединяющий различные способы получения файлов (FTP/HTTP/"
+"BitTorrent) в один формат для облегчения загрузок. Поэтому он так хорош для "
+"загрузки файлов ISO, особенно для людей, которые не могут использовать P2P "
+"из-за ограничений, наложенных их провайдерами. Он может обеспечить очень "
+"высокие скорости загрузки, так как большинство клиентов поддерживает "
+"множественные подключения к нескольким зеркалам автоматически. Более того, "
+"он осуществляет автоматическое обнаружение и исправление ошибок. Для "
+"использования Metalink нужен специальный клиент."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://ru.opensuse.org/openSUSE:License\">Лицензия</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Примечания к выпуску</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>официальный выпуск</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>официальное обновление</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Рабочий стол GNOME, который можно запустить с %s или USB-брелока.<br/>Только "
+"установка «с нуля» (без обновления)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Рабочий стол KDE, который можно запустить с %s или USB-брелока.<br/>Только "
+"установка «с нуля» (без обновления)."
+
+msgid "Add repository and install manually"
+msgstr "Добавить репозиторий и установить вручную"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Загрузка дополнений (необязательно)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"После успешной загрузки ISO-образа можно создать загрузочный USB-брелок или "
+"прожечь образ на DVD (или на CD, если образ подходящего размера)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Все данные используются для отправки рекламных материалов openSUSE\n"
+"и не передаются третьим лицам. Мы храним данные для уведомления\n"
+"пользователей о выходе новой версии. Все запросы изучаются на\n"
+"предмет соответствия экспортному эмбарго США. Больше сведений об\n"
+"эмбарго и список стран можно найти в википедии <a href='http://en.wikipedia."
+"org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Браузер приложений"
+
+msgid "Available Images"
+msgstr "Доступные образы"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Загрузитесь с DVD, CD или USB-брелка. Если ваш компьютер не загружается с "
+"выбранного устройства автоматически, откройте меню настройки BIOS для "
+"разрешения загрузки с него."
+
+msgid "Bronze Sponsor"
+msgstr "«Бронзовый» спонсор"
+
+msgid "Browser incompatibility"
+msgstr "Несовместимость с браузером"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Запись образа(ов) CD/DVD"
+
+#  frame label, around checkbuttons
+msgid "Categories"
+msgstr "Категории"
+
+#  frame label, around checkbuttons
+msgid "Category"
+msgstr "Категория"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Выберите установочный носитель, кликнув на нём, и нажмите кнопку Загрузить. "
+"Также можете выбрать тип компьютера или альтернативный метод загрузки."
+
+msgid "Click here to display these alternative versions."
+msgstr "Нажмите здесь для показа этих альтернативных версий."
+
+msgid "Click to Download"
+msgstr "Нажмите для загрузки"
+
+msgid "Community"
+msgstr "Сообщество"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Содержит огромный набор ПО для настольного или серверного использования.<br/"
+"> Подходит для установки или обновления."
+
+msgid "Countdown"
+msgstr "Обратный отсчёт"
+
+msgid "Country"
+msgstr "Страна"
+
+msgid "Development"
+msgstr "Разработка"
+
+msgid "Development Version"
+msgstr "разрабатываемой версии"
+
+msgid "Development packages"
+msgstr "Пакеты для разработчиков"
+
+msgid "Development-"
+msgstr "Разработка-"
+
+msgid "Direct Install"
+msgstr "Прямая установка"
+
+msgid "Direct Link"
+msgstr "Прямая ссылка"
+
+msgid "Documentation"
+msgstr "Документация"
+
+msgid "Don't show this warning the next time"
+msgstr "Больше не показывать это предупреждение."
+
+msgid "Download"
+msgstr "Загрузить"
+
+msgid "Download %s"
+msgstr "Загрузить %s"
+
+msgid "Download Help"
+msgstr "Справка по скачиванию"
+
+msgid "Download Method"
+msgstr "Способ загрузки"
+
+msgid "Download appliance from %s"
+msgstr "Загрузить из %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Загрузить&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Загрузить&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Загрузить&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Загрузить сетевой образ"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Загрузить&nbsp;диск восстановления"
+
+msgid "Downloads"
+msgstr "Загрузки"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Загружает систему установки и все пакеты из сетевых репозиториев.<br/"
+">Подходит для установки или обновления."
+
+msgid "Expand all sections ('e')"
+msgstr "Развернуть все разделы ('e')"
+
+msgid "Extra Languages"
+msgstr "Дополнительные языки"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Дополнительные языки (32 бита)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Дополнительные языки (64 бита)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "Для <strong>%s</strong> запустите от имени <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Для <strong>%s</strong> запустите:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Для <strong>Arch Linux</strong> отредактируйте /etc/pacman.conf и добавьте "
+"следующее (обратите внимание, что в pacman.conf важен порядок репозиториев, "
+"поскольку pacman всегда загружает первый найденный пакет):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Для каждого образа ISO мы предлагаем файл с соответствующей контрольной "
+"суммой SHA256."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Для дополнительной безопасности вы можете использовать GPG, чтобы проверить, "
+"кто подписал эти .sha256 файлы. Должно быть <tt>%s</tt>."
+
+msgid "Games"
+msgstr "Игры"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Скачайте один из специализированных дистрибутивов на основе openSUSE."
+
+msgid "Getting Help"
+msgstr "Справка"
+
+msgid "Gold Sponsor"
+msgstr "«Золотой» спонсор"
+
+msgid "Grab binary packages directly"
+msgstr "Получить бинарные пакеты напрямую"
+
+msgid "Header Logo"
+msgstr "Логотип"
+
+msgid "Help on Download Method"
+msgstr "Справка по способам загрузки"
+
+msgid "Help on Type of Computer"
+msgstr "Справка по типу компьютера"
+
+msgid "How to Proceed"
+msgstr "Что делать дальше"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Если вы хотите использовать прямую ссылку, но живёте в таком месте, о "
+"котором у нашей утилиты перенаправления недостаточно сведений для назначения "
+"самого быстрого зеркала, вы можете выбрать зеркало самостоятельно."
+
+msgid "Image:"
+msgstr "Образ:"
+
+#  summary information texts
+msgid "Install package %s / %s"
+msgstr "Установить пакет %s / %s"
+
+#  summary information texts
+msgid "Install pattern %s / %s"
+msgstr "Установить шаблон %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Установить в один клик"
+
+msgid "Installation Guides"
+msgstr "Руководства по установке"
+
+msgid "Installation Medium"
+msgstr "Установочный носитель"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Присоединяйтесь к быстро растущему сообществу, получите\n"
+"новые PromoDVD для openSUSE и распространяйте их в группах,\n"
+"некоммерческих организациях, школах и университетах, а также\n"
+"встречах LUG, инсталл-фестах и конференциях.\n"
+"Promo DVD увеличивают осведомлённость людей об openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror из KDE 3, к сожалению, не поддерживается, и его реализация "
+"javascript содержит ошибки, делающие невозможным использование этой "
+"страницы. Убедитесь, что вы отключили javascript перед тем, как <a "
+"href='%s'>продолжить</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Язык"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Устаревший 32-битный PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Устаревший 32-битный&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Множество приложений может проверить целостность загрузки по контрольной "
+"сумме. Такая проверка поможет вам убедиться, что вы получили именно желаемый "
+"файл ISO, а не какое-то битое недоразумение."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Больше сведений о записи файла ISO на CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Больше сведений о создании <a href='http://ru.opensuse.org/"
+"Live_USB_брелок'>загрузочного USB-брелока</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Больше сведений о загрузке openSUSE доступно на страницах <a href=\"http://"
+"ru.opensuse.org/SDB:Помощь_по_загрузке\">Помощь по загрузке</a> и <a href="
+"\"http://ru.opensuse.org/Установка_через_Интернет\">Установка через "
+"Интернет</a> в нашей <a href=\"http://ru.opensuse.org/Portal:Документация"
+"\">вики</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Большинство новых компьютеров поддерживает архитектуру <a href=\"http://ru."
+"wikipedia.org/wiki/X86-64\">x86-64</a> (также известную как AMD64 и "
+"Intel64), но некоторые ноутбуки и нетбуки не поддерживают её. Чтобы знать "
+"наверняка, поддерживает ли её ваш компьютер, уточните в Википедии."
+
+msgid "Multimedia"
+msgstr "Мультимедиа"
+
+msgid "Need help?"
+msgstr "Нужна помощь?"
+
+msgid "Network"
+msgstr "Установка по сети"
+
+msgid "No appliance data for %s"
+msgstr "Нет данных для %s"
+
+msgid "No appliances found in project %s"
+msgstr "В проекте %s образы не найдены"
+
+msgid "No data for %s / %s"
+msgstr "Нет сведений %s / %s"
+
+msgid "No description found..."
+msgstr "Описание не найдено…"
+
+msgid "No downloads found for %s in project %s"
+msgstr "Загрузки для %s в проекте %s не найдены"
+
+msgid "No packages found matching your search. "
+msgstr "По вашему запросу пакетов не найдено. "
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+msgid "OBS Backend not available"
+msgstr "Механизм OBS недоступен"
+
+msgid "Official Manuals"
+msgstr "Официальные руководства"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Полностью протестированы только DVD и установка по сети. Альтернативные "
+"версии, т.е. live-диски или спасательный диск, рекомендованы только для "
+"ограниченного применения."
+
+msgid "Package %s not found..."
+msgstr "Пакет %s не найден…"
+
+msgid "Package Repositories"
+msgstr "Репозитории пакетов"
+
+msgid "Package Search"
+msgstr "Поиск пакетов"
+
+msgid "Packages for %s:"
+msgstr "Пакеты для %s:"
+
+msgid "Pick Mirror"
+msgstr "Выбрать зеркало"
+
+msgid "Platinum Sponsor"
+msgstr "«Платиновый» спонсор"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Пожалуйста, обратите внимание, что это пакеты из неофициальных "
+"репозиториев.\n"
+"Это означает, что они не проверяются командой openSUSE и могут содержать "
+"нестабильное или экспериментальное программное обеспечение."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Пожалуйста, укажите <b>краткую</b> причину (на английском!), по которой вам "
+"нужны DVD и предоставьте ссылку на событие."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Обратите внимание, что это не последний релиз openSUSE. Вы можете получить "
+"новейшую версию <a href='/'>здесь</a>. "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo DVD и всё необходимое графическое оформление — ярлыки и упаковку — "
+"можно\n"
+"скачать из <a href=\"http://download.opensuse.org/promodvd/\">каталога "
+"promodvd %s</a>.\n"
+"Учтите, что это особая версия openSUSE,\n"
+"специально предназначенная для рекламных целей."
+
+#  frame label, around checkbuttons
+msgid "Related categories:"
+msgstr "Связанные категории:"
+
+msgid "Released Version"
+msgstr "выпущенной версии"
+
+msgid "Reporting Bugs"
+msgstr "Сообщение об ошибках"
+
+msgid "Rescue"
+msgstr "Диск восстановления"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Спасательная система, которую можно запустить с CD или USB-брелока.<br/"
+">Установка «с нуля» и обновление не предусмотрены."
+
+msgid "SHA256 checksum"
+msgstr "Контрольная сумма SHA256"
+
+msgid "Search"
+msgstr "Поиск"
+
+msgid "Select Your Operating System"
+msgstr "Выберите операционную систему"
+
+msgid "Select the image type"
+msgstr "Выберите тип образа"
+
+msgid "Show"
+msgstr "Показать"
+
+msgid "Show development, language and debug packages"
+msgstr "Показывать пакеты для разработчиков, отладочные пакеты и переводы"
+
+msgid "Show distribution:"
+msgstr "Показать дистрибутив:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Показать больше пакетов для неподдерживаемых дистрибутивов"
+
+msgid "Show more..."
+msgstr "Ещё…"
+
+msgid "Show other versions"
+msgstr "Показать другие версии"
+
+#  summary information texts
+msgid "Show unstable packages"
+msgstr "Показывать нестабильные пакеты"
+
+#  summary information texts
+msgid "Show unsupported packages"
+msgstr "Показывать неподдерживаемые пакеты"
+
+msgid "Silver Sponsor"
+msgstr "«Серебряный» спонсор"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Доступны и другие носители (т.е. спасательный и live-диски), хотя они менее "
+"протестированы и рекомендованы только для ограниченного применения."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Дистрибутивы на основе openSUSE. Желающие попытаться собрать собственный "
+"дистрибутив могут взглянуть на <a href=\"http://susestudio.com/\">SUSE "
+"Studio</a>."
+
+msgid "Source"
+msgstr "Источник"
+
+msgid "Sponsored by"
+msgstr "Спонсоры"
+
+msgid "Sponsored by: AMD"
+msgstr "AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Подпакеты"
+
+msgid "Support"
+msgstr "Поддержка"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Процесс установки переведён на множество языков, но для большинства из них "
+"переводы приложений в образ не входят. Если вы хотите, чтобы ваша система "
+"openSUSE поддерживала ещё какой-то язык, то придётся скачать его из "
+"интернета во время или после установки. Если у вас хороший доступ к "
+"интернету, то этот CD вам не нужен, но если вы планируете установить "
+"openSUSE на машину без доступа к интернету, то все имеющиеся переводы "
+"доступны на этом диске."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Затем запустите от имени <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"В настоящее время ни один выпуск openSUSE не проходит тестирование. <br/> "
+"Если вы хотите использовать новейшее ПО, воспользуйтесь <a href='http://ru."
+"opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Этот диск содержит бесплатное ПО, распространяемое под проприетарными "
+"лицензиями, не позволяющими включать его на главный установочный носитель "
+"вместе со свободным ПО с открытым исходным кодом. Всё ПО с этого диска можно "
+"скачать из репозитория NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Эта версия запускается на всех PC, включая 64-битные. Если у вас более 3 ГБ "
+"оперативной памяти, выберите 64-битную версию. openSUSE не поддерживает "
+"процессоры ниже Pentium — LiveCD поддерживают только i686 (Pentium Pro и "
+"выше)."
+
+msgid "Type of Computer"
+msgstr "Тип компьютера"
+
+msgid "Unsupported distributions:"
+msgstr "Неподдерживаемые дистрибутивы:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Руководства пользователя доступны на <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, например, <a href=\"http://activedoc.opensuse."
+"org/book/opensuse-start-up/\">Руководство для начинающих</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Использование <a href=\"http://ru.opensuse.org/SDB:BitTorrent\">BitTorrent</"
+"a> рекомендовано для медленных соединений, особенно при загрузке образа DVD. "
+"Загрузки BitTorrent имеют несколько преимуществ: клиенты защищены от "
+"повреждения данных и вы уменьшаете нагрузку на серверы, участвуя в раздаче — "
+"при участии достаточного количества людей загрузка также будут быстрее, чем "
+"с централизованных серверов, причём для всех. Более того, вы можете "
+"остановить загрузку в любое время и возобновить её позже."
+
+msgid "Verify your download before use"
+msgstr "Проверка загруженного образа перед использованием"
+
+msgid "Version"
+msgstr "Версия"
+
+msgid "We offer three different checksums:"
+msgstr "Мы предлагаем три разных контрольных суммы:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Мы бы хотели знать больше о вашем использовании DVD, чтобы помочь\n"
+"вам продвигать вашу организацию, событие или школу на нашей странице\n"
+"<a href='http://news.opensuse.org' title='news.opensuse.org'>новостей</a> "
+"или других ресурсах. (Кстати! Мы любим фоточки. Снимайте тысячи их!).\n"
+"Свяжитесь с нами по адресу <a href='mailto:opensuse-marketing@opensuse."
+"org'>opensuse-marketing@opensuse.org</a>,\n"
+"чтобы обсудить это и/или другие способы взаимопомощи."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"При загрузке любых образов, кроме CD для установки по сети, <i>настоятельно</"
+"i> рекомендуется использовать менеджер загрузок для уменьшения риска "
+"повреждения данных."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Вы можете добавить ключ репозитория в apt. Имейте в виду, что владелец ключа "
+"может распространять обновления, пакеты и репозитории, которым ваша система "
+"будет доверять (<a href=\"%s\">подробнее</a>). Для добавления ключа "
+"запустите:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Вы можете расширить свой поиск на пакеты для разработчиков или искать их для "
+"другого дистрибутива."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Вы можете проверить файл в процессе загрузки. Например, контрольная сумма "
+"SHA256 будет использована автоматически при выборе <a href='http://en."
+"opensuse.org/SDB:Metalink'>Metalink</a> в качестве способа загрузки."
+
+msgid "gpg signature"
+msgstr "Подпись gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://ru.opensuse.org/Производные"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://ru.opensuse.org/Репозитории_пакетов"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://ru.opensuse.org/Portal:Установка"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://ru.opensuse.org/SDB:Помощь_по_загрузке"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+"http://ru.opensuse.org/SDB:%D0%9F%D0%BE%D0%BC%D0%BE%D1%89%D1%8C_%D0%BF%D0%BE_"
+"%D0%B7%D0%B0%D0%B3%D1%80%D1%83%D0%B7%D0%BA%D0%B5#.D0.97.D0.B0.D0.BF.D0.B8."
+"D1.81.D1.8C_.D0.BE.D0.B1.D1.80.D0.B0.D0.B7.D0.B0_.D0.B4.D0.B8.D1.81.D0.BA.D0."
+"B0_.28ISO.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://ru.opensuse.org/openSUSE:Сообщить_об_ошибке"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"всё ещё используется наиболее широко. Многие приложения для записи ISO "
+"показывают её перед началом записи."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "менее известна, но более безопасна, чем md5."
+
+msgid "md5 checksum"
+msgstr "Контрольная сумма md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"обеспечивает наибольший уровень безопасности, так как вы можете проверить, "
+"кто подписал файл. Должно быть <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Обратный отсчёт openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Производные дистрибутивы openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE доступна по http (прямая ссылка) или BitTorrent. CD для установки "
+"по сети доступен только по http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE поддерживает только 32-битные и 64-битные компьютеры."
+
+msgid "see Derivatives on wiki"
+msgstr "Производные дистрибутивы в вики"
+
+msgid "sha1 checksum"
+msgstr "Контрольная сумма sha1"
+
+msgid "switch to"
+msgstr "перейти к"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Произошла внутренняя ошибка :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Введите не менее двух символов"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Недавно искали:"
+
+#~ msgid "Statistics"
+#~ msgstr "Статистика"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Чаще всего устанавливают в 1 клик:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Чаще всего не находят:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Чаще всего ищут:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "На данный момент не существует снимка Factory новее последнего релиза "
+#~ "openSUSE. <br/>Вы можете найти больше сведений на <a href='http://ru."
+#~ "opensuse.org/Portal:Factory'>http://ru.opensuse.org/Portal:Factory</a>."
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "Вы можете добавить ключ репозитория в apt вот так: "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7 ГБ DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD содержат только четыре языка (английский, немецкий, русский и "
+#~ "итальянский). Если вам нужна поддержка других языков, придётся скачивать "
+#~ "пакеты из интернета во время установки или после неё. Если у вас широкий "
+#~ "канал в интернет или вы используете DVD (который содержит все доступные "
+#~ "языки), то вам не нужен этот диск."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "После успешной загрузки ISO-образа(ов), запишите его(их) на DVD или CD с "
+#~ "помощью любимого приложения. Пожалуйста, обратите внимание, что <em>не "
+#~ "нужно</em> записывать DVD/CD с данными, вместо этого следует выбрать "
+#~ "запись образа ISO."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#~ "installed as is (no upgrade)."
+#~ msgstr ""
+#~ "Рабочий стол GNOME, который можно запустить с CD или USB-брелока.<br/"
+#~ ">Только установка «с нуля» (без обновления)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Рабочий стол KDE, который можно запустить с CD или USB-брелока.<br/"
+#~ ">Только установка «с нуля» (без обновления)."
+
+#~ msgid ""
+#~ "You could try to extend your search to unsupported packages or search for "
+#~ "another base distribution (currently )."
+#~ msgstr ""
+#~ "Вы можете расширить свой поиск на неподдерживаемые пакеты или искать их "
+#~ "для другого дистрибутива."
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.ru.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.ru.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "В поисковом запросе должно быть не менее двух символов"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Перехожу на точное соответствие из-за слишком большого числа совпадений в "
+#~ "подстроках."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Слишком много результатов, уточните запрос."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Невозможно выполнить поиск: "
+
+#~ msgid "Popular Software"
+#~ msgstr "Популярные программы"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Купить openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://ru.opensuse.org/Купить_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Установка в 1 клик"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Загрузить пакет вручную"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Проект в OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Коллекция программного обеспечения]"
+
+#~ msgid "Search Results"
+#~ msgstr "Результаты поиска"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "В openSUSE Build Service не найдено пакетов, соответствующих вашему "
+#~ "запросу."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "Коллекции: %d; бинарные сборки: %d (пакеты с исходным кодом: %d)"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "Экранный снимок "
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Статистика поиска:"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Статистика загрузок:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Поиск и установка программного обеспечения из <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Параметры поиска"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "Включить «домашние» проекты пользователей"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Исключить отладочные пакеты"
+
+#~ msgid "Additional Information"
+#~ msgstr "Дополнительные сведения"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Краткое руководство по установке</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Купить openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Купите openSUSE 11.3!"
+
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Больше сведений о загрузке openSUSE можно узнать из <a href=\"http://en."
+#~ "opensuse.org/SDB:Download_help\">справки по скачиванию</a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Доступны следующие инструкции:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Установка с DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Официальное руководство %s для начинающих"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Пошаговое руководство по установке"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Установка по сети"
+
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/SDB:Network_installation"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Установка по интернету"
+
+#~ msgid "More information"
+#~ msgstr "Дополнительные сведения"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"

--- a/locale/sk/software.po
+++ b/locale/sk/software.po
@@ -1,0 +1,1258 @@
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# Ferdinand Galko <galko.ferdinand@gmail.com>, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-03 18:48+0100\n"
+"Last-Translator: Ferdinand Galko <galko.ferdinand@gmail.com>\n"
+"Language-Team: Slovak <opensuse-translation-sk@opensuse.org>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0;\n"
+"X-Poedit-Language: Slovak\n"
+"X-Poedit-Country: SLOVAKIA\n"
+
+msgid " and "
+msgstr " a "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr "(skryť)"
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "64 Bitové PC"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE_License\">Licencia</a>"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/Metalink\">Metalink</a> je otvorený "
+"štandard, ktorý pre zjenodušenie sťahovania zlučuje rôzne možnosti (FTP/HTTP/"
+"BitTorrent) získania súborov, do jedného formátu. Je výhodný na použitie "
+"sťahovania ISO obrazov, obzvlášť pre ľudí ktorý nemôžu použiť P2P siete, "
+"kôly obmedzeniam zo strany poskytovateľov internetového pripojenia. Je "
+"schopný zabezpečiť vysokú rýchlosť sťahovania, pretože väčšina klientov "
+"podporuje viacnásobné pripojenia na rôzne obrazy automaticky. Naviac je "
+"schopný automatickej detekcií chýb s ich následnouch opravou. Na jeho "
+"použitie zo strany klienta je potrebný špeciálny software."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licencia</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Poznámky k vydaniu</a>"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "Oficiálne manuály"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "Oficiálne manuály"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"GNOME prostredie, ktoré je možné spustiť z CD, prípadne USB kľúčiku.<br/"
+">Môže byť použité aj na inštaláciu systému (nie aktualizáciu)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"KDE prostredie, ktoré môžete spustiť z %s alebo USB kľúča.<br/>Môže byť "
+"nainštalované ako je (žiadne zvýšenie verzie)."
+
+msgid "Add repository and install manually"
+msgstr ""
+
+msgid "Add-On Downloads (optional)"
+msgstr "Rozširujúce stiahnutia (voliteľné)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+#  frame
+#, fuzzy
+msgid "App Browser"
+msgstr "Prehliadač aplikácií"
+
+#, fuzzy
+msgid "Available Images"
+msgstr "Dostupné aktualizácie"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Spustite z DVD, alebo CD. V prípade, že počítač automaticky nespustí systém "
+"z CD/DVD, v BIOSe povoľte spustenie z CD, alebo DVD."
+
+msgid "Bronze Sponsor"
+msgstr "Bronzový sponzor"
+
+msgid "Browser incompatibility"
+msgstr ""
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Napálenie CD/DVD obrazu"
+
+msgid "Categories"
+msgstr "Kategórie"
+
+msgid "Category"
+msgstr "Kategória"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Vyberte inštalačné médium kliknutím a stlačte tlačidlo Stiahnuť pre začatie "
+"sťahovania. Pokiaľ je potrebné, vyberte typ počítača, alebo iný spôsob "
+"sťahovania."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Kliknúť pre stiahnutie"
+
+msgid "Community"
+msgstr "Komunita"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Obsahuje kolekciu aplikácií určených pre domáce, alebo serverové použitie."
+"<br/>Vhodné pre inštaláciu, alebo upgrade."
+
+#, fuzzy
+msgid "Countdown"
+msgstr "Vypnúť počítač"
+
+msgid "Country"
+msgstr "Krajina"
+
+msgid "Development"
+msgstr "Vývoj"
+
+msgid "Development Version"
+msgstr "Vývojová verzia"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "Devel balíky pre KDE"
+
+#, fuzzy
+msgid "Development-"
+msgstr "Vývoj"
+
+#, fuzzy
+msgid "Direct Install"
+msgstr "1-Click inštalácia"
+
+msgid "Direct Link"
+msgstr "Priamy odkaz"
+
+#, fuzzy
+msgid "Documentation"
+msgstr "Dokumenty"
+
+msgid "Don't show this warning the next time"
+msgstr ""
+
+msgid "Download"
+msgstr "Stiahnuť"
+
+msgid "Download %s"
+msgstr "Stiahnuť %s"
+
+msgid "Download Help"
+msgstr "Pomocník sťahovania"
+
+msgid "Download Method"
+msgstr "Spôsob sťahovania"
+
+#, fuzzy
+msgid "Download appliance from %s"
+msgstr "Sťahujem patch rpm (záplatu)"
+
+msgid "Download&nbsp;DVD"
+msgstr "Stiahnuť"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Stiahnuť"
+
+msgid "Download&nbsp;KDE"
+msgstr "Stiahnuť"
+
+msgid "Download&nbsp;Network"
+msgstr "Stiahnuť"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "Stiahnuť"
+
+msgid "Downloads"
+msgstr "Stiahnuť"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Stiahne inštalačný systém a všetky balíky z online zdrojov.<br/>Vhodné pre "
+"inštaláciu, alebo upgrade."
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "Extra jazyky"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Extra jazyky (32 Bit)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Extra jazyky (64 Bit)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be"
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"ponúka najbezpečnejšiu metódu, ako môžete overiť kto ho podpísal. Mal by byť"
+
+msgid "Games"
+msgstr "Hry"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Získať jednu zo špecializovaných distribúcií založenej na openSUSE."
+
+msgid "Getting Help"
+msgstr "Získanie pomoci"
+
+msgid "Gold Sponsor"
+msgstr "Zlatý sponzor"
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr "Logo hlavičky"
+
+msgid "Help on Download Method"
+msgstr "Pomocník pre spôsob sťahovania"
+
+msgid "Help on Type of Computer"
+msgstr "Pomocník pre typ počítača"
+
+msgid "How to Proceed"
+msgstr "Ako pokračovať"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Pokiaľ si prajete použiť priamy odkaz, ale žijete v mieste kde náš "
+"presmerovač sťahovaní nemá dostatok informácií na vaše presmerovanie na "
+"rýchlejší server, môžete vybrať zrkadlo podľa vlastnej voľby."
+
+msgid "Image:"
+msgstr "Obraz:"
+
+#, fuzzy
+msgid "Install package %s / %s"
+msgstr "Nainštalované balíky: %d"
+
+msgid "Install pattern %s / %s"
+msgstr ""
+
+#, fuzzy
+msgid "Install using One Click Install"
+msgstr "Voľba inštalácie: instalácia"
+
+msgid "Installation Guides"
+msgstr "Inštalační sprievodcovia"
+
+msgid "Installation Medium"
+msgstr "Inštalačné médium"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror prostredia KDE 3 nie je udržiavaný a implementácia jeho "
+"javascriptu obsahuje chyby, s ktorými nie je možné použiť túto stránku. "
+"Uistite sa, že máte javascript zakázaný, kým budete <a href='%s'>pokračovať</"
+"a>."
+
+msgid "Language"
+msgstr "Jazyk"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "32 Bitové PC"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "32&nbsp;Bitové&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+#, fuzzy
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Veľa aplikácií môže overiť kontrolný súčet stiahnutia. Pre overenie Vášho "
+"stiahnutia môže byť dôležité, či ste naozaj stiahli ISO súbor, ktorý ste "
+"chceli stiahnuť a nie je poškodený. Ponúkame tri metódy overenia kontrolných "
+"súčtov:"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Ďalšie informácie o stiahnutí openSUSE sú dostupné na stránke <a href="
+"\"http://en.opensuse.org/Download_Help\">pomocníka sťahovania.</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Väčšina dnešných počítačov obsahuje architektúru typu<a href=\"http://sk."
+"wikipedia.org/wiki/X86-64\">x86-64</a> (napríklad AMD64 a Intel64). "
+"Informáciu o tom, akej architektúry je váš počítač, môžete nájsť napríklad "
+"na wikipedií, prípade na stránkach výrobcu či predajcu."
+
+msgid "Multimedia"
+msgstr "Multimédiá"
+
+msgid "Need help?"
+msgstr "Potrebujete pomoc?"
+
+msgid "Network"
+msgstr "Sieť"
+
+#, fuzzy
+msgid "No appliance data for %s"
+msgstr "Informácie pre: %s %s"
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+#, fuzzy
+msgid "No data for %s / %s"
+msgstr "Informácie pre: %s %s"
+
+#, fuzzy
+msgid "No description found..."
+msgstr "Nebol nájdený žiaden repozitár."
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+#, fuzzy
+msgid "No packages found matching your search. "
+msgstr "Neboli nájdené žiadne balíky vyhovujúce výrazu '%s'."
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "scdb nie je k dispozícii"
+
+msgid "Official Manuals"
+msgstr "Oficiálne manuály"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+#, fuzzy
+msgid "Package %s not found..."
+msgstr "'Záplata %s' nebola nájdená."
+
+msgid "Package Repositories"
+msgstr "Repozitáre balíkov"
+
+msgid "Package Search"
+msgstr "Hľadať balíky"
+
+#, fuzzy
+msgid "Packages for %s:"
+msgstr "Mažem uložené RPM súbory pre '%s'."
+
+msgid "Pick Mirror"
+msgstr "Vybrať zrkadlo"
+
+msgid "Platinum Sponsor"
+msgstr "Platinový sponzor"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+#, fuzzy
+msgid "Related categories:"
+msgstr "Kategória"
+
+msgid "Released Version"
+msgstr "Stabilná verzia"
+
+msgid "Reporting Bugs"
+msgstr "Hlásenie chýb"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "Záchranný systém"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"KDE prostredie, ktoré je možné spustiť z CD, prípadne USB kľúčiku.<br/>Môže "
+"byť použité aj na inštaláciu systému (nie aktualizáciu)."
+
+msgid "SHA256 checksum"
+msgstr "Kontrolný súčet SHA256"
+
+msgid "Search"
+msgstr "Hľadať"
+
+#, fuzzy
+msgid "Select Your Operating System"
+msgstr "Štart operačného systému"
+
+#, fuzzy
+msgid "Select the image type"
+msgstr "Vyberte typ obrazovky."
+
+msgid "Show"
+msgstr "Ukázať:"
+
+#, fuzzy
+msgid "Show development, language and debug packages"
+msgstr "Devel balíky pre KDE"
+
+#, fuzzy
+msgid "Show distribution:"
+msgstr "Distribúcia: %1\n"
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+msgid "Show more..."
+msgstr ""
+
+#, fuzzy
+msgid "Show other versions"
+msgstr "zastaralý (nainštalovaná "
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "zobraziť inštalované balíky"
+
+#, fuzzy
+msgid "Show unsupported packages"
+msgstr "zobraziť inštalované balíky"
+
+msgid "Silver Sponsor"
+msgstr "Strieborný sponzor"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Niektoré z live distribúcií založených na openSUSE. Záujemcovia v snahe o "
+"vybudovanie vlastných derivátov sa môžu pozrieť na <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Zdroj"
+
+msgid "Sponsored by"
+msgstr "Sponzori"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "Sponzorované od AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Sponzori: B1 systémy"
+
+msgid "Sponsored by: Heinlein"
+msgstr "Sponzorované: Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Sponzorované od: IP Exchange"
+
+#, fuzzy
+msgid "Sub-Packages"
+msgstr "_Skryť subbalíky"
+
+msgid "Support"
+msgstr "Podpora"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Toto CD obsahuje slobodný softvér šírený pod proprietárnou licenciou "
+"neumožňujúcou jeho zaradenie do hlavného inštalačného média spolu s voľným "
+"open-source softvérom. Všetok softvér z tohoto CD sa dá stiahnuť z NON-OSS "
+"repozitára."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Túto verziu je možné nainštalovať na všetky PC ( vrátane 64 bitových). "
+"Pokiaľ máte viacej ako 3 GB RAM mali by ste zvoliť 64 bitovú verziu. "
+"openSUSE nepodporuje precesory nižšej rady ako Pentium - live CD podporuje "
+"až radu i686 (Pentium Pro a vyššie)"
+
+msgid "Type of Computer"
+msgstr "Typ počítača"
+
+msgid "Unsupported distributions:"
+msgstr "Nepodporované distribúcie:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Použitie BitTorrentu je odporúčané pre pomalé pripojenie, obzvlášť pri "
+"sťahovaní DVD obrazov. BitTorrent má niekoľko výhod, klientov chráni proti "
+"poškodeniu sťahovaných dát a pomáha znižovať vyťaženosť serverov. Pokiaľ sa "
+"dostatočné množstvo ľudí zapojí do zdieľania súborov, je toto riešenie "
+"rýchlejšie ako centralizovaný server - pre všetkých. Naviac, umožňuje "
+"užívateľovi zastaviť sťahovanie dát v ľubovoľnom čase, s možnosťou "
+"pokračovania. Viacej užitočných informácií nájdete na <a href=\"http://en."
+"opensuse.org/BitTorrent_and_openSUSE\">BitTorrent and openSUSE</a>."
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "Kontrola stiahnutia (voliteľné, pre expertov)"
+
+msgid "Version"
+msgstr "Verzia"
+
+msgid "We offer three different checksums:"
+msgstr ""
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Pokiaľ sťahujete CD ISO obraz iný ako Sieťová inštalácia, je <i>dôrazne</i> "
+"odporúčané použiť aplikáciu určenú na sťahovanie dát. Týmto spôsobom môžete "
+"znížiť riziko poškodenia dát"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+
+msgid "gpg signature"
+msgstr "gpg podpis"
+
+#, fuzzy
+msgid "http://doc.opensuse.org/"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"je najčastejšie používaný kontrolný súčet. Veľa napaľovacích programov ho "
+"zobrazuje tesne pred napaľovaním."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "je menej známy, ale bezpečnejší kontrolný súčet ako md5."
+
+msgid "md5 checksum"
+msgstr "kontrolný súčet md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"ponúka najväčšiu bezpečnosť, ako si môžete overiť kto ho podpísal. Mal by "
+"byť <tt>%s</tt>."
+
+#, fuzzy
+msgid "openSUSE Countdown"
+msgstr "openSUSE 11.3 počítadlo"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE deriváty"
+
+#, fuzzy
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE je dostupné cez http (priamy odkaz), alebo BitTorrent. CD pre "
+"sieťovú inštaláciu je dostupné len cez http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE podporuje iba 32 Bitové a 64 Bitové PC"
+
+msgid "see Derivatives on wiki"
+msgstr "pozrieť deriváty na wiki"
+
+msgid "sha1 checksum"
+msgstr "kontrolný súčet sha1"
+
+msgid "switch to"
+msgstr "prepnúť na"
+
+#, fuzzy
+#~ msgid "An internal error happened :-("
+#~ msgstr "Vyskytla sa interná chyba systému"
+
+#, fuzzy
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Heslo je príliš krátke (musí obsahovať aspoň 5 znakov)."
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~ msgid "Last searches:"
+#~ msgstr "Hľadať:"
+
+#, fuzzy
+#~ msgid "Statistics"
+#~ msgstr "Stav"
+
+#, fuzzy
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Stiahnuť"
+
+#, fuzzy
+#~ msgid "Top searches:"
+#~ msgstr "Hľadať:"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD obsahuje iba štyri jazyky (angličtinu, nemčinu, ruštinu a "
+#~ "taliančinu). Ak chcete mať podporu pre zvyšné jazyky, musíte si ich "
+#~ "stiahnuť z internetu počas inštalácie, alebo kedykoľvek potom. Ak máte "
+#~ "jednoduchý prístup k internetu, alebo ak používate DVD obsahujúce všetky "
+#~ "jazyky, nepotrebujete toto CD."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Po úspešnom stiahnutí ISO obrazu, napáľte obraz s obľúbeným napaľovacím "
+#~ "programom na DVD, alebo CD. Nenapaľujte ako dáta DVD/CD, ale vyberte "
+#~ "možnosť napáliť ako ISO obraz."
+
+#, fuzzy
+#~| msgid "Password is too short (must have at least 8 characters)."
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Heslo je príliš krátke (musí obsahovať aspoň 5 znakov)."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "Prosím buďte presnejší vo vyhľadávaní, dosiahnutý limit hľadania."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Nedá sa hľadať:"
+
+#~ msgid "Popular Software"
+#~ msgstr "Populárny softvér"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Kúpiť openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Click inštalácia"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Ručné stiahnutie balíka"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Ísť do OBS projektu"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Zbierka softvéru]"
+
+#~ msgid "Search Results"
+#~ msgstr "Výsledky hľadania"
+
+#, fuzzy
+#~| msgid "No packages found that matched your query."
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "Neboli nájdené žiadne balíky, ktoré zodpovedajú vášmu dotazu."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d kolekcií %d binárnych súborov z/zo %d inštalačných balíkov"
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "Každodenné verzie programu Wine z CVS"
+
+#, fuzzy
+#~| msgid "Search Results"
+#~ msgid "Search Statistics:"
+#~ msgstr "Výsledky hľadania"
+
+#, fuzzy
+#~| msgid "Download failed: "
+#~ msgid "Download Statistics:"
+#~ msgstr "Zlyhalo sťahovanie"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Hľadať a inštalovať softvérové balíky z <a href=\"http://build.opensuse."
+#~ "org\">openSUSE Build Service</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "Možnosti hľadania"
+
+#, fuzzy
+#~| msgid "Exclude user's home projects"
+#~ msgid "Include users' home projects"
+#~ msgstr "Vylúčiť používateľské domovské projekty"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Vylúčiť balíky ladenia (debug)"
+
+#~ msgid "Additional Information"
+#~ msgstr "Ďalšie informácie"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Kúpiť openSUSE 11.2"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2!"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Kúpiť openSUSE 11.2!"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Ďalšie informácie o stiahnutí openSUSE sú dostupné na stránke <a href="
+#~ "\"http://en.opensuse.org/Download_Help\">pomocníka sťahovania.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Inštrukcie sú nasledovné:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Inštalácia z DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Oficiálny %s sprievodca"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Inštalačný sprievodca krok za krokom"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Sieťová inštalácia"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Derivatives"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Inštalácia z internetu"
+
+#~ msgid "More information"
+#~ msgstr "Viac informácií"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Získať softvér"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Vytvoriť softvér"
+
+#~ msgid "User Directory"
+#~ msgstr "Priečinok používateľa"
+
+#  tree node string - means "hardware bus"
+#~ msgid "Features"
+#~ msgstr "Funkcie"
+
+#~ msgid "News"
+#~ msgstr "Novinky"
+
+#~ msgid "Forums"
+#~ msgstr "Fórum"
+
+#~ msgid "Shop"
+#~ msgstr "Obchod"
+
+#~ msgid "Software"
+#~ msgstr "Softvér"
+
+#~ msgid "Software Search"
+#~ msgstr "Hľadať softvér"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Repozitáre s aktualizáciami"
+
+#~ msgid "Source Repository"
+#~ msgstr "Zdrojový repozitár"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Ďalšie voľby"
+
+#~ msgid "Mirrors"
+#~ msgstr "Zrkadlá"
+
+#~ msgid "In other languages"
+#~ msgstr "V iných jazykoch"
+
+#~ msgid "Get it"
+#~ msgstr "Získať"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Hľadať v Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr "Hľadať a inštalovať ďalšie balíky z openSUSE Build Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Získať openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Trvalý odkaz na výsledok hladania"
+
+#~ msgid "Nothing found"
+#~ msgstr "Nič nenájdené"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Získať softvér z openSUSE Build Service"
+
+#~ msgid "Searching"
+#~ msgstr "Hľadám"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Obsahuje kolekciu aplikácií určených pre domáce, alebo serverové "
+#~ "použitie. Vhodné pre inštaláciu, alebo upgrade."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "GNOME prostredie, ktoré je možné spustiť z CD, prípadne USB kľúčiku. Môže "
+#~ "byť použité aj na inštaláciu systému."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "KDE prostredie, ktoré je možné spustiť z CD, prípadne USB kľúčiku. Môže "
+#~ "byť použité aj na inštaláciu systému."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Stiahne inštalačný systém a všetky balíky z online zdrojov. Vhodné pre "
+#~ "inštaláciu, alebo upgrade."
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinky"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Kúpiť openSUSE 11.1!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Pre používateľov začínajúcich s Linuxom, môže byť podporovaná verzia "
+#~ "openSUSE najlepšou voľbou&mdash;získate kompletnú dokumentáciu pre "
+#~ "koncového používateľa, inštalovateľné médiá pre 32 Bitové a 64 Bitové "
+#~ "systémy, plus 90 dní inštalačnej podpory."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 je dostupné v niekoľkých <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> obchodoch, alebo u lokálnych predajcov."
+
+#~ msgid "Expert view"
+#~ msgstr "Zobrazenie pre expertov"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: Počítače s napr. AMD&reg; Sempron, alebo Intel&reg; Celeron&trade;, "
+#~ "takmer všetky počítače z roku 2004, alebo skoršie. Táto verzie beží tiež "
+#~ "na 64bitových počítačoch."
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: Väčšina nových počítačov s napr. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, alebo Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D jadrami."
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "Ak chcete stiahnuť médium, vyberte si zo spôsobov inštalácie, prípadne "
+#~ "zmenu architektúry a spôsob sťahovania a vyberte \"Uložiť súbor\"."
+
+#~ msgid "Popup: Help on Download Media"
+#~ msgstr "Vyskakovacie okno: Pomocník pre typy médií"
+
+#~ msgid "Help"
+#~ msgstr "Pomocník"
+
+#~ msgid "DVD is the standard medium for most"
+#~ msgstr "DVD je štandardné médium pre väčšinu"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Live CD s GNOME prostredím"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "Live CD s KDE prostredím"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "Sieťová inštalácia pre expertov"
+
+#~ msgid ""
+#~ "is still the most commonly used checksum. Many ISO burners display it "
+#~ "right before burning.."
+#~ msgstr ""
+#~ "je najčastejšie používaný kontrolný súčet. Veľa napaľovacích programov ho "
+#~ "zobrazuje tesne pred napaľovaním.."
+
+#~ msgid "is the less known but more secure checksum than md5.."
+#~ msgstr "je menej známy, ale bezpečnejší kontrolný súčet ako md5.."

--- a/locale/software.pot
+++ b/locale/software.pot
@@ -1,0 +1,604 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the software package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: software 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2016-08-31 16:19+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr ""
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr ""
+
+msgid "<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE startup guide</a>"
+msgstr ""
+
+msgid "<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files into one format for easier downloads. This makes it good for downloading ISOs; particularly for people who can't use P2P because of restrictions from their ISP or University. It can deliver very fast download speeds since most clients support multiple connections, to multiple mirrors, automatically. In addition, it can do automatic error detection, and correction. It needs a special client to handle it though."
+msgstr ""
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr ""
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr ""
+
+msgid "<b>official release</b>"
+msgstr ""
+
+msgid "<b>official update</b>"
+msgstr ""
+
+msgid "A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed as is (no upgrade)."
+msgstr ""
+
+msgid "A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as is (no upgrade)."
+msgstr ""
+
+msgid "Add repository and install manually"
+msgstr ""
+
+msgid "Add-On Downloads (optional)"
+msgstr ""
+
+msgid "After having successfully downloaded the ISO image(s), create a bootable USB stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/United_States_embargoes</a>."
+msgstr ""
+
+msgid "App Browser"
+msgstr ""
+
+msgid "Available Images"
+msgstr ""
+
+msgid "BitTorrent"
+msgstr ""
+
+msgid "Boot from the DVD, CD or USB stick. In case your computer does not automatically boot from the chosen device, open the BIOS setup to allow booting from it."
+msgstr ""
+
+msgid "Bronze Sponsor"
+msgstr ""
+
+msgid "Browser incompatibility"
+msgstr ""
+
+msgid "Burn CD/DVD Image(s)"
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid "Choose an installation medium by clicking it and hit the Download button to start the download. Optionally choose your computer type or an alternative download method."
+msgstr ""
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr ""
+
+msgid "Community"
+msgstr ""
+
+msgid "Contains a large collection of software for desktop or server use.<br/>Suitable for installation or upgrade."
+msgstr ""
+
+msgid "Countdown"
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Development Version"
+msgstr ""
+
+msgid "Development packages"
+msgstr ""
+
+msgid "Development-"
+msgstr ""
+
+msgid "Direct Install"
+msgstr ""
+
+msgid "Direct Link"
+msgstr ""
+
+msgid "Documentation"
+msgstr ""
+
+msgid "Don't show this warning the next time"
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Download %s"
+msgstr ""
+
+msgid "Download Help"
+msgstr ""
+
+msgid "Download Method"
+msgstr ""
+
+msgid "Download appliance from %s"
+msgstr ""
+
+msgid "Download&nbsp;DVD"
+msgstr ""
+
+msgid "Download&nbsp;GNOME"
+msgstr ""
+
+msgid "Download&nbsp;KDE"
+msgstr ""
+
+msgid "Download&nbsp;Network"
+msgstr ""
+
+msgid "Download&nbsp;Rescue"
+msgstr ""
+
+msgid "Downloads"
+msgstr ""
+
+msgid "Downloads the installation system and all packages from online repositories.<br/>Suitable for installation or upgrade."
+msgstr ""
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr ""
+
+msgid "Extra Languages (32 Bit)"
+msgstr ""
+
+msgid "Extra Languages (64 Bit)"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid "For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following (note that the order of repositories in pacman.conf is important, since pacman always downloads the first found package):"
+msgstr ""
+
+msgid "For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+msgid "For extra security, you can use GPG to verify who signed those .sha256 files. It should be %s."
+msgstr ""
+
+msgid "Games"
+msgstr ""
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr ""
+
+msgid "Getting Help"
+msgstr ""
+
+msgid "Gold Sponsor"
+msgstr ""
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr ""
+
+msgid "Help on Download Method"
+msgstr ""
+
+msgid "Help on Type of Computer"
+msgstr ""
+
+msgid "How to Proceed"
+msgstr ""
+
+msgid "If you want to use a direct link but live in a place in the world where our download redirector has not enough information to redirect to the fastest mirror, you can pick a mirror yourself."
+msgstr ""
+
+msgid "Image:"
+msgstr ""
+
+msgid "Install package %s / %s"
+msgstr ""
+
+msgid "Install pattern %s / %s"
+msgstr ""
+
+msgid "Install using One Click Install"
+msgstr ""
+
+msgid "Installation Guides"
+msgstr ""
+
+msgid "Installation Medium"
+msgstr ""
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, school\n"
+"        university or event like LUG meetings, installfests, and conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid "Konqueror of KDE 3 is unfortunately unmaintained and its javascript implementation contains bugs that make it impossible to use with this page. Please make sure you have javascript disabled before you <a href='%s'>continue</a>."
+msgstr ""
+
+msgid "Language"
+msgstr ""
+
+msgid "Legacy 32 Bit PC"
+msgstr ""
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr ""
+
+msgid "Live GNOME"
+msgstr ""
+
+msgid "Live KDE"
+msgstr ""
+
+msgid "Many applications can verify the checksum of a download. To verify your download can be important as it verifies you really have got the ISO file you wanted to download and not some broken version."
+msgstr ""
+
+msgid "Metalink"
+msgstr ""
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+
+msgid "More information on creating a <a href='http://en.opensuse.org/Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+
+msgid "More information on downloading openSUSE is available from the <a href=\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href=\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> pages in our <a href=\"http://en.opensuse.org/Portal:Documentation\">Documentation Wiki</a>."
+msgstr ""
+
+msgid "Most new computers support <a href=\"http://en.wikipedia.org/wiki/X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop processors and netbook processors do not support it. So you need to check wikipedia if you want to be sure your computer supports it."
+msgstr ""
+
+msgid "Multimedia"
+msgstr ""
+
+msgid "Need help?"
+msgstr ""
+
+msgid "Network"
+msgstr ""
+
+msgid "No appliance data for %s"
+msgstr ""
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+msgid "No data for %s / %s"
+msgstr ""
+
+msgid "No description found..."
+msgstr ""
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+msgid "No packages found matching your search. "
+msgstr ""
+
+msgid "NonOSS CD"
+msgstr ""
+
+msgid "OBS Backend not available"
+msgstr ""
+
+msgid "Official Manuals"
+msgstr ""
+
+msgid "Only DVD and Network medias are fully tested. Alternatives, like live or rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr ""
+
+msgid "Package Repositories"
+msgstr ""
+
+msgid "Package Search"
+msgstr ""
+
+msgid "Packages for %s:"
+msgstr ""
+
+msgid "Pick Mirror"
+msgstr ""
+
+msgid "Platinum Sponsor"
+msgstr ""
+
+msgid ""
+"Please be aware that the following packages are from unofficial repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or experimental software."
+msgstr ""
+
+msgid "Please enter a <b>brief</b> reason (in English!) why you need the DVDs and provide a link of the event/purpose."
+msgstr ""
+
+msgid "Please note that this is not the latest openSUSE release. You can get the latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+msgid "Related categories:"
+msgstr ""
+
+msgid "Released Version"
+msgstr ""
+
+msgid "Reporting Bugs"
+msgstr ""
+
+msgid "Rescue"
+msgstr ""
+
+msgid "Rescue system that you can run from CD or from USB stick.<br/>Can not be used for installation or upgrade."
+msgstr ""
+
+msgid "SHA256 checksum"
+msgstr ""
+
+msgid "Search"
+msgstr ""
+
+msgid "Select Your Operating System"
+msgstr ""
+
+msgid "Select the image type"
+msgstr ""
+
+msgid "Show"
+msgstr ""
+
+msgid "Show development, language and debug packages"
+msgstr ""
+
+msgid "Show distribution:"
+msgstr ""
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+msgid "Show more..."
+msgstr ""
+
+msgid "Show other versions"
+msgstr ""
+
+msgid "Show unstable packages"
+msgstr ""
+
+msgid "Show unsupported packages"
+msgstr ""
+
+msgid "Silver Sponsor"
+msgstr ""
+
+msgid "Some alternative media (eg. live and rescue systems) are also available, although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid "Some of the live distributions based on openSUSE. Those interested in trying to build their own derivatives can take a look at <a href=\"http://susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+
+msgid "Source"
+msgstr ""
+
+msgid "Sponsored by"
+msgstr ""
+
+msgid "Sponsored by: AMD"
+msgstr ""
+
+msgid "Sponsored by: B1 Systems"
+msgstr ""
+
+msgid "Sponsored by: Heinlein"
+msgstr ""
+
+msgid "Sponsored by: IP Exchange"
+msgstr ""
+
+msgid "Sub-Packages"
+msgstr ""
+
+msgid "Support"
+msgstr ""
+
+msgid "The installation process is available in many languages but, for most of them, the translation of the applications is not included in the image. If you want your openSUSE system to support some additional language, you need to download it from the Internet during the installation or any time after it. If you have easy access to the Internet you do not need this CD, but if you are planning to install openSUSE in some machine with no Internet connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid "There is no openSUSE release in testing phase at the moment. <br/> If you want to use bleeding edge software, please use <a href='http://en.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid "This CD contains free software distributed under proprietary licence not allowing its inclusion to main installation media together with free open-source software. All software from this CD could be downloaded from NON-OSS repository."
+msgstr ""
+
+msgid "This version runs on all PCs including those that support 64 Bit. If you have more than 3 GB of RAM you should prefer the 64 Bit version though. openSUSE does not support processors before Pentium - the live CDs even support only i686 (Pentium Pro and later)."
+msgstr ""
+
+msgid "Type of Computer"
+msgstr ""
+
+msgid "Unsupported distributions:"
+msgstr ""
+
+msgid "User manuals are available from <a href=\"http://activedoc.opensuse.org\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc.opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+
+msgid "Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is recommended on slow links, especially when downloading the DVD image. BitTorrent downloads have several benefits, the clients protect against data corruption and you help relieving the load on the servers by participating in the upload - if enough people participate it will also be faster than the centralized servers - for everybody. Whatsmore, it allows you to stop the download at any time and resume it later."
+msgstr ""
+
+msgid "Verify your download before use"
+msgstr ""
+
+msgid "Version"
+msgstr ""
+
+msgid "We offer three different checksums:"
+msgstr ""
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid "When downloading images other than the CD for network installation, it is <i>strongly</i> recommended to use a proper download manager to reduce the risk of corrupted data."
+msgstr ""
+
+msgid "You can add the repository key to apt. Keep in mind that the owner of the key may distribute updates, packages and repositories that your system will trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid "You could try to extend your search to development packages or search for another base distribution (currently )."
+msgstr ""
+
+msgid "You could verify the file in the process of downloading. For example a checksum (SHA256) will be used automatically if you choose <a href='http://en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+
+msgid "gpg signature"
+msgstr ""
+
+msgid "http://doc.opensuse.org/"
+msgstr ""
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr ""
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr ""
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr ""
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr ""
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr ""
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr ""
+
+msgid "is still the most commonly used checksum. Many ISO burners display it right before burning."
+msgstr ""
+
+msgid "is the less known but more secure checksum than md5."
+msgstr ""
+
+msgid "md5 checksum"
+msgstr ""
+
+msgid "offers the most security as you can verify who signed it. It should be <tt>%s</tt>."
+msgstr ""
+
+msgid "openSUSE Countdown"
+msgstr ""
+
+msgid "openSUSE Derivatives"
+msgstr ""
+
+msgid "openSUSE is available via http (direct link) or BitTorrent. The CD for network installation is only available via http."
+msgstr ""
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr ""
+
+msgid "see Derivatives on wiki"
+msgstr ""
+
+msgid "sha1 checksum"
+msgstr ""
+
+msgid "switch to"
+msgstr ""

--- a/locale/th/software.po
+++ b/locale/th/software.po
@@ -1,0 +1,1172 @@
+# Thai message file for YaST2 (@memory@).
+# Copyright (C) 2008 SUSE Linux Products GmbH.
+#
+# Thanomsub Noppaburana <donga.nb@gmail.com>, 2010.
+msgid ""
+msgstr ""
+"Project-Id-Version: YaST (@memory@)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2010-07-17 12:57+0700\n"
+"Last-Translator: Thanomsub Noppaburana <donga.nb@gmail.com>\n"
+"Language-Team: Thai <thai-l10n@googlegroups.com>\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Lokalize 1.0\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr ""
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "พีซี 64 บิท"
+
+#, fuzzy
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE_License\">สัญญาอนุญาต</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">เมตาลิงก์</a> "
+"เป็นมาตรฐานเปิดที่รวมหลาย ๆ วิธีการเข้าไว้ด้วยกัน (FTP/HTTP/BitTorrent) "
+"สำหรับใช้ในการรับแฟ้มต่าง ๆ มาเป็นรูปแบบเดียวเพื่อให้สะดวกต่อการดาวน์โหลด "
+"ซึ่งวิธีการนี้ดีสำหรับการดาวน์โหลดแฟ้มอิมเมจต่าง ๆ ที่เป็นแบบ ISO "
+"โดยเฉพาะอย่างยิ่งกับผู้ที่ไม่สามารถดาวน์โหลดในรูปแบบ P2P ได้ "
+"ซึ่งอาจเนื่องมาจากการห้ามการใช้งาน P2P ขององค์กรหรือจากผู้ให้บริการอินเทอร์เน็ต วิธีการนี้นั้น "
+"สามารถช่วยให้ทำการดาวน์โหลดได้อย่างรวดเร็วมากขึ้น "
+"เนื่องจากไคลเอนท์ส่วนมากมักจะรองรับการเชื่อมต่อได้หลายการเชื่อมต่อ, "
+"เชื่อมต่อไปยังเครื่องแม่ข่ายสำรองได้หลายเครื่อง และเป็นไปอย่างอัตโนมัติ นอกจากนี้ "
+"มันยังสามารถตรวจสอบความผิดพลาดและความถูกต้องได้อัตโนมัติอีกด้วย "
+"ทั้งนี้มันจำเป็นต้องใช้ไคลเอนท์แบบพิเศษในการจัดการมันด้วย"
+
+#, fuzzy
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/OpenSUSE_License\">สัญญาอนุญาต</a>"
+
+#, fuzzy
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>บันทึกประจำรุ่น</a> (ข้อมูลรายละเอียดล่าสุด)"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "คู่มือการใช้งานอย่างเป็นทางการ"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "คู่มือการใช้งานอย่างเป็นทางการ"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"เดสก์ท็อประบบ GNOME ที่คุณสามารถเรียกใช้งานได้โดยตรงผ่านทางซีดีหรือจากไดรฟ์ยูเอสบี<br/"
+">นอกจากนี้ยังสามารถนำไปใช้ทำการติดตั้งได้อีกด้วย (แต่ไม่สามารถใช้อัพเกรดได้)"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"เดสก์ท็อประบบ KDE ที่คุณสามารถเรียกใช้งานได้โดยตรงผ่านทางซีดีหรือจากไดรฟ์ยูเอสบี<br/"
+">นอกจากนี้ยังสามารถนำไปใช้ทำการติดตั้งได้อีกด้วย (แต่ไม่สามารถใช้อัพเกรดได้)"
+
+#, fuzzy
+msgid "Add repository and install manually"
+msgstr "ข้อมูลกำกับของคลังแพกเกจใช้งานไม่ได้"
+
+msgid "Add-On Downloads (optional)"
+msgstr "ดาวน์โหลด ผลิตภัณฑ์เสริม (เป็นตัวเลือก)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+#, fuzzy
+msgid "App Browser"
+msgstr "เบราว์เซอร์ SLP"
+
+#, fuzzy
+msgid "Available Images"
+msgstr "ส่วนเชื่อมต่อเครือข่ายที่มีอยู่"
+
+msgid "BitTorrent"
+msgstr "บิททอร์เรนท์"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"ให้ทำการบูตคอมพิวเตอร์ของคุณจากแผ่นดีวีดีหรือแผ่นซีดี "
+"ในกรณีที่คอมพิวเตอร์ของคุณไม่ได้ถูกตั้งค่าให้ทำการบูตระบบจากแผ่นดีวีดีหรือแผ่นซีดีโดยอัตโนมัติ "
+"ให้ทำการเข้าหน้าตั้งค่าไบออสของคอมพิวเตอร์ของคุณ "
+"เพื่ออนุญาตให้ทำการบูตระบบได้จากแผ่นซีดีหรือแผ่นดีวีดี"
+
+msgid "Bronze Sponsor"
+msgstr "ผู้สนับสนุนระดับเหรียญทองแดง"
+
+msgid "Browser incompatibility"
+msgstr ""
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "เขียนแฟ้มอิมเมจแผ่นซีดี/แผ่นดีวีดี"
+
+msgid "Categories"
+msgstr "หมวดหมู่"
+
+msgid "Category"
+msgstr "หมวดหมู่"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"เลือกสื่อสำหรับใช้ติดตั้งโดยการคลิกบนรายการที่ต้องการแล้วกดที่ปุ่มดาวน์โหลดเพื่อเริ่มการดาวน์โหลด "
+"คุณสามารถเลือกชนิดคอมพิวเตอร์ของคุณหรือวิธีการดาวน์โหลดที่ต่างออกไปเป็นทางเลือกได้อีกด้วย"
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "คลิกเพื่อดาวน์โหลด"
+
+msgid "Community"
+msgstr "ชุมชน"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"บรรจุไปด้วยชุดซอฟต์แวร์ต่าง ๆ อย่างหลากหลาย "
+"สำหรับการใช้งานกับทั้งระบบเดสก์ท็อปและระบบแม่ข่าย<br/"
+">โดยเหมาะสำหรับทั้งการติดตั้งใหม่หรือสำหรับการอัพเกรด"
+
+#, fuzzy
+msgid "Countdown"
+msgstr "นับจำนวน"
+
+#, fuzzy
+msgid "Country"
+msgstr "ประเทศ"
+
+msgid "Development"
+msgstr "การพัฒนา"
+
+msgid "Development Version"
+msgstr "รุ่นที่กำลังพัฒนา"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "รุ่นที่กำลังพัฒนา"
+
+#, fuzzy
+msgid "Development-"
+msgstr "การพัฒนา"
+
+#, fuzzy
+msgid "Direct Install"
+msgstr "การติดตั้งไว้ในไดเรกทอรี"
+
+msgid "Direct Link"
+msgstr "ดาวน์โหลดโดยตรง"
+
+#, fuzzy
+msgid "Documentation"
+msgstr "ส่วนต่อขยายเชื่อมแล็ปท็อป"
+
+#, fuzzy
+msgid "Don't show this warning the next time"
+msgstr "ไม่ต้องแสดงข้อความนี้อีก"
+
+msgid "Download"
+msgstr "ดาวน์โหลด"
+
+msgid "Download %s"
+msgstr "ดาวน์โหลด %s"
+
+msgid "Download Help"
+msgstr "ดาวน์โหลดความช่วยเหลือ"
+
+msgid "Download Method"
+msgstr "วิธีการดาวน์โหลด"
+
+#, fuzzy
+msgid "Download appliance from %s"
+msgstr ""
+"การดาวน์โหลดล้มเหลว:\n"
+"    %1"
+
+msgid "Download&nbsp;DVD"
+msgstr "ดาวน์โหลด&nbsp;แผ่นดีวีดี"
+
+msgid "Download&nbsp;GNOME"
+msgstr "ดาวน์โหลด&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "ดาวน์โหลด&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "ดาวน์โหลด&nbsp;เครือข่าย"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "ดาวน์โหลด&nbsp;KDE"
+
+msgid "Downloads"
+msgstr "ดาวน์โหลด"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"ดาวน์โหลดระบบติดตั้งและแพกเกจทั้งหมดจากคลังแพกเกจออนไลน์<br/"
+">เหมาะสำหรับทั้งใช้ในการติดตั้งและอัพเกรดระบบ"
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "ภาษาพิเศษ"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "ภาษาพิเศษ (32 บิท)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "ภาษาพิเศษ (64 บิท)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"เสนอวิธีการที่มีความปลอดภัยสูงสุดที่คุณสามารถนำมาใช้ตรวจสอบได้ว่า ผู้ใดเป็นผู้ลงลายเซ็นกำกับมัน "
+"โดยมันควรจะเป็น <tt>%s</tt>"
+
+msgid "Games"
+msgstr "เกมส์"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "เลือกใช้ดิสทริบิวชันพิเศษที่ถูกสร้างโดยอิงพื้นฐานมาจาก openSUSE"
+
+msgid "Getting Help"
+msgstr "ขอรับความช่วยเหลือ"
+
+msgid "Gold Sponsor"
+msgstr "ผู้สนับสนุนระดับเหรียญทอง"
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr "โลโก้ส่วนหัว"
+
+msgid "Help on Download Method"
+msgstr "ช่วยเหลือเกี่ยวกับวิธีการดาวน์โหลด"
+
+msgid "Help on Type of Computer"
+msgstr "ช่วยเหลือเกี่ยวกับชนิดของคอมพิวเตอร์"
+
+msgid "How to Proceed"
+msgstr "จะดำเนินการอย่างไร"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"หากคุณต้องการจะใช้การดาวน์โหลดโดยตรง "
+"แต่พักอาศัยอยู่ในพื้นที่ที่ตัวเปลี่ยนเส้นทางการดาวน์โหลดมีข้อมูลไม่เพียงพอในการเปลี่ยนเส้นทางการดาวน์โหลดไปยังแม่ข่ายสำรองที่มีความเร็วสูงสุดได้ "
+"คุณก็ควรจะทำการเลือกแม่ข่ายสำรองด้วยตัวเอง"
+
+#, fuzzy
+msgid "Image:"
+msgstr "แฟ้มอิมเมจ"
+
+#, fuzzy
+msgid "Install package %s / %s"
+msgstr "ติดตั้งแพกเกจ"
+
+#, fuzzy
+msgid "Install pattern %s / %s"
+msgstr "กำลังติดตั้งตามรูปแบบ..."
+
+msgid "Install using One Click Install"
+msgstr ""
+
+msgid "Installation Guides"
+msgstr "คู่มือแนะนำการติดตั้ง"
+
+msgid "Installation Medium"
+msgstr "สื่อสำหรับติดตั้ง"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"โปรแกรม Konqueror ของ KDE 3 นั้น ไม่มีการดูแลอีกต่อไปแล้ว "
+"และส่วนจัดการจาวาสคริปต์ของมันก็ยังมีบั๊กอยู่ ซึ่งอาจทำให้ไม่สามารถใช้งานได้กับหน้าเว็บเพจนี้ได้ "
+"ดังนั้น โปรดตรวจสอบให้แน่ใจก่อนว่า คุณได้ทำการปิดส่วนรองรับการทำงานจาวาสคริปต์ของมันแล้ว "
+"ก่อนที่คุณจะ<a href='%s'>ทำต่อไป</a>"
+
+msgid "Language"
+msgstr "ภาษา"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "พีซี 32 บิท"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "&nbsp;พีซี 32&nbsp;บิท"
+
+msgid "Live GNOME"
+msgstr "แผ่นซีดีระบบ GNOME ในรูปแบบ Live"
+
+msgid "Live KDE"
+msgstr "แผ่นซีดีระบบ KDE ในรูปแบบ Live"
+
+#, fuzzy
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"โปรแกรมต่าง ๆ จำนวนมาก "
+"สามารถตรวจสอบความถูกต้องของผลรวมการตรวจสอบของการดาวน์โหลดได้ "
+"การตรวจความถูกต้องของการดาวน์โหลดของคุณนั้นนับว่ามีความสำคัญเป็นอย่างมาก "
+"ทั้งนี้เพื่อให้มั่นใจได้ว่า คุณได้ทำการดาวน์โหลดแฟ้ม ISO ที่ถูกต้องตามที่คุณต้องการแล้วจริง ๆ "
+"และไม่มีอะไรผิดพลาดในการดาวน์โหลดมัน "
+"เราขอเสนอแนะกระบวนการตรวจผลรวมการตรวจสอบที่แตกต่างกันสามวิธีคือ:"
+
+msgid "Metalink"
+msgstr "เมตาลิงก์"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"ข้อมูลรายละเอียดเพิ่มเติมสำหรับการดาวน์โหลด openSUSE นั้น สามารถดูเพิ่มเติมได้ที่ <a href="
+"\"http://en.opensuse.org/Download_Help\">ช่วยเหลือการดาวน์โหลด</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"เครื่องคอมพิวเตอร์สมัยใหม่ในปัจจุบันโดยทั่วไปนั้น มักจะรองรับสถาปัตยกรรมแบบ <a href=\"http://"
+"en.wikipedia.org/wiki/X86-64\">x86-64</a> (บางคนรู้จักหรือเรียกกันในชื่อ AMD64 และ "
+"Intel64) แต่ก็ยังมีตัวประมวลผลของเครื่องแล็บท็อปและเน็ตบุ้กบางแบบที่ไม่รองรับมัน "
+"ดังนั้นคุณควรจะทำการตรวจสอบจาก วิกิพีเดีย ก่อน เพื่อให้แน่ใจว่า "
+"คอมพิวเตอร์ของคุณนั้นรองรับสถาปัตยกรรมดังกล่าวนี้หรือไม่"
+
+msgid "Multimedia"
+msgstr "สื่อประสม"
+
+msgid "Need help?"
+msgstr "ต้องการความช่วยเหลือ ?"
+
+msgid "Network"
+msgstr "ระบบเครือข่าย"
+
+msgid "No appliance data for %s"
+msgstr ""
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+msgid "No data for %s / %s"
+msgstr ""
+
+#, fuzzy
+msgid "No description found..."
+msgstr "ไม่พบข้อผิดพลาด..."
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+msgid "No packages found matching your search. "
+msgstr ""
+
+msgid "NonOSS CD"
+msgstr "แผ่นซีดี NonOSS"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "ไม่มีแพกเกจอยู่ %1 แพกเกจ"
+
+msgid "Official Manuals"
+msgstr "คู่มือการใช้งานอย่างเป็นทางการ"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+#, fuzzy
+msgid "Package %s not found..."
+msgstr "ไม่พบแพกเกจ"
+
+msgid "Package Repositories"
+msgstr "คลังแพกเกจต่างๆ"
+
+msgid "Package Search"
+msgstr "การค้นหาแพกเกจ"
+
+#, fuzzy
+msgid "Packages for %s:"
+msgstr "แพกเกจที่จะเรียกคืนข้อมูล"
+
+msgid "Pick Mirror"
+msgstr "เลือกแม่ข่ายสำรอง"
+
+msgid "Platinum Sponsor"
+msgstr "ผู้สนับสนุนระดับเหรียญแพลททินัม"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+#, fuzzy
+msgid "Related categories:"
+msgstr "เป็น_หมวดหมู่"
+
+msgid "Released Version"
+msgstr "รุ่นที่ออกเผยแพร่แล้ว"
+
+msgid "Reporting Bugs"
+msgstr "แจ้งรายงานข้อผิดพลาดต่างๆ"
+
+msgid "Rescue"
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"เดสก์ท็อประบบ KDE ที่คุณสามารถเรียกใช้งานได้โดยตรงผ่านทางซีดีหรือจากไดรฟ์ยูเอสบี<br/"
+">นอกจากนี้ยังสามารถนำไปใช้ทำการติดตั้งได้อีกด้วย (แต่ไม่สามารถใช้อัพเกรดได้)"
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "ผลรวมตรวจสอบแบบ md5"
+
+msgid "Search"
+msgstr "ค้นหา"
+
+#, fuzzy
+msgid "Select Your Operating System"
+msgstr "เลือกระบบพื้นที่ทำงานปริยายของคุณ"
+
+#, fuzzy
+msgid "Select the image type"
+msgstr "เลือกชนิดของสื่อ"
+
+#, fuzzy
+msgid "Show"
+msgstr "แสดงปูมบันทึก"
+
+msgid "Show development, language and debug packages"
+msgstr ""
+
+#, fuzzy
+msgid "Show distribution:"
+msgstr "ผู้รวบรวมเผยแพร่:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+#, fuzzy
+msgid "Show more..."
+msgstr "เพิ่มเติม..."
+
+msgid "Show other versions"
+msgstr ""
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "แพกเกจที่แนะนำ"
+
+#, fuzzy
+msgid "Show unsupported packages"
+msgstr "แพกเกจที่แนะนำ"
+
+msgid "Silver Sponsor"
+msgstr "ผู้สนับสนุนระดับเหรียญเงิน"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"มีดิสทริบิวชันแบบ Live บางดิสทริบิวชันที่มีพื้นฐานการพัฒนามาจาก openSUSE "
+"โดยดิสทริบิวชันเหล่านั้นมีความสนใจในการพัฒนางานของพวกเขาขึ้นมาจากงานเดิมที่มีอยู่ก่อนแล้ว "
+"ซึ่งสามารถดูได้ที่ <a href=\"http://susestudio.com/\">SUSE Studio</a>"
+
+msgid "Source"
+msgstr "ต้นฉบับ"
+
+msgid "Sponsored by"
+msgstr "สนับสนุนโดย"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "สนับสนุนโดย AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "สนับสนุนโดย: B1 Systems"
+
+#, fuzzy
+msgid "Sponsored by: Heinlein"
+msgstr "สนับสนุนโดย"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "สนับสนุนโดย: IP Exchange"
+
+#, fuzzy
+msgid "Sub-Packages"
+msgstr "แพกเกจย่อยที่ถูกเพิ่ม:"
+
+msgid "Support"
+msgstr "การสนับสนุน"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"แผ่นซีดีนี้บรรจุซอฟต์แวร์ที่เป็นประเภทฟรีซอฟต์แวร์ โดยถูกแจกจ่ายภายใต้สัญญาอนุญาตที่เป็นแบบมีเจ้าของ "
+"และไม่อนุญาตให้ซอฟต์แวร์เหล่านี้ถูกรวมอยู่ร่วมกับซอฟต์แวร์เสรีที่เป็นแบบเปิดรหัสต้นฉบับซึ่งอยู่ในสื่อหลักสำหรับใช้ในการติดตั้ง "
+"นอกจากนี้ ยังสามารถดาวน์โหลดซอฟต์แวร์ทั้งหมดที่อยู่ในแผ่นซีดีนี้ ผ่านทางคลังแพกเกจ Non-OSS "
+"ก็ได้เช่นกัน"
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"รุ่นนี้สามารถทำงานได้กับเครื่องพีซีทั้งหมด รวมถึงเครื่องที่รองรับระบบ 64 บิทด้วย "
+"หากคุณมีหน่วยความจำมากกว่า 3 กิกะไบต์ คุณควรจะเลือกรุ่นที่เป็น 64 บิทแทน openSUSE "
+"ไม่รองรับตัวประมวลผลที่เก่ากว่าเพนเทียม - และแผ่นซีดีแบบ Live นั้นรองรับสถาปัตยกรรม i686 "
+"เท่านั้น (เพนเทียมโปร และรุ่นหลังมัน)"
+
+msgid "Type of Computer"
+msgstr "ชนิดของคอมพิวเตอร์"
+
+#, fuzzy
+msgid "Unsupported distributions:"
+msgstr "ผู้รวบรวมเผยแพร่:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"ขอแนะนำให้ใช้<a href=\"http://en.opensuse.org/index.php?title=SDB:"
+"BitTorrent_and_openSUSE\">บิททอร์เรนท์</a>หากมีการเชื่อมต่อที่มีความเร็วต่ำ "
+"โดยเฉพาะอย่างยิ่ง เมื่อทำการดาวน์โหลดแฟ้มอิมเมจของแผ่นดีวีดี "
+"การดาวน์โหลดผ่านทางบิททอเรนท์นั้นมีประโยชน์อยู่หลายอย่าง "
+"ทั้งการที่ไคลเอนท์สามารถปกป้องความเสียหายของข้อมูล "
+"และยังช่วยให้คุณได้กระจายการดาวน์โหลดจากเครื่องแม่ข่ายไปยังเครื่องไคลเอนท์เครื่องอื่น ๆ ด้วย - "
+"หากมีผู้ร่วมดาวน์โหลดที่มากเพียงพอ จะยิ่งช่วยให้การดาวน์โหลดของทุกคน "
+"เป็นไปอย่างรวดเร็วมากกว่าการดาวน์โหลดโดยตรงจากเครื่องแม่ข่ายอีกด้วย นอกจากนี้ "
+"มันยังอนุญาตให้คุณหยุดทำการดาวน์โหลดได้ทุกเวลาที่ต้องการ และกลับมาดาวน์โหลดต่อได้ในภายหลัง"
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "ตรวจความถูกต้องของการดาวน์โหลดของคุณ (เป็นตัวเลือก สำหรับผู้ใช้ที่ชำนาญ)"
+
+msgid "Version"
+msgstr "รุ่น"
+
+msgid "We offer three different checksums:"
+msgstr ""
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"เมื่อทำการดาวน์โหลดแฟ้มอิมเมจอื่น ๆ นอกเหนือจากแผ่นซีดีสำหรับการติดตั้งผ่านเครือข่าย  "
+"ขอแนะนำ<i>อย่างยิ่ง</i>ว่า "
+"ให้ทำการดาวน์โหลดโดยใช้ตัวจัดการการดาวน์โหลดช่วยในการดาวน์โหลด "
+"เพื่อลดความเสี่ยงที่จะมีข้อมูลเสียหายได้"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+
+msgid "gpg signature"
+msgstr "ลายเซ็น gpg"
+
+#, fuzzy
+msgid "http://doc.opensuse.org/"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"เป็นผลรวมการตรวจสอบที่นิยมใช้กันมากที่สุด โดยโปรแกรมเขียนแผ่นจากอิมเมจ ISO "
+"มักจะแสดงผลรวมนี้ให้เห็นก่อนจะทำการเขียนแผ่น"
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "เป็นที่รู้จักกันน้อย แต่มีความปลอดภัยสูงกว่าแบบ md5"
+
+msgid "md5 checksum"
+msgstr "ผลรวมตรวจสอบแบบ md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"เสนอวิธีการที่มีความปลอดภัยสูงสุดที่คุณสามารถนำมาใช้ตรวจสอบได้ว่า ผู้ใดเป็นผู้ลงลายเซ็นกำกับมัน "
+"โดยมันควรจะเป็น <tt>%s</tt>"
+
+#, fuzzy
+msgid "openSUSE Countdown"
+msgstr "นับถอยหลังสู่ openSUSE 11.3"
+
+msgid "openSUSE Derivatives"
+msgstr "งานที่มีพื้นฐานจาก openSUSE"
+
+#, fuzzy
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE มีให้เลือกใช้ทั้งผ่านทางโพรโทคอล (ดาวน์โหลดโดยตรง) หรือผ่านทางบิททอเรนท์ "
+"ส่วนแผ่นซีดีสำหรับทำการติดตั้งผ่านเครือข่ายนั้น จะมีให้เลือกผ่านทางโพรโทคอล http เท่านั้น"
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE รองรับการใช้กับพีซีแบบ 32 บิท และ 64 บิทเท่านั้น"
+
+msgid "see Derivatives on wiki"
+msgstr "ดูผลงานที่ถูกพัฒนาต่อได้ที่วิกิ"
+
+msgid "sha1 checksum"
+msgstr "ผลรวมตรวจสอบแบบ sha1"
+
+msgid "switch to"
+msgstr "เปลี่ยนไปยัง"
+
+#, fuzzy
+#~ msgid "An internal error happened :-("
+#~ msgstr "เกิดข้อผิดพลาดภายในขึ้น"
+
+#, fuzzy
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "รายการค้นสามารถมีได้สูงสุด %1 ตัวอักษร"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~ msgid "Last searches:"
+#~ msgstr "หยุดบริการ"
+
+#, fuzzy
+#~ msgid "Statistics"
+#~ msgstr "สถานะ"
+
+#, fuzzy
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "ดาวน์โหลด"
+
+#, fuzzy
+#~ msgid "Top searches:"
+#~ msgstr "หยุดบริการ"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "แผ่นดีวีดี 4.7 กิกะไบต์"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "แผ่นซีดีแบบ Live จะบรรจุภาษาต่าง ๆ มาเพียงสี่ภาษาเท่านั้น (ภาษาอังกฤษ, เยอรมัน, รัสเซีย "
+#~ "และอิตาลี) หากคุณต้องการจะให้มีการรองรับภาษาอื่น ๆ ที่เหลือ "
+#~ "คุณจำเป็นจะต้องทำการดาวน์โหลดพวกมันจากอินเทอร์เน็ตในระหว่างทำการติดตั้งหรือในช่วงอื่นภายหลังก็ได้ "
+#~ "หากคุณสามารถเข้าใช้งานอินเทอร์เน็ตได้สะดวก หรือคุณมีแผ่นดีวีดีที่บรรจุภาษาต่าง ๆ ทั้งหมด "
+#~ "คุณก็ไม่จำเป็นต้องใช้แผ่นซีดีนี้"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "หลังจากทำการดาวน์โหลดแฟ้มอิมเมจแบบ ISO เสร็จสิ้นแล้ว "
+#~ "ในการเขียนมันลงแผ่นดีวีดีหรือแผ่นซีดีนั้น โปรด<em>อย่า</"
+#~ "em>เขียนมันในแบบข้อมูลของแผ่นดีวีดีข้อมูลหรือแผ่นซีดีข้อมูล "
+#~ "โปรดเลือกตัวเลือกสำหรับการเขียนแผ่นในรูปแบบ เขียนแผ่นจากแฟ้มอิมเมจ ISO"
+
+#, fuzzy
+#~| msgid "The search list can have at most %1 characters."
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "รายการค้นสามารถมีได้สูงสุด %1 ตัวอักษร"
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "ถึงข้อจำกัดของการค้นหาแล้ว โปรดปรับให้การค้นหาของคุณให้มีความถูกต้องมากขึ้น"
+
+#~ msgid "Could not perform search: "
+#~ msgstr "ไม่สามารถปฏิบัติการค้นหาต่อไปนี้ได้: "
+
+#~ msgid "Popular Software"
+#~ msgstr "ซอฟต์แวร์ที่ได้รับความนิยม"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "ซื้อ openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "ติดตั้งใน 1-คลิก"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "ดาวน์โหลดแพกเกจด้วยตนเอง"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "ไปยังโครงการ OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[ชุดซอฟต์แวร์]"
+
+#~ msgid "Search Results"
+#~ msgstr "ผลการค้นหา"
+
+#, fuzzy
+#~| msgid "No packages found that matched your query."
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "ไม่พบแพกเกจที่ตรงกับการค้นข้อมูลของคุณ"
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "ชุดซอฟต์แวร์ %d ชุด และไบนารี %d รายการ จากแหล่งแพกเกจ %d แหล่ง"
+
+#, fuzzy
+#~| msgid "Save screen shot to..."
+#~ msgid "Screenshot of  "
+#~ msgstr "บันทึกภาพหน้าจอที่จับได้ไปยัง..."
+
+#, fuzzy
+#~| msgid "Search Constraints"
+#~ msgid "Search Statistics:"
+#~ msgstr "ข้อจำกัดการค้นหา"
+
+#, fuzzy
+#~| msgid "Download Size:"
+#~ msgid "Download Statistics:"
+#~ msgstr "ขนาดเมื่อดาวน์โหลด:"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "ค้นหาและติดตั้งแพกเกจโปรแกรมต่าง ๆ จาก <a href=\"http://build.opensuse.org"
+#~ "\">บริการสร้างแพกเกจของ openSUSE</a>:"
+
+#~ msgid "Search options"
+#~ msgstr "ตัวเลือกการค้นหา"
+
+#, fuzzy
+#~| msgid "Exclude user's home projects"
+#~ msgid "Include users' home projects"
+#~ msgstr "ไม่รวมโครงการต่าง ๆ ในพื้นที่ส่วนตัวของผู้ใช้"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "ไม่รวมแพกเกจสำหรับการดีบั๊ก"
+
+#~ msgid "Additional Information"
+#~ msgstr "ข้อมูลรายละเอียดเพิ่มเติม"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "ซื้อ openSUSE 11.2"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2!"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "ซื้อ openSUSE 11.2!"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "ข้อมูลรายละเอียดเพิ่มเติมสำหรับการดาวน์โหลด openSUSE นั้น สามารถดูเพิ่มเติมได้ที่ <a href="
+#~ "\"http://en.opensuse.org/Download_Help\">ช่วยเหลือการดาวน์โหลด</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "มีคำแนะนำการใช้ดังต่อไปนี้:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "การติดตั้งจากแผ่นดีวีดี/แผ่นซีดี:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "คู่มือแนะนำการเริ่มต้นใช้งาน %s อย่างเป็นทางการ"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "คู่มือแนะนำการติดตั้งทีละขั้น"
+
+#~ msgid "Network Installation"
+#~ msgstr "การติดตั้งผ่านเครือข่าย"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Derivatives"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "การติดตั้งผ่านอินเทอร์เน็ต"
+
+#~ msgid "More information"
+#~ msgstr "ข้อมูลรายละเอียดเพิ่มเติม"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+#~ msgid "Get Software"
+#~ msgstr "เลือกซอฟต์แวร์"
+
+#, fuzzy
+#~ msgid "User Directory"
+#~ msgstr "ไดเรกทอรี"
+
+#, fuzzy
+#~ msgid "Features"
+#~ msgstr "คุณลักษณะของบริการ"
+
+#~ msgid "Software"
+#~ msgstr "ซอฟต์แวร์"
+
+#, fuzzy
+#~ msgid "Software Search"
+#~ msgstr "การเลือกซอฟต์แวร์"
+
+#, fuzzy
+#~ msgid "Update Repositories"
+#~ msgstr "บันทึกคลังแพกเกจ"
+
+#, fuzzy
+#~ msgid "Source Repository"
+#~ msgstr "คลังแพกเกจ"
+
+#~ msgid "Other Options"
+#~ msgstr "ตัวเลือกอื่น ๆ"
+
+#, fuzzy
+#~ msgid "Mirrors"
+#~ msgstr "ข้อผิดพลาด"
+
+#, fuzzy
+#~ msgid "In other languages"
+#~ msgstr "เป็นก_ลุ่มภาษา"
+
+#, fuzzy
+#~ msgid "Search Build Service"
+#~ msgstr "บริการสร้างแพกเกจ"
+
+#, fuzzy
+#~ msgid "Get openSUSE"
+#~ msgstr "openSUSE.org"
+
+#~ msgid "Nothing found"
+#~ msgstr "ไม่พบอะไรเลย"
+
+#, fuzzy
+#~ msgid "Searching"
+#~ msgstr "ค้นหาใน"
+
+#, fuzzy
+#~ msgid "Metalinks"
+#~ msgstr "ภาษาอิตาลี"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "openSUSE.org"
+
+#, fuzzy
+#~ msgid "Expert view"
+#~ msgstr "ผู้เชี่ยวชาญ"
+
+#~ msgid "Help"
+#~ msgstr "ช่วยเหลือ"
+
+#, fuzzy
+#~ msgid "Choose an Installation Medium"
+#~ msgstr "คัดลอกสื่อสำหรับติดตั้ง"
+
+#, fuzzy
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "ระบบพื้นที่ทำงาน GNOME"
+
+#, fuzzy
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "ระบบพื้นที่ทำงาน KDE"

--- a/locale/uk/software.po
+++ b/locale/uk/software.po
@@ -1,0 +1,1166 @@
+# Translation of software-opensuse-org.uk.po to Ukrainian
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# Ivan Petrouchtchak <fr.ivan@ukrainian-orthodox.org>, 2009.
+# Andriy Bandura <andriykopanytsia@gmail.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org.uk\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-04 07:44+0200\n"
+"Last-Translator: Andriy Bandura <andriykopanytsia@gmail.com>\n"
+"Language-Team: Ukrainian <www-uk-translations@gnu.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms:  nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgid " and "
+msgstr " і "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} не підтримується.\""
+
+msgid "(hide)"
+msgstr "(приховати)"
+
+msgid "(show)"
+msgstr "(показати)"
+
+msgid "... and keep us informed"
+msgstr "... і повідомляти в подальшому"
+
+msgid "... get other marketing stuff"
+msgstr "... отримувати маркетингову інформацію"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7 ГБ DVD (також підходить для USB-носія)"
+
+msgid "64 Bit PC"
+msgstr "64-бітовий ПК"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">Посібник "
+"openSUSE для початківців</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> — це відкритий "
+"стандарт, який пов'язує різні способи (FTP/HTTP/BitTorrent), щоб покласти "
+"файли в один формат для полегшення завантаження. Добре підходить для "
+"звантаження ISO-штампів; особливо для людей, які не можуть користуватись P2P "
+"через обмеження їхніх постачальників Інтернету. Цей спосіб надає дуже високу "
+"швидкість завантаження, позаяк більшість клієнтів автоматично підтримують "
+"мульти-з'єднання до різних дзеркал. Крім того, він може автоматично виявляти "
+"і виправляти помилки, але для цього потрібно мати спеціальний клієнт."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Ліцензія</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Примітки до випуску</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>офіційний випуск</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>офіційне оновлення</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"Стільниця GNOME, яку можна запустити з %s або USB-носія. <br/>Також її можна "
+"встановити (але не можна нею оновити)."
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"Стільниця KDE, яку можна запустити з %s або USB-носія. <br/>Також її можна "
+"встановити (але не можна нею оновити)."
+
+msgid "Add repository and install manually"
+msgstr "Додати сховище і встановити вручну"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Додаткові звантаження (необов'язкові)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"Після успішного завантаження ISO-штампу можна створити завантажувальний USB-"
+"носій або записати штамп(и) на DVD (або навіть на КД, якщо образ "
+"відповідного розміру)."
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"Усі дані використовуються для відправлення рекламних матеріалів openSUSE\n"
+"і не передаються третім особам. Ми зберігаємо дані для повідомлення\n"
+"користувачів про вихід нової версії. Всі запити вивчаються на\n"
+"предмет відповідності експортного ембарго США. Більше відомостей про\n"
+"ембарго і список країн можна знайти у вікіпедії <a href='http://en.wikipedia."
+"org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+
+msgid "App Browser"
+msgstr "Навігатор програм"
+
+msgid "Available Images"
+msgstr "Доступні штампи"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Завантажте комп'ютер з DVD, КД або USB. Якщо ваш комп'ютер автоматично не "
+"завантажується з вибраного пристрою, відкрийте налаштування BIOS, щоб "
+"дозволити завантаження з нього."
+
+msgid "Bronze Sponsor"
+msgstr "Бронзовий спонсор"
+
+msgid "Browser incompatibility"
+msgstr "Несумісність з навігатором"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Записати штамп(и) КД/DVD"
+
+msgid "Categories"
+msgstr "Категорії"
+
+msgid "Category"
+msgstr "Категорія"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Виберіть носій звантаження (клацнувши на нього) і натисніть кнопку "
+"Звантажити, щоб розпочати звантаження. На додачу, можете також вибрати тип "
+"вашого комп'ютера або альтернативний спосіб звантаження."
+
+msgid "Click here to display these alternative versions."
+msgstr "Клацніть тут, щоб побачити альтернативні версії."
+
+msgid "Click to Download"
+msgstr "Натисніть для завантаження"
+
+msgid "Community"
+msgstr "Спільнота"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"Містить велику збірку програмного забезпечення для використання на сервері "
+"або на стільничній системі. <br/>Підходить для встановлення або оновлення "
+"системи."
+
+msgid "Countdown"
+msgstr "Зворотний відлік"
+
+msgid "Country"
+msgstr "Країна"
+
+msgid "Development"
+msgstr "Розробка"
+
+msgid "Development Version"
+msgstr "Версія в розробці"
+
+msgid "Development packages"
+msgstr "Пакунки для розробки"
+
+msgid "Development-"
+msgstr "Розробка-"
+
+msgid "Direct Install"
+msgstr "Пряме встановлення"
+
+msgid "Direct Link"
+msgstr "Пряме посилання"
+
+msgid "Documentation"
+msgstr "Документація"
+
+msgid "Don't show this warning the next time"
+msgstr "Більше не показувати це попередження"
+
+msgid "Download"
+msgstr "Звантажити"
+
+msgid "Download %s"
+msgstr "Звантажити %s"
+
+msgid "Download Help"
+msgstr "Звантажити довідку"
+
+msgid "Download Method"
+msgstr "Спосіб звантаження"
+
+msgid "Download appliance from %s"
+msgstr "Завантажити із %s"
+
+msgid "Download&nbsp;DVD"
+msgstr "Звантажити&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Звантажити&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Звантажити &nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Звантажити&nbsp;Мережний"
+
+msgid "Download&nbsp;Rescue"
+msgstr "Завантажити &nbsp;диск відновлення"
+
+msgid "Downloads"
+msgstr "Завантаження"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Завантажує систему встановлення і всі пакунки з мережних сховищ.<br/> "
+"Підходить для встановлення чи оновлення."
+
+msgid "Expand all sections ('e')"
+msgstr "Розгорнути усі розділи ('e')"
+
+msgid "Extra Languages"
+msgstr "Додаткові мови"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Додаткові мови (32 біти)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Додаткові мови (64 біти)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "Для <strong>%s</strong> запустіть від імені <strong>root</strong>:"
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "Для <strong>%s</strong> запустіть:"
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"Для <strong>Arch Linux</strong> відредагуйте /etc/pacman.conf і додайте "
+"наступне (зверніть увагу, що в pacman.conf важливий порядок сховищ, оскільки "
+"pacman завжди завантажує перший знайдений пакет):"
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+"Для кожного ISO ми пропонуємо контрольну суму файлу з відповідною сумою "
+"SHA256."
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"Для додаткової безпеки ви можете вживати GPG, щоб перевірити, ким підписано "
+"файли  .sha256. Має бути %s."
+
+msgid "Games"
+msgstr "Ігри"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Завантажте один із спеціалізованих дистрибутивів на основі openSUSE."
+
+msgid "Getting Help"
+msgstr "Отримання допомоги"
+
+msgid "Gold Sponsor"
+msgstr "Золотий спонсор"
+
+msgid "Grab binary packages directly"
+msgstr "Отримати безпосередньо двійкові пакунки"
+
+msgid "Header Logo"
+msgstr "Логотип"
+
+msgid "Help on Download Method"
+msgstr "Довідка щодо способів звантаження"
+
+msgid "Help on Type of Computer"
+msgstr "Довідка щодо типу комп'ютера"
+
+msgid "How to Proceed"
+msgstr "Як продовжити"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Якщо ви хочете використовувати безпосереднє посилання, але живете у тій "
+"частині світу, де система перенаправлення звантаження не має достатньо "
+"інформації для перенаправлення до найшвидшого дзеркала, то можете вибрати "
+"дзеркало самі."
+
+msgid "Image:"
+msgstr "Штамп:"
+
+msgid "Install package %s / %s"
+msgstr "Встановити пакунок %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "Встановити шаблон %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "Встановити за  1 клацання"
+
+msgid "Installation Guides"
+msgstr "Інструкції із встановлення"
+
+msgid "Installation Medium"
+msgstr "Носій встановлення"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"Приєднуйтесь до швидко зростаючої спільноти і отримайте\n"
+"нові PromoDVD для openSUSE, щоб поширювати їх у групах,\n"
+"некомерційних організаціях, школах і університетах, а також\n"
+"зустрічах LUG, фестивалях інсталяцій і конференціях.\n"
+"Promo DVD збільшують обізнаність людей про openSUSE!"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"На жаль, javascript на Konqueror в KDE 3 містить вади, які роблять його "
+"непридатним для навігації цієї сторінки. Переконайтесь, що у вас вимкнено "
+"javascript перед тим як натиснути на <a href='%s'>продовжити</a>."
+
+# label for language selection
+msgid "Language"
+msgstr "Мова"
+
+msgid "Legacy 32 Bit PC"
+msgstr "Застарілий 32-бітовий ПК"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "Застарілий 32-бітовий ПК"
+
+msgid "Live GNOME"
+msgstr "„Живий“ GNOME"
+
+msgid "Live KDE"
+msgstr "„Живий“ KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Багато програм можуть мають змогу перевіряти контрольну суму звантаженого. "
+"Важливо перевірити звантажене вами, щоб файл ISO не виявився якоюсь "
+"пошкодженою версією."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "Більше інформації про запис файлу ISO на CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Більше відомостей про створення <a href='http://en.opensuse.org/"
+"Live_USB_stick'>завантажувального USB-носія</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Більше відомостей про завантаження openSUSE доступно на сторінках <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Допомога по завантаженню</a>, "
+"<a href=\"http://en.opensuse.org/SDB:Network_installation\">Установка через "
+"Інтернет</a> в нашій <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">вікі</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Більшість нових комп'ютерів підтримує <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (також відомі як AMD64 та Intel64), але деякі процесори "
+"на лептопах і нетбуках її не підтримують. Перевірте на вікіпідії чи ваш "
+"комп'ютер її пітримує."
+
+msgid "Multimedia"
+msgstr "Мультимедія"
+
+msgid "Need help?"
+msgstr "Потрібна допомога?"
+
+msgid "Network"
+msgstr "Мережа"
+
+msgid "No appliance data for %s"
+msgstr "Немає даних для %s"
+
+msgid "No appliances found in project %s"
+msgstr "У проекті %s образи не знайдені"
+
+msgid "No data for %s / %s"
+msgstr "Немає даних %s / %s"
+
+msgid "No description found..."
+msgstr "Опис не знайдено..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "Завантаження для %s у проекті %s не знайдено"
+
+msgid "No packages found matching your search. "
+msgstr "За вашим запитом пакетів не знайдено."
+
+msgid "NonOSS CD"
+msgstr "Не-OSS КД"
+
+msgid "OBS Backend not available"
+msgstr "Сервер OBS недоступний"
+
+msgid "Official Manuals"
+msgstr "Офіційні підручники"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"Лише DVD та мережеві носії повністю протестовані. Альтернативи, на кшталт "
+"живих дисків або систем відновлення, рекомендовані виключно для обмеженого "
+"використання."
+
+msgid "Package %s not found..."
+msgstr "Пакунок %s не знайдено…"
+
+msgid "Package Repositories"
+msgstr "Сховища з пакунками"
+
+msgid "Package Search"
+msgstr "Пошук пакунків"
+
+msgid "Packages for %s:"
+msgstr "Пакунки для %s:"
+
+msgid "Pick Mirror"
+msgstr "Виберіть дзеркало"
+
+msgid "Platinum Sponsor"
+msgstr "Платиновий спонсор"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"Будь ласка, зверніть увагу, що це пакети з неофіційних сховищ.\n"
+"Це означає, що вони не перевіряються командою openSUSE і можуть містити "
+"нестабільне або експериментальне програмне забезпечення."
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"Будь ласка, вкажіть <b>коротку</b> причину (англійською!), через яку вам "
+"потрібні DVD і надайте посилання на подію."
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"Зверніть увагу, що це не найновіший випуск openSUSE. Ви можете отримати "
+"новітню версію <a href='/'>тут</a>."
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"Promo DVD і все необхідне графічне оформлення - ярлики і упаковку - можна\n"
+"завантажити з <a href=\"http://download.opensuse.org/promodvd/\">каталогу "
+"promodvd %s</a>.\n"
+"Врахуйте, що це особлива версія openSUSE,\n"
+"спеціально призначена для рекламних цілей."
+
+msgid "Related categories:"
+msgstr "Пов'язані категорії:"
+
+msgid "Released Version"
+msgstr "Випущена версія"
+
+msgid "Reporting Bugs"
+msgstr "Повідомлення про хиби"
+
+msgid "Rescue"
+msgstr "Відновлення"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"Система відновлення, яку можна запустити з КД або USB-носія. <br/>Але її не "
+"можна встановити чи оновити."
+
+msgid "SHA256 checksum"
+msgstr "контрольна сума SHA256"
+
+msgid "Search"
+msgstr "Пошук"
+
+msgid "Select Your Operating System"
+msgstr "Виберіть вашу операційну систему"
+
+msgid "Select the image type"
+msgstr "Виберіть тип штампа"
+
+msgid "Show"
+msgstr "Показати"
+
+msgid "Show development, language and debug packages"
+msgstr "Показувати пакунки для розробників, налагоджувальні і мовні пакунки"
+
+msgid "Show distribution:"
+msgstr "Показати дистрибутив:"
+
+msgid "Show more packages for unsupported distributions"
+msgstr "Показати більше пакунків для непідтримуваних дистрибутивів"
+
+msgid "Show more..."
+msgstr "Показати більше..."
+
+msgid "Show other versions"
+msgstr "Показати інші версії"
+
+msgid "Show unstable packages"
+msgstr "Показати нестабільні пакунки"
+
+msgid "Show unsupported packages"
+msgstr "Показати непідтримувані пакунки"
+
+msgid "Silver Sponsor"
+msgstr "Срібний спонсор"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"Деякі альтернативні носії (наприклад, живі диски або системи відновлення) "
+"також доступні, хоча вони менше тестувалися, а тому рекомендовані  тільки "
+"для обмеженого використання."
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Дистрибутиви на основі openSUSE. Бажаючі спробувати зібрати власний "
+"дистрибутив можуть поглянути на <a href=\"http://susestudio.com/\">SUSE "
+"Studio</a>."
+
+msgid "Source"
+msgstr "Джерело"
+
+msgid "Sponsored by"
+msgstr "Спонсори"
+
+msgid "Sponsored by: AMD"
+msgstr "За підтримки AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "За підтримки B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "За підтримки Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "За підтримки IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "Підпакунки(ів)"
+
+msgid "Support"
+msgstr "Підтримка"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"Процес установки перекладений на безліч мов, але для більшості з них "
+"переклади програм у штамп не входять. Якщо ви хочете, щоб ваша система "
+"openSUSE підтримувала ще якусь мову, то доведеться завантажити її з "
+"інтернету під час або після установки. Якщо у вас хороший доступ до "
+"інтернету, то цей CD вам не потрібен, але якщо ви плануєте встановити "
+"openSUSE на машину без доступу до інтернету, то всі наявні переклади "
+"доступні на цьому диску."
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "Потім запустіть від імені <strong>root</strong>"
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"Наразі жодний випуск openSUSE не проходить тестування. <br/> Якщо ви хочете "
+"використовувати новітнє ПЗ, то скористайтесь <a href='http://en.opensuse.org/"
+"Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"Цей диск містить безкоштовне ПЗ, яке розповсюджується під власницькими "
+"ліцензіями, що не дозволяють включати його на головний інсталяційний носій "
+"разом з вільним ПЗ з відкритим вихідним кодом. Усе з цього диску можна "
+"завантажити із сховища NON-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Ця версія підходить для всіх ПК, включаючи ті, що підтримують 64 біти. Якщо "
+"у вас є більше 3 ГБ RAM, вам варто надати перевагу 64-бітовій версії. "
+"openSUSE не підтримує процесори старіші за Pentium, а «живі» компакт диски "
+"підтримують тільки i686 (Pentium Pro і новіші)."
+
+msgid "Type of Computer"
+msgstr "Тип комп'ютера"
+
+msgid "Unsupported distributions:"
+msgstr "Непідтримувані дистрибутиви:"
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Посібники користувача доступні на <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, наприклад <a href=\"http://activedoc.opensuse."
+"org/book/opensuse-start-up/\">Посібникдля початківців</a>."
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Не повільних з'єднаннях рекомендовано використовувати BitTorrent, особливо "
+"для завантаження штампа DVD. Завантаження через BitTorrent має декілька "
+"вигод: клієнти запобігають пошкодженню даних і зменшують навантаження на "
+"сервери через участь в вивантаженні; якщо досить людей бере участь, то "
+"завантаження для всіх стає швидшим, ніж з централізованих серверів. Також ви "
+"можете у будь-який момент зупинити завантаження і продовжити його пізніше. "
+"Більше інформації можна знайти на <a href=\"http://en.opensuse.org/SDB:"
+"BitTorrent\">BitTorrent</a>"
+
+msgid "Verify your download before use"
+msgstr "Перевірити ваше звантаження перед використанням"
+
+msgid "Version"
+msgstr "Версія"
+
+msgid "We offer three different checksums:"
+msgstr "Ми пропонуємо три різні контрольні суми:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"Ми хотіли б знати більше про ваше використанні DVD, щоб допомогти\n"
+"вам просувати вашу організацію, подію або школу на нашій сторінці\n"
+"<a href='http://news.opensuse.org' title='news.opensuse.org'>новин</a> або "
+"інших ресурсах. (Доречі ми любимо світлини. Робіть їх тисячами!).\n"
+"Зв'яжіться з нами за адресою <a href='mailto:opensuse-marketing@opensuse."
+"org'>opensuse-marketing@opensuse.org</a>,\n"
+"щоб обговорити це і/або інші способи взаємодопомоги."
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Для звантаження штампів, за винятком КД для мережного встановлення, <i>дуже</"
+"i> рекомендовано використовувати належний менеджер встановлення, щоб "
+"зменшити ризик пошкодження даних."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"Ви можете додати ключ сховища в apt. Майте на увазі, що власник ключа може "
+"поширювати оновлення, пакунки і сховища, яким ваша система буде довіряти (<a "
+"href=\"%s\">подробиці</a>). Для додавання ключа запустіть:"
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"Ви можете розширити свій пошук на пакунки для розробників або шукати їх для "
+"іншого дистрибутива."
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Ви можете перевірити файл у процесі завантаження. Наприклад, контрольна сума "
+"SHA256 буде використана автоматично при виборі <a href='http://en.opensuse."
+"org/SDB:Metalink'>Metalink</a> у полі вище та використанні додатку "
+"DownThemAll! у <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "підпис gpg"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"ще й досі є найуживанішою контрольною сумою. Багато програм запису ISO-"
+"штампів показують її перед тим, як почати запис на носій."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "є менш відомою, але більше безпечною ніж md5."
+
+msgid "md5 checksum"
+msgstr "контрольна сума md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"надає найбільшу безпеку, оскільки ви можете перевірити, ким підписано. Має "
+"бути <tt>%s</tt>."
+
+msgid "openSUSE Countdown"
+msgstr "Зворотний відлік openSUSE"
+
+msgid "openSUSE Derivatives"
+msgstr "Похідні від openSUSE"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE доступна через http (пряме посилання) або через BitTorrent. КД для "
+"мережного встановлення доступне тільки через http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE підтримує тільки 32-бітові та 64-бітові ПК."
+
+msgid "see Derivatives on wiki"
+msgstr "Похідні дистрибутиви у вікі"
+
+msgid "sha1 checksum"
+msgstr "контрольна сума sha1"
+
+msgid "switch to"
+msgstr "перемкнути на"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "Сталася внутрішня помилка :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "Введіть не менше двох символів"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "Останні пошуки:"
+
+#~ msgid "Statistics"
+#~ msgstr "Статистика"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Найчастіші установки за 1 натиск:"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Найчастіше не знаходять:"
+
+#~ msgid "Top searches:"
+#~ msgstr "Найпопулярніші пошуки:"
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7ГБ DVD"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Після успішного звантаження штампів ISO, запишіть штампи за допомогою "
+#~ "відповідної програми на DVD або КД. Будь ласка, <em>не</em> не записуйте "
+#~ "їх як DVD/КД з даними, а виберіть параметр для запису ISO-штампа."
+
+#, fuzzy
+#~| msgid "Password is too short (must have at least 8 characters)."
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "Закороткий пароль (повинно бути не менше 8 символів)."
+
+#, fuzzy
+#~| msgid "Could not find %s"
+#~ msgid "Could not perform search: "
+#~ msgstr "Не вдалося знайти %s"
+
+#, fuzzy
+#~| msgid "Proprietary Software"
+#~ msgid "Popular Software"
+#~ msgstr "Закрите ПЗ"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Придбання openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "Встановити через 1-натиск"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Ручне звантаження пакунків"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Перейти до проекту ССП"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Збірка ПЗ]"
+
+#, fuzzy
+#~| msgid "Searching details"
+#~ msgid "Search Results"
+#~ msgstr "Пошук подробиць"
+
+#, fuzzy
+#~| msgid "No packages found."
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "Не знайдено пакунків."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "збірок: %d і двійкових: %d з пакунків джерел: %d"
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "Версія в розробці (CVS) Wine"
+
+#, fuzzy
+#~| msgid "Search Domains:"
+#~ msgid "Search Statistics:"
+#~ msgstr "Пошук доменів:"
+
+#, fuzzy
+#~| msgid "Download size"
+#~ msgid "Download Statistics:"
+#~ msgstr "Звантажений розмір"
+
+#, fuzzy
+#~| msgid ""
+#~| "Search for and install additional software packages from the openSUSE "
+#~| "Build Service."
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Пошук і встановлення додаткових пакунків програм зі Служби Складання "
+#~ "Пакунків openSUSE."
+
+#, fuzzy
+#~| msgid "vnc options"
+#~ msgid "Search options"
+#~ msgstr "параметри vnc"
+
+#, fuzzy
+#~| msgid "Downloaded packages"
+#~ msgid "Exclude debug packages"
+#~ msgstr "Завантажені пакунки"
+
+#~ msgid "Additional Information"
+#~ msgstr "Додаткові відомості"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Придбайте openSUSE 11.2"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2!"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Придбайте openSUSE 11.2!"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Додаткову інформацію про звантаженням openSUSE можна знайти на <a href="
+#~ "\"http://en.opensuse.org/Download_Help\">Довідка щодо звантаження.</a>"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Наявні наступні інструкції:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Встановлення з DVD/КД:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Офіційний короткий посібник %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Покроковий посібник встановлення"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "Мережне встановлення"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Встановлення через Інтернет"
+
+#~ msgid "More information"
+#~ msgstr "Більше інформації"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Звантажити програми"
+
+#~ msgid "Wiki"
+#~ msgstr "Вікі"
+
+#~ msgid "Build Software"
+#~ msgstr "Скласти програми"
+
+#~ msgid "User Directory"
+#~ msgstr "Каталог користувача"
+
+#~ msgid "Features"
+#~ msgstr "Функціональність"
+
+#~ msgid "News"
+#~ msgstr "Новини"
+
+#~ msgid "Forums"
+#~ msgstr "Форуми"
+
+#~ msgid "Shop"
+#~ msgstr "Магазин"
+
+#~ msgid "Software"
+#~ msgstr "Програми"
+
+#~ msgid "Software Search"
+#~ msgstr "Пошук програм"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Сховища з оновленнями"
+
+#~ msgid "Source Repository"
+#~ msgstr "Сховища з сирцями"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "Інші параметри"
+
+#~ msgid "Mirrors"
+#~ msgstr "Дзеркала"
+
+#, fuzzy
+#~ msgid "In other languages"
+#~ msgstr "Виберіть мову."
+
+#~ msgid "Get it"
+#~ msgstr "Звантажити"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Пошук в службі складання"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Пошук і встановлення додаткових пакунків програм зі Служби Складання "
+#~ "Пакунків openSUSE."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Звантажити openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Постійне посилання на цей результат"
+
+#~ msgid "Nothing found"
+#~ msgstr "Нічого не знайдено"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Взяти програми зі Служби Складання Пакунків openSUSE"
+
+#~ msgid "Searching"
+#~ msgstr "Пошук"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Містить велику збірку програмного забезпечення для використання на "
+#~ "сервері або на стільничній системі. Підходить для встановлення або "
+#~ "оновлення системи."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "Стільниця GNOME, яку можна запустити з КД або USB-бруска. Також, її можна "
+#~ "встановити (але не можна нею оновити)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "Стільниця KDE, яку можна запустити з КД або USB-бруска. Також, її можна "
+#~ "встановити (але не можна нею оновити)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Звантажує систему встановлення і всі пакунки з мережних сховищ. Підходить "
+#~ "для встановлення і оновлення."

--- a/locale/wa/software.po
+++ b/locale/wa/software.po
@@ -1,0 +1,1249 @@
+# Translation into the walloon language.
+# Copyright (C) 2007 SUSE Linux Products GmbH.
+#
+# Pablo Saratxaga <pablo@walon.org>, 2001, 2004.
+# Jean Cayron <jean.cayron@gmail.com>, 2007, 2009, 2010, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: yast memory\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2011-02-16 21:33+0100\n"
+"Last-Translator: Jean Cayron <jean.cayron@gmail.com>\n"
+"Language-Team: Walloon <linux-wa@walon.org>\n"
+"Language: wa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 1.2\n"
+
+msgid " and "
+msgstr ""
+
+msgid "\"#{release} is not a supported release.\""
+msgstr ""
+
+msgid "(hide)"
+msgstr ""
+
+msgid "(show)"
+msgstr ""
+
+msgid "... and keep us informed"
+msgstr ""
+
+msgid "... get other marketing stuff"
+msgstr ""
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr ""
+
+msgid "64 Bit PC"
+msgstr "PC 64 bites"
+
+#, fuzzy
+#| msgid ""
+#| "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#| "startup/\">openSUSE startup guide</a>"
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+"startup/\">Guide pos ataker avou openSUSE (en)</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://fr.opensuse.org/Metalink\">Metalink</a> est on drovou "
+"standård ki met eshonne les diferinnès façons (FTP/HTTP/BitTorrent) d' aler "
+"cweri des fitchîs dins ene cogne pos aberweter pus åjheymint. Ça fwait k' c' "
+"est bén pos aberweter des ISO; sor-tot po les djins ki n' si savèt nén "
+"siervi do P2P a cåze di rastrindaedjes di leu ISP ou Université. I sait fé "
+"aberweter mo rade ca li pupårt des cliyint sopoirtèt sacwants raloyaedjes a "
+"sacwants muroes, otomaticmint. Di pus, i sait otomaticmint trover les arokes "
+"eyet les coridjî. Mins nerén, il a dandjî d' on speciå cliyint po l' apougnî."
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">Licince</a>"
+
+#, fuzzy
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>Notes del modêye</a> (dierinnès informåcions)"
+
+#, fuzzy
+msgid "<b>official release</b>"
+msgstr "Oficirès esplikêyes"
+
+#, fuzzy
+msgid "<b>official update</b>"
+msgstr "Oficirès esplikêyes"
+
+#, fuzzy
+#| msgid ""
+#| "A GNOME desktop you can run from CD or from USB stick.<br/>Can be "
+#| "installed as is (no upgrade)."
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"On scribanne GNOME ki vs savoz enonder a pårti d' ene plake lazer ou d' ene "
+"clé USB.<br/>On l' sait astaler come il est sol media (pont d' metaedje a "
+"livea)."
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"On scribanne KDE ki vs savoz enonder a pårti d' ene plake lazer ou d' ene "
+"clé USB.<br/>On l' sait astaler come il est sol media (pont d' metaedje a "
+"livea)."
+
+#, fuzzy
+msgid "Add repository and install manually"
+msgstr "Enonder YaST eyet astaler les metaedjes a djoû al mwin"
+
+msgid "Add-On Downloads (optional)"
+msgstr "Aberwetaedjes di rawetes Add-On (nén rekis)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+
+#, fuzzy
+msgid "App Browser"
+msgstr "Naivieu d' programes"
+
+#, fuzzy
+msgid "Available Images"
+msgstr "Metaedje a djoû d' disponibes"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+#, fuzzy
+#| msgid ""
+#| "Boot from the DVD or CD. In case your computer does not automatically "
+#| "boot from CD/DVD, open the BIOS setup to allow booting from CD or DVD."
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"Enondez a pårti del plake DVD ou CD. Si vosse copiutrece n' enonde nén "
+"otomaticmint a pårti del plake CD/DVD, candjîz l' apontiaedje do BIOS po "
+"permete d' enonder (boot) a pårti d' ene plake CD ou DVD."
+
+msgid "Bronze Sponsor"
+msgstr "Avou l' côp di spale e bronze di"
+
+msgid "Browser incompatibility"
+msgstr "Betchteu waibe nén compatibe"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "Broûler imådje(s) di plake lazer CD/DVD"
+
+#, fuzzy
+msgid "Categories"
+msgstr "Categoreye"
+
+msgid "Category"
+msgstr "Categoreye"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"Tchoezixhoz on media d' astalaedje el clitchant eyet tchôkî l' boton "
+"Aberweter pos ataker l' aberwetaedje. Tchoezixhoz (mins ça n' est nén rekis) "
+"vosse sôre di copiutrece oudonbén ene ôte metôde d' aberwetaedje."
+
+msgid "Click here to display these alternative versions."
+msgstr ""
+
+msgid "Click to Download"
+msgstr "Clitchî pos aberweter"
+
+msgid "Community"
+msgstr "Cominålté"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr ""
+"I gn a dvins ene grande ramexhnêye di programes pol sicribanne eyet l' "
+"eployaedje come sierveu.<br/>Bon po l' astalaedje ou l' metaedje a livea."
+
+#, fuzzy
+msgid "Countdown"
+msgstr "Distinde"
+
+#, fuzzy
+msgid "Country"
+msgstr "Distinde"
+
+msgid "Development"
+msgstr "Disvelopmint"
+
+msgid "Development Version"
+msgstr "Modêye di diswalpaedje"
+
+#, fuzzy
+msgid "Development packages"
+msgstr "Pacaedjes di disvelopmint po KDE"
+
+#, fuzzy
+msgid "Development-"
+msgstr "Disvelopmint"
+
+#, fuzzy
+msgid "Direct Install"
+msgstr "1-Clitche Astale"
+
+msgid "Direct Link"
+msgstr "Hårdêye direke"
+
+msgid "Documentation"
+msgstr "Documintåcion"
+
+msgid "Don't show this warning the next time"
+msgstr ""
+
+msgid "Download"
+msgstr "Aberweter"
+
+msgid "Download %s"
+msgstr "Aberweter %s"
+
+msgid "Download Help"
+msgstr "Aidance po l' aberwetaedje"
+
+msgid "Download Method"
+msgstr "Metôde d' aberwetaedje"
+
+msgid "Download appliance from %s"
+msgstr ""
+
+msgid "Download&nbsp;DVD"
+msgstr "Aberweter&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "Aberweter&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "Aberweter&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "Aberweter&nbsp;Rantoele"
+
+#, fuzzy
+#| msgid "Download&nbsp;KDE"
+msgid "Download&nbsp;Rescue"
+msgstr "Aberweter&nbsp;KDE"
+
+msgid "Downloads"
+msgstr "Aberwetaedjes"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr ""
+"Aberwete li sistinme d' astalaedje eyet tos les pacaedjes a pårti des depots "
+"so fyis.<br/>Bon po l' astalaedje eyet l' metaedje a livea."
+
+msgid "Expand all sections ('e')"
+msgstr ""
+
+msgid "Extra Languages"
+msgstr "Ôtes lingaedjes (walon evnd...)"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "Ôtes lingaedjes (32 bites)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "Ôtes lingaedjes (64 bites)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr ""
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr ""
+
+#, fuzzy
+#| msgid ""
+#| "offers the most security as you can verify who signed it. It should be "
+#| "<tt>%s</tt>."
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"ofere li meyeuse såvrité ca vos ploz verifyî kî l' a siné. Ça dvreut esse "
+"<tt>%s</tt>."
+
+msgid "Games"
+msgstr "Djeus"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "Awè ene des distribucions speciålijheyes basteyes a pårti d' openSUSE."
+
+msgid "Getting Help"
+msgstr "Awè d' l' aidance"
+
+msgid "Gold Sponsor"
+msgstr "Sponsor d' ôr"
+
+msgid "Grab binary packages directly"
+msgstr ""
+
+msgid "Header Logo"
+msgstr "Imådjete del tiestire"
+
+msgid "Help on Download Method"
+msgstr "Aidance sol metôde d' aberwetaedje"
+
+msgid "Help on Type of Computer"
+msgstr "Aidance sol sôre di copiutrece"
+
+msgid "How to Proceed"
+msgstr "Comint fé"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"Si vos vs voloz siervi d' ene hårdêye direke mins k' vos vikez dins ene "
+"plaece do monde ewou çki nosse ridjibleu d' aberwetaedje n' a pont d' "
+"informåcions assez po vs rimoenner viè l' muroe l' pus roed, vos ploz "
+"tchoezi on muroe al mwin."
+
+msgid "Image:"
+msgstr ""
+
+#, fuzzy
+msgid "Install package %s / %s"
+msgstr "Astaler l' pacaedje avou YaST"
+
+msgid "Install pattern %s / %s"
+msgstr ""
+
+msgid "Install using One Click Install"
+msgstr ""
+
+msgid "Installation Guides"
+msgstr "Guides d' astalaedje"
+
+msgid "Installation Medium"
+msgstr "Media d' astalaedje"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"Konqueror di KDE 3 n' est målureuzmint pus mintnou eyet si implemintåcion do "
+"javascript a des bugs ki fjhèt k' on n' si sait nén sieriv di cisse pådje. "
+"Waitîz bén s' i vs plait k' vos avoz javascript essocté divant d' <a "
+"href='%s'>continouwer</a>."
+
+msgid "Language"
+msgstr "Lingaedje"
+
+#, fuzzy
+#| msgid "32 Bit PC"
+msgid "Legacy 32 Bit PC"
+msgstr "PC 32 bites"
+
+#, fuzzy
+#| msgid "32&nbsp;Bit&nbsp;PC"
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "PC 32&nbsp;bites&nbsp;"
+
+msgid "Live GNOME"
+msgstr "Vicante GNOME"
+
+msgid "Live KDE"
+msgstr "Vicante KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"Bråmint des programes savèt verifyî l' checksum d' en aberwetaedje. Verifyî "
+"vost aberwetaedje pout esse impôrtant ca ça verifeye ki vs avoz vormint l' "
+"fitchî ISO ki volîz aberweter eyet nén ene schetêye modêye."
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr ""
+"Co pus d' informåcions so comint broûler l' fitchî ISO so ene plake CD/DVD"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"Co pus d' informåcions so comint fé ene <a href='http://en.opensuse.org/"
+"Live_USB_stick'>clé USB enondåve</a>"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"Pus di pondants eyet d' djondants so l' aberwetaedje d' openSUSE dins les "
+"pådjes <a href=\"http://fr.opensuse.org/Aide_au_téléchargement\">Aide au "
+"téléchargement (fr)</a>, <a href=\"http://walotux.walon.org/spip.php?"
+"article16\">Aberweter li DVD d’ openSUSE (wa)</a> eyet <a href=\"http://fr."
+"opensuse.org/SDB:Installation_réseau\">Astalaedje a pårti del rantoele (fr, "
+"en)</a> dins nosse <a href=\"http://fr.opensuse.org/Portal:Documentation"
+"\">Wiki di documintåcion (fr)</a>."
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"Li pupårt des novelès copiutreces sopoirtèt li <a href=\"http://en.wikipedia."
+"org/wiki/X86-64\">x86-64</a> (ossu conoxhou come AMD64 eyet Intel64) mins i "
+"gn a des processeus d' axhlåves eyet d' netbooks ki nel sopoirtèt nén. "
+"Dabôrd i fåt k' vos verifyîz e wikipedia si vs voloz esse seur ki vs "
+"copiutrece el sopoite."
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Need help?"
+msgstr "Dandjî k' on vs aide?"
+
+msgid "Network"
+msgstr "Rantoele"
+
+msgid "No appliance data for %s"
+msgstr ""
+
+msgid "No appliances found in project %s"
+msgstr ""
+
+msgid "No data for %s / %s"
+msgstr ""
+
+#, fuzzy
+msgid "No description found..."
+msgstr "Rén d' trové"
+
+msgid "No downloads found for %s in project %s"
+msgstr ""
+
+msgid "No packages found matching your search. "
+msgstr ""
+
+msgid "NonOSS CD"
+msgstr "Plake lazer nén OSS"
+
+#, fuzzy
+msgid "OBS Backend not available"
+msgstr "Gn a 1 pacaedje di disponibe"
+
+msgid "Official Manuals"
+msgstr "Oficirès esplikêyes"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+
+msgid "Package %s not found..."
+msgstr ""
+
+msgid "Package Repositories"
+msgstr "Depots des pacaedjes"
+
+msgid "Package Search"
+msgstr "Cweraedje di pacaedje"
+
+#, fuzzy
+msgid "Packages for %s:"
+msgstr "Fijheu do pacaedje: %1\n"
+
+msgid "Pick Mirror"
+msgstr "Tchoezi on muroe"
+
+msgid "Platinum Sponsor"
+msgstr "Avou l' côp di spale èn ôr di"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+
+#, fuzzy
+msgid "Related categories:"
+msgstr "Categoreye"
+
+msgid "Released Version"
+msgstr "Modêye rexhowe"
+
+msgid "Reporting Bugs"
+msgstr "Rapoirter des bugs"
+
+#, fuzzy
+#| msgid "Rescue System"
+msgid "Rescue"
+msgstr "Sistinme di houplaedje"
+
+#, fuzzy
+#| msgid ""
+#| "A KDE desktop you can run from CD or from USB stick.<br/>Can be installed "
+#| "as is (no upgrade)."
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr ""
+"On scribanne KDE ki vs savoz enonder a pårti d' ene plake lazer ou d' ene "
+"clé USB.<br/>On l' sait astaler come il est sol media (pont d' metaedje a "
+"livea)."
+
+#, fuzzy
+#| msgid "md5 checksum"
+msgid "SHA256 checksum"
+msgstr "verifiaedje del some md5"
+
+msgid "Search"
+msgstr "Trover"
+
+#, fuzzy
+msgid "Select Your Operating System"
+msgstr "Enonder l' Sistinme d' Operance"
+
+#, fuzzy
+msgid "Select the image type"
+msgstr "Tchoezixhoz l' sôre di båre di tite."
+
+#, fuzzy
+msgid "Show"
+msgstr "Mostrer:"
+
+#, fuzzy
+msgid "Show development, language and debug packages"
+msgstr "Pacaedjes di disvelopmint po KDE"
+
+#, fuzzy
+msgid "Show distribution:"
+msgstr "Distribucion: %1\n"
+
+msgid "Show more packages for unsupported distributions"
+msgstr ""
+
+msgid "Show more..."
+msgstr ""
+
+#, fuzzy
+msgid "Show other versions"
+msgstr "Ôtès modêyes"
+
+#, fuzzy
+msgid "Show unstable packages"
+msgstr "mostrer les pacaedjes astalés"
+
+#, fuzzy
+msgid "Show unsupported packages"
+msgstr "mostrer les pacaedjes astalés"
+
+msgid "Silver Sponsor"
+msgstr "Sponsor d' årdjint"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"Des vicantes distribucions båzêyes so openSUSE. Les cis k' ont d' l' agrès "
+"po sayî d' basti leus derivés da zels polèt aler fé on toû dins <a href="
+"\"http://susestudio.com/\">SUSE Studio</a>."
+
+msgid "Source"
+msgstr "Sourdant"
+
+msgid "Sponsored by"
+msgstr "Avou l' côp di spale di"
+
+#, fuzzy
+msgid "Sponsored by: AMD"
+msgstr "Avou l' côp di spale d' AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "Avou l' côp di spale di : B1 Systems"
+
+#, fuzzy
+msgid "Sponsored by: Heinlein"
+msgstr "Avou l' côp di spale di"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "Avou l' côp di spale di: IP Exchange"
+
+msgid "Sub-Packages"
+msgstr ""
+
+msgid "Support"
+msgstr "Sopoirt"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr ""
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"I gn a dins cisse plake des programes gratiss cossemés dins ene licince "
+"prôpiyetaire ni permetant nén del mete dins l' mwaisse media d' astalaedje "
+"eshonne avou les libes programes. Tos les programes di cisse plake lazer "
+"duvrént esse aberwetés do depot NÉN-OSS."
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"Cisse modêye va so tos les PC, avou ossu les cis ki sopoirtèt l' 64 bites. "
+"Si vs avoz pus ki 3 GB di RAM, vos vs duvrîz cwand minme pus rade siervi del "
+"modêye 64 bites. openSUSE ni sopoite nén les processeus divant l' Pentium - "
+"eyet les vicantes plakes ni sopoirtèt k' les i686 (Pentium Pro ey adon)."
+
+msgid "Type of Computer"
+msgstr "Sôre di copiutrece"
+
+msgid "Unsupported distributions:"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"Vos savoz aler prinde les esplikêyes po ls uzeus so <a href=\"doc.opensuse."
+"org\">doc.opensuse.org</a>, metans, li <a href=\"http://doc.opensuse.org/"
+"products/opensuse/openSUSE/opensuse-startup/\">Official Start-Up Guide</a>, "
+"eyet li <a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/"
+"opensuse-installquick/\">Installation Guide</a>."
+
+#, fuzzy
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"Si siervi d' <a href=\"http://fr.opensuse.org/index.php?title=SDB:BitTorrent"
+"\">BitTorrent</a> est ricomandé si les hårdêyes sont londjinnes, sor-tot po "
+"l' aberwetaedje d' imådje di DVD. Les aberwetaedjes BitTorrent sont bons po "
+"bråmint des costés, les cliyint waerantixhèt sconte li crombaedje di dnêyes "
+"eyet vs aidîz a baxhî l' tchedje so les sierveus e pårticipant a l' "
+"eberwetaedje - si gn a assez d' djins ki p pårticipèt ça srè ossu pus roed "
+"ki les sierveus k' i n' sont k' a ene seule plaece - po tot l' monde. Ça vs "
+"permet ossu d' arester l' aberwetaedje tolminme cwand vos vloz eyet l' "
+"rataker pus tård."
+
+#, fuzzy
+msgid "Verify your download before use"
+msgstr "Verifyîz vost aberwetaedje (nén rekis, po les spepieus)"
+
+msgid "Version"
+msgstr "Modêye"
+
+msgid "We offer three different checksums:"
+msgstr "Nos ofrans troes diferins verifiaedje del some :"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"Cwand ons aberwete des imådjes ôtes ki les cisse po l' astalaedje pal "
+"rantoele, il est <i>foirt</i> ricomandé d' si siervi d' on vraiy manaedjeu "
+"d' aberwetaedje pos awè l' minimom di risse d' awè des crombès dnêyes."
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"Vos pôrîz verifyî l' fitchî e processus d' aberwetaedje. On verifiaedje del "
+"some (SHA256), metans, serè eployî otomaticmint si vs tchoezixhoz <a "
+"href='http://fr.opensuse.org/Metalink'>Metalink</a> e tchmp chal pa dzeu "
+"eyet eployî l' pacaedje di rawete DownThemAll! e <a href='http://fr.opensuse."
+"org/Firefox'>Firefox</a>."
+
+msgid "gpg signature"
+msgstr "sinateure gpg"
+
+#, fuzzy
+msgid "http://doc.opensuse.org/"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Derivatives"
+
+#, fuzzy
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#, fuzzy
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#| msgid "http://en.opensuse.org/Buy_openSUSE"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr ""
+"est co l' pus eployî totavå des verifiaedjes di some. Bråmint des broûleus "
+"d' ISO l' håyene djusse divant del broûler."
+
+msgid "is the less known but more secure checksum than md5."
+msgstr ""
+"est l' moens conoxhowe mins est on verifiaedje di some pus såve ki md5."
+
+msgid "md5 checksum"
+msgstr "verifiaedje del some md5"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr ""
+"ofere li meyeuse såvrité ca vos ploz verifyî kî l' a siné. Ça dvreut esse "
+"<tt>%s</tt>."
+
+#, fuzzy
+msgid "openSUSE Countdown"
+msgstr "Conteu d' openSUSE 11.3"
+
+msgid "openSUSE Derivatives"
+msgstr "Derivés d' openSUSE"
+
+#, fuzzy
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE est disponibe pa l' http (hårdêye direke) oudonbén l' BitTorrent. "
+"Li plake lazer po l' astalaedje pal rantoele n' est disponibe ki pa l' http."
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE ni sopoite ki les PC avou des processeus 32 eyet 64 bites"
+
+msgid "see Derivatives on wiki"
+msgstr "vey les Derivés sol wiki"
+
+msgid "sha1 checksum"
+msgstr "verifiaedje del some sha1"
+
+msgid "switch to"
+msgstr "passer a"
+
+#, fuzzy
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr ""
+#~ "Siervoz vs s' i vs plait d' tchinnes di cweraedje di pol moens 2 "
+#~ "caracteres"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#, fuzzy
+#~ msgid "Last searches:"
+#~ msgstr "Meyeus cweraedjes :"
+
+#~ msgid "Statistics"
+#~ msgstr "Sitatistikes"
+
+#, fuzzy
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "Meyeus aberwetaedjes :"
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "Meyeus cweraedjes sins rzultats :"
+
+#~ msgid "Top searches:"
+#~ msgstr "Meyeus cweraedjes :"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "DVD 4,7Go"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "I gn a ezès vicantès plakes ki cwate lingaedjes (inglès, almand, rûsse "
+#~ "eyet italyin). Si vs voloz awè on sopoirt po ls ôtes lingaedjes, vos l' "
+#~ "divoz aberweter del Daegntoele sol tins d' l' astalaedje ou tolminme "
+#~ "cwand après. Si vs avoz èn accès åjhey al Daegntoel ou si vs eployîz ene "
+#~ "plake DVD avou tos les lingaedjes, vos n' avoz nén dandjî di cisse plake "
+#~ "lazer."
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "Après awè aberweté comifåt li/les imådje(s) ISO, broûlez li/les imådje(s) "
+#~ "avou vosse programe colåd di broûlaedje sos ene plake DVD ou CD. S' i vs "
+#~ "plait, ni broûlez <em>NÉN</em> ene plake CD/DVD di dnêyes mins "
+#~ "tchoezixhoz pus rade li tchuze di broûler ene imådje ISO."
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr ""
+#~ "Siervoz vs s' i vs plait d' tchinnes di cweraedje di pol moens 2 "
+#~ "caracteres"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr ""
+#~ "Passé a coresponde totafwait a cåze k' i gn aveu trop d' rizultats sol "
+#~ "cweraedje di bokets d' tchinne."
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr ""
+#~ "Soeyoz pus spepieus dins vosse ricweraedje s' i vs plait. Li limite do "
+#~ "cweraedje est houte."
+
+#~ msgid "Could not perform search: "
+#~ msgstr "Dji n' a savou fé l' ricweraedje : "
+
+#~ msgid "Popular Software"
+#~ msgstr "Programes populaires"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "Atchter openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "1-Clitche Astale"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "Aberwetaedje al mwin do pacaedje"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "Potchî å pordjet OBS"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[Ramexhnêye di programes]"
+
+#~ msgid "Search Results"
+#~ msgstr "Rizultats do cweraedje"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr ""
+#~ "Dji n' a trové d' pacaedje e l' openSUSE build service ki corespondeut a "
+#~ "vosse ricweraedje."
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d ramexhnêyes eyet %d binaires di %d pacaedjes sourdants."
+
+#, fuzzy
+#~| msgid "Snapshots of Wine CVS"
+#~ msgid "Screenshot of  "
+#~ msgstr "Egaloyaedjes di Wine CVS"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "Sitatistikes di cweraedje :"
+
+#~ msgid "Download Statistics:"
+#~ msgstr "Sitatistikes d' aberwetaedje :"
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "Cachî après eyet astaler des pacaedjes di programe a pårti di l' <a href="
+#~ "\"http://build.opensuse.org\">openSUSE Build Service</a> :"
+
+#~ msgid "Search options"
+#~ msgstr "Tchuzes do cweraedje"
+
+#, fuzzy
+#~| msgid "Exclude user's home projects"
+#~ msgid "Include users' home projects"
+#~ msgstr "Ni nén cweri dins les pordjets måjhon dås uzeus"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "Ni nén cweri dins les pacaedjes di disbugaedje"
+
+#~ msgid "Additional Information"
+#~ msgstr "Informåcions di rawete"
+
+#~ msgid ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Installation quickstart</a>"
+#~ msgstr ""
+#~ "<a href=\"http://doc.opensuse.org/products/opensuse/openSUSE/opensuse-"
+#~ "installquick/\">Rade ataker avou l' astalaedje (en)</a>"
+
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "Atchter openSUSE 11.3"
+
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "Atchtez openSUSE 11.3 !"
+
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "Pus di pondants eyet d' djondants so l' aberwetaedje d' openSUSE dins l' "
+#~ "<a href=\"http://fr.opensuse.org/Aide_au_téléchargement\">Aide au "
+#~ "téléchargement (fr)</a> ou dins <a href=\"http://walotux.walon.org/spip."
+#~ "php?article16\">Aberweter li DVD d’ openSUSE (wa)</a>."
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "Les esplikêyes sont disponibes come çoula:"
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "Astalaedje a pårti del plake DVD/CD:"
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "Guide oficire pos ataker avou %s"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "Guide d' astalaedje e vos tnant pal mwin"
+
+#~ msgid "Network Installation"
+#~ msgstr "Astalaedje pal rantoele"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Internet Installation"
+#~ msgstr "Astalaedje pel daegntoele"
+
+#~ msgid "More information"
+#~ msgstr "Co pus d' infôrmåcions"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://walotux.walon.org/spip.php?article24"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "Awè des programes"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "Basti des programes"
+
+#~ msgid "User Directory"
+#~ msgstr "Calpin des uzeus"
+
+#~ msgid "Features"
+#~ msgstr "Fonccionålités"
+
+#~ msgid "News"
+#~ msgstr "Noveles"
+
+#~ msgid "Forums"
+#~ msgstr "Foroms"
+
+#~ msgid "Shop"
+#~ msgstr "Botike"
+
+#~ msgid "Software"
+#~ msgstr "Programe"
+
+#~ msgid "Software Search"
+#~ msgstr "Trover on programe"
+
+#~ msgid "Update Repositories"
+#~ msgstr "Depots des metaedjes a djoû"
+
+#~ msgid "Source Repository"
+#~ msgstr "Depot des sourdants"
+
+#~ msgid "Other Options"
+#~ msgstr "Ôtès tchuzes"
+
+#~ msgid "Mirrors"
+#~ msgstr "Muroes"
+
+#~ msgid "In other languages"
+#~ msgstr "Dins ds ôtes lingaedjes (walon evnd...)"
+
+#~ msgid "Get it"
+#~ msgstr "L' awè"
+
+#~ msgid "Search Build Service"
+#~ msgstr "Cweri e Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr ""
+#~ "Cachî après eyet astaler des ôtes pacaedjes di programe a pårti di l' "
+#~ "openSUSE Build Service."
+
+#~ msgid "Get openSUSE"
+#~ msgstr "Awè openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "Hårdêye po tot l' tins viè c' rizultat ci"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "Awè des programes di l' openSUSE Build Service"
+
+#~ msgid "Searching"
+#~ msgstr "Dji cwir"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "I gn a dvins ene grande ramexhnêye di programes pol sicribanne eyet l' "
+#~ "eployaedje come sierveu. Bon po l' astalaedje eyet l' metaedje a livea."
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "On scribanne GNOME ki vs savoz enonder a pårti d' ene plake lazer ou d' "
+#~ "ene clé USB. On l' sait astaler come il sol media (pont d' metaedje a "
+#~ "livea)."
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "On scribanne KDE ki vs savoz enonder a pårti d' ene plake lazer ou d' ene "
+#~ "clé USB. On l' sait astaler come il sol media (pont d' metaedje a livea)."
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr ""
+#~ "Aberwete li sistinme d' astalaedje eyet tos les pacaedjes a pårti di "
+#~ "depots so fyis. Bon po l' astalaedje eyet l' metaedje a livea."
+
+#~ msgid "Metalinks"
+#~ msgstr "Meta-loyéns"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "Atchtez openSUSE 11.1!"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "Po des uzeus ki sont novea e monde di Linux, li modêye d' openSUSE avou "
+#~ "sopoirt pôreut esse li meyeu tchoes&mdash;vos åroz tote li documintåcion "
+#~ "po l' uzeu finå do sistinme, on media d' astalaedje po les sistinmes 32 "
+#~ "bites eyet 64 bites et co 90 djoûs di sopoirt po l' astalaedje po l' uzeu "
+#~ "finå."
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "On sait awè openSUSE 11.1 dins sacwantès botikes <a href=\"http://en."
+#~ "opensuse.org/Buy_openSUSE\">so fyis</a> oudonbén amon des vindeus "
+#~ "coinreces."
+
+#, fuzzy
+#~ msgid "Expert view"
+#~ msgstr "Sipepieusès tchuzes"
+
+#~ msgid "Help"
+#~ msgstr "Aidance"
+
+#, fuzzy
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "Sicribanne GNOME"

--- a/locale/zh_CN/software.po
+++ b/locale/zh_CN/software.po
@@ -1,0 +1,981 @@
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+#
+#
+# margurite <i@marguerite.su>, 2012, 2013.
+# hillwood <hillwoodroc@gmail.com>, 2012, 2013.
+# 玛格丽特 · 苏 <marguerite@opensuse.org>, 2013, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: @PACKAGE@\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-06 19:28+0800\n"
+"Last-Translator: marguerite <marguerite@opensuse.org>\n"
+"Language-Team: Chinese <kde-i18n-doc@kde.org>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 2.0\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+msgid " and "
+msgstr " 和 "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} 不是一个受支持的版本。\""
+
+msgid "(hide)"
+msgstr "(隐藏)"
+
+msgid "(show)"
+msgstr "(显示)"
+
+msgid "... and keep us informed"
+msgstr "... 并知会我们"
+
+msgid "... get other marketing stuff"
+msgstr "... 获取其它营销材料"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (也适用于 U 盘)"
+
+msgid "64 Bit PC"
+msgstr "64 位计算机"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-startup/\">openSUSE 入"
+"门指南</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://zh.opensuse.org/SDB:Metalink\">Metalink</a> 是一种开源标准，"
+"它将多种撷取文件的方式 (FTP/HTTP/BT) 捆绑成了一种格式以方便下载。这使得它非常"
+"适合下载 ISO; 尤其是对于那些由于他们的 ISP 或大学限制而不能使用 P2P 的人来"
+"说。它可以提供非常快的下载速度，因为它的大多数客户端均支持自动多点连接，以及"
+"从多镜像下载。还有，它能自动查错并纠错。然而您需要特殊的客户端才能使用它。"
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">授权许可</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>版本资讯</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>官方版本</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>官方升级版本</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"可以在 %s 或 U 盘中运行的 GNOME 桌面。<br/>可用于安装 (不能用于升级，语言包需"
+"另装)。"
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"可在 %s 或 U 盘中运行的 KDE 桌面。<br/>可用于安装 (不能用于升级，语言包需另"
+"装)。"
+
+msgid "Add repository and install manually"
+msgstr "添加软件源并手动安装"
+
+msgid "Add-On Downloads (optional)"
+msgstr "扩展下载 (可选)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"在成功下载 ISO 映像后，创建一个可引导 U 盘或将映像刻录到一张 DVD (若所选映像"
+"够小也可以刻录到 CD) 上。"
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"全部数据仅用于投递 openSUSE 推广材料且不会扩散给第三方。\n"
+"我们存根数据是为了通知用户新版资讯。\n"
+"全部邮寄请求都必须被美国出口禁运组织审查。\n"
+"关于禁运和禁运国家名单的更多信息可参考维基百科 <a href='http://en.wikipedia."
+"org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a> 词条。"
+
+msgid "App Browser"
+msgstr "应用程序浏览器"
+
+msgid "Available Images"
+msgstr "可用映像"
+
+msgid "BitTorrent"
+msgstr "BitTorrent 种子"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"从 DVD、CD 或 U 盘引导。若您的计算机没有自动从所选设备引导，请打开 BIOS 设置"
+"并允许从该设备引导。"
+
+msgid "Bronze Sponsor"
+msgstr "青铜赞助商"
+
+msgid "Browser incompatibility"
+msgstr "浏览器不兼容"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "刻录 CD/DVD 映像"
+
+msgid "Categories"
+msgstr "分类"
+
+msgid "Category"
+msgstr "分类"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"通过点击来选择安装介质，然后点击下载按钮来开始下载。另外您也可以选择您的计算"
+"机架构或者额外的下载方式。"
+
+msgid "Click here to display these alternative versions."
+msgstr "点此显示这些可选版本。"
+
+msgid "Click to Download"
+msgstr "点击下载"
+
+msgid "Community"
+msgstr "社区"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr "包含桌面或服务器使用的一篮子软件。<br/>适用于安装或升级。"
+
+msgid "Countdown"
+msgstr "倒计时"
+
+msgid "Country"
+msgstr "国家"
+
+msgid "Development"
+msgstr "开发"
+
+msgid "Development Version"
+msgstr "开发版本"
+
+msgid "Development packages"
+msgstr "开发包"
+
+msgid "Development-"
+msgstr "开发-"
+
+msgid "Direct Install"
+msgstr "直接安装"
+
+msgid "Direct Link"
+msgstr "直接链接"
+
+msgid "Documentation"
+msgstr "文档"
+
+msgid "Don't show this warning the next time"
+msgstr "下次不要显示此提醒"
+
+msgid "Download"
+msgstr "下载"
+
+msgid "Download %s"
+msgstr "下载 %s "
+
+msgid "Download Help"
+msgstr "下载帮助"
+
+msgid "Download Method"
+msgstr "下载方式"
+
+msgid "Download appliance from %s"
+msgstr "从 %s 下载应用"
+
+msgid "Download&nbsp;DVD"
+msgstr "下载&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "下载&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "下载&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "网络下载"
+
+msgid "Download&nbsp;Rescue"
+msgstr "下载&nbsp;救援系统"
+
+msgid "Downloads"
+msgstr "下载"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr "从在线软件源下载安装系统和全部软件包。<br/>适用于安装或升级。"
+
+msgid "Expand all sections ('e')"
+msgstr "展开所有部分 ('e')"
+
+msgid "Extra Languages"
+msgstr "额外语言"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "额外语言 (32位)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "额外语言 (64位)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr ""
+"对于 <strong>%s</strong>，请以 <strong>根用户 root</strong> 运行下面命令："
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "对于 <strong>%s</strong>，请运行以下命令："
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"对于 <strong>Arch Linux</strong>，请编辑 /etc/pacman.conf 并添加以下内容 (注"
+"意 pacman.conf 中的软件源顺序是很重要的，因为 pacman 总是会下载第一个找到的软"
+"件包)："
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "针对每个 ISO，我们都提供了一个带有相应 SHA256 和的 checksum 文件。"
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"出于更加安全考虑，您可以使用 GPG 校验谁签发了这些 .sha256 文件。应该是 %s。"
+
+msgid "Games"
+msgstr "游戏"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "获取基于 openSUSE 定制的衍生发行版"
+
+msgid "Getting Help"
+msgstr "获取帮助"
+
+msgid "Gold Sponsor"
+msgstr "黄金赞助商"
+
+msgid "Grab binary packages directly"
+msgstr "直接抓取制式软件包"
+
+msgid "Header Logo"
+msgstr "头部徽标"
+
+msgid "Help on Download Method"
+msgstr "下载方式帮助"
+
+msgid "Help on Type of Computer"
+msgstr "关于计算机架构的帮助"
+
+msgid "How to Proceed"
+msgstr "如何进行"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"若您想要使用直接链接，但却居住在世界上的某个神秘角落以至于我们的下载中转器没"
+"有足够的关于该位置的信息来把您中转到最快的镜像，这时您可以自行选择一个镜像。"
+
+msgid "Image:"
+msgstr "映像："
+
+msgid "Install package %s / %s"
+msgstr "安装软件包 %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "安装软件集 %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "使用一键安装"
+
+msgid "Installation Guides"
+msgstr "安装指南"
+
+msgid "Installation Medium"
+msgstr "安装介质"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"快来加入快速壮大的社区，为您的社团、非盈利组织、学校、大学，\n"
+"或如 LUG 聚会、装机市集、发布会等事件预订最新推广 DVD，\n"
+"把 openSUSE 送给更多的人吧。\n"
+"推广 DVD 能帮助提高 openSUSE 的知名度和可视性！"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"KDE 3 中的 Konqueror 很不幸没人维护了，它的 javascript 实现有 bug，使其无法正"
+"常渲染此页面。您在<a href='%s'>继续</a>前请确保禁用了 javascript。"
+
+# label for language selection
+msgid "Language"
+msgstr "语言"
+
+msgid "Legacy 32 Bit PC"
+msgstr "老式 32 位计算机"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "老式 32 位计算机"
+
+msgid "Live GNOME"
+msgstr "GNOME LiveCD"
+
+msgid "Live KDE"
+msgstr "KDE LiveCD"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"许多程序都可以校验下载文件的 checksum。校验您下载的文件挺重要的，因为它可以校"
+"验您是否真的撷取到了您想要下载的 ISO 文件而不是一些损坏的版本。"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "更多关于刻录 ISO 文件到 CD/DVD 上的信息"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"更多关于创建<a href='http://zh.opensuse.org/Live_USB_stick'>可引导 U 盘</a> "
+"的信息"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"更多关于下载 openSUSE 的信息可以看一看我们<a href=\"http://zh.opensuse.org/"
+"Category:SDB:安装\">维基的支持数据库专题</a>上的 <a href=\"http://zh."
+"opensuse.org/SDB:下载帮助\">下载帮助</a> ，以及 <a href=\"http://zh.opensuse."
+"org/SDB:网络安装方式\">网络安装</a> 页面。"
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"许多新计算机都支持 <a href=\"http://en.wikipedia.org/wiki/X86-64\">x86_64</> "
+"(也叫做 AMD64 或 Intel64)，但是一些笔记本/上网本处理器可能不支持它。所以若您"
+"想要确保您的计算机支持它，您需要自己去维基百科上确认一下。"
+
+msgid "Multimedia"
+msgstr "多媒体"
+
+msgid "Need help?"
+msgstr "需要帮助吗？"
+
+msgid "Network"
+msgstr "网络"
+
+msgid "No appliance data for %s"
+msgstr "没有 %s 的应用数据"
+
+msgid "No appliances found in project %s"
+msgstr "未找到应用位于 %s 工程中"
+
+msgid "No data for %s / %s"
+msgstr "没有 %s / %s 的数据"
+
+msgid "No description found..."
+msgstr "未发现该软件的描述..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "未找到可下载的 %s 位于工程 %s 中"
+
+msgid "No packages found matching your search. "
+msgstr "没有找到匹配您搜索条件的软件包"
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+msgid "OBS Backend not available"
+msgstr "OBS 后端暂不可用"
+
+msgid "Official Manuals"
+msgstr "官方手册"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"只有 DVD 和网络介质是完整测试过的。其它备选，如 Live 介质或救援系统，仅推荐用"
+"于有限用途。"
+
+msgid "Package %s not found..."
+msgstr "未找到软件包 %s..."
+
+msgid "Package Repositories"
+msgstr "软件源"
+
+msgid "Package Search"
+msgstr "软件包搜索"
+
+msgid "Packages for %s:"
+msgstr "用于 %s 的软件包："
+
+msgid "Pick Mirror"
+msgstr "选择镜像站点"
+
+msgid "Platinum Sponsor"
+msgstr "白金赞助商"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"请留神以下软件包来自于非官方的软件源。\n"
+"这意味着它们没有被 openSUSE 复核过，因此可能携带不稳定或实验性的软件。"
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"请输入一个<b>简短</b>的需要 DVD 的理由(英文) 并提供一个事件/目的的链接。"
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"请注意这不是最新版本的 openSUSE。您可以在<a href='/'>这儿</a>获取最新版本。 "
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"推广 DVD 和全部相关的艺术作品 -  盘面标签和封套 - 可在\n"
+"<a href=\"http://download.opensuse.org/promodvd/\">推广 DVD 下载文件夹 %s</a>"
+"下载。\n"
+"请注意这是一个特殊版本的 openSUSE，亦即设计就是用于推广分发的。"
+
+msgid "Related categories:"
+msgstr "相关分类："
+
+msgid "Released Version"
+msgstr "稳定版本"
+
+msgid "Reporting Bugs"
+msgstr "汇报故障"
+
+msgid "Rescue"
+msgstr "救援系统 (基于 Xfce 桌面)"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr "可在 CD 或 U 盘中运行的救援系统。<br/>不能用于安装或升级。"
+
+msgid "SHA256 checksum"
+msgstr "SHA256 checksum"
+
+msgid "Search"
+msgstr "搜索"
+
+msgid "Select Your Operating System"
+msgstr "选择您的操作系统"
+
+msgid "Select the image type"
+msgstr "选择映像类型"
+
+msgid "Show"
+msgstr "显示"
+
+msgid "Show development, language and debug packages"
+msgstr "显示开发包、语言包和调试包"
+
+msgid "Show distribution:"
+msgstr "显示发行版："
+
+msgid "Show more packages for unsupported distributions"
+msgstr "显示更多适用于不受官方支持的发行版的软件包"
+
+msgid "Show more..."
+msgstr "显示更多..."
+
+msgid "Show other versions"
+msgstr "显示其它版本"
+
+msgid "Show unstable packages"
+msgstr "显示不稳定版的软件包"
+
+msgid "Show unsupported packages"
+msgstr "显示不受官方支持的软件包"
+
+msgid "Silver Sponsor"
+msgstr "白银赞助商"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"也有一些其它的介质 (例如 Live 介质和救援系统），虽然它们进行的测试较少并仅推"
+"荐用于有限用途。"
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"一些还活着的基于 openSUSE 的发行版。对尝试制作自己的 openSUSE 衍生版本感兴趣"
+"的人可以看一看 <a href=\"http://susestudio.com/\">SuSE Studio</a>。"
+
+msgid "Source"
+msgstr "源代码"
+
+msgid "Sponsored by"
+msgstr "赞助商"
+
+msgid "Sponsored by: AMD"
+msgstr "由 AMD 赞助"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "由 B1 Systems 资助"
+
+msgid "Sponsored by: Heinlein"
+msgstr "由 Heinlein 赞助"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "由 IP Exchange 资助"
+
+msgid "Sub-Packages"
+msgstr "子软件包"
+
+msgid "Support"
+msgstr "支持"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"安装过程可以多种语言进行，但是，对多数语言来讲，应用程序的翻译并没有收录在映"
+"像中。若您想要您的 openSUSE 系统支持一些额外语言，您需要在安装时或安装后从互"
+"联网下载该语言的翻译。若您能够轻松地访问互联网，那么您并不需要此 CD; 但是若您"
+"打算在某些没有互联网连接的计算机上安装 openSUSE，该 CD 可以让您接触到全部可用"
+"语言的翻译。"
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "然后以根用户 <strong>root</strong> 身份运行以下命令："
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"目前没有处在测试阶段的 openSUSE 版本。<br/>若您想要使用最前沿的软件，请使用 "
+"<a href='http://zh.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>。"
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"此 CD 收录了在私有许可证下发布，因此不允许与自由开源软件一起放置于主安装介质"
+"内的免费软件。此 CD 中的全部软件都能从 NON-OSS 源中下载。"
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"这个版本可以在全部计算机上运行，包括那些支持 64 位的计算机。若您有大于 3GB 的"
+"内存，您可能会倾向于选择 64 位的版本。openSUSE 不支持奔腾之前的处理器 - live "
+"CD 甚至只支持 i686 (奔腾专业版和之后的处理器)。"
+
+msgid "Type of Computer"
+msgstr "计算机架构"
+
+msgid "Unsupported distributions:"
+msgstr "不受官方支持的发行版："
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"用户手册可从 <a href=\"http://activedoc.opensuse.org\">activedoc.opensuse."
+"org</a> 获取，例如<a href=\"http://activedoc.opensuse.org/book/opensuse-"
+"startup/\">官方入门指南</a>。"
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"对于网速较慢的人，推荐使用 <a href=\"http://zh.opensuse.org/SDB:BitTorrent"
+"\">BitTorrent 种子</a>，尤其是下载 DVD 映像时。BT 有诸多好处，客户端能防止数"
+"据损坏，并且您还可以通过参与上传来降低服务器的负载。若参与的人数足够多，它甚"
+"至比中央服务器还快，对每个人都快。更赞的是，您可以随时停止下载，在有时间时再"
+"续传。"
+
+msgid "Verify your download before use"
+msgstr "请在使用前校验您下载的文件"
+
+msgid "Version"
+msgstr "版本"
+
+msgid "We offer three different checksums:"
+msgstr "我们提供了三种不同的 checksums："
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"我们期待您，知会我们您对 DVD 的使用情况，\n"
+"这样我们能够帮助您在我们的<a href='http://news.opensuse.org' title='news."
+"opensuse.org'>新闻页面</a>\n"
+"或其它资源中推广您的组织、事件或学校。\n"
+"(嘤嘤嘤！我们爱美图！多拍点嘛！)。\n"
+"请用 <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"联系我们来讨论推广和/或其它我们可协助您的方式。"
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"当下载映像而不是网络安装 CD 时，<i>强烈</i>建议使用下载管理器来降低数据损坏的"
+"风险。"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"您可以把软件源金钥添加到 apt。记住该金钥的拥有者将能够分发您的系统将会信任的"
+"更新、软件包和软件源 (<a href=\"%s\">更多信息</a>)。要添加该金钥，请运行："
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr ""
+"您可尝试将搜索条件扩展到开发软件包或搜索另一个基础发行版中的软件包 (目前)。"
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"你可以在下载进行时校验文件。例如若您在上面框中选择了 <a href='http://zh."
+"opensuse.org/SDB:Metalink'>Metalink</a> 下载方式，并使用 <a href='http://zh."
+"opensuse.org/Firefox'>Firefox</a> 的 DownThemAll! 插件下载，就会自动使用 "
+"SHA256 checksum 验证。"
+
+msgid "gpg signature"
+msgstr "GPG 签名"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://zh.opensuse.org/主软件源"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://zh.opensuse.org/SDB:DVD_安装方式"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://zh.opensuse.org/SDB:下载帮助"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr ""
+"http://zh.opensuse.org/SDB:下载帮助#.E7.83.A7.E5.BD.95_ISO_.E6.98.A0."
+"E5.83.8F.E6.A1.A3"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://zh.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr "依然是最常用的 checksum。许多 ISO 刻录程序会在开始刻录前显示它。"
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "比较鲜为人知但比 md5 要安全一些。"
+
+msgid "md5 checksum"
+msgstr "md5 checksum"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr "提供了最大安全性，您可以校验是谁签发了它。签发人应该是 <tt>%s</tt>。"
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE 新版倒计时"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE 衍生版本"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE 可以籍 http(直接链接) 或 BitTorrent 种子撷取。网络安装 CD 只能通过直"
+"接链接下载。"
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE 只支持 32/64 位的计算机。"
+
+msgid "see Derivatives on wiki"
+msgstr "请参考维基上的「衍生版本」文章"
+
+msgid "sha1 checksum"
+msgstr "sha1 checksum"
+
+msgid "switch to"
+msgstr "切换至"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "发生了一个内部错误呦 :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "请输入至少两个字符"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "最后搜索："
+
+#~ msgid "Statistics"
+#~ msgstr "统计"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "流行的一键安装："
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "搜索排行榜"
+
+#~ msgid "Top searches:"
+#~ msgstr "流行搜索："
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "目前我们没有比最新的 openSUSE 稳定版本还新的 openSUSE 工厂版抢先版 <br/>详"
+#~ "情可见 <a href='http://zh.opensuse.org/Portal:Factory'>工厂版专题</a>。"
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "您可以像这样把源密钥添加到 apt："
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7 GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD 只包含了四种语言（英文、德文、俄文和意大利语）。如果想要剩下的其他"
+#~ "语言，您需要在安装时或安装后从万维网下载它。如果您可以访问网络或者您使用的"
+#~ "是包含所有语言的 DVD，您不需要下载本 CD。"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "在成功下载了 ISO 镜像文件之后，使用您最爱的刻录程序刻录镜像文件到 DVD/CD。"
+#~ "请 <em>不要</em> 刻录成“数据 DVD/CD”，而应该选择“烧录 ISO 镜像”的选项。"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.zh_CN.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.zh_CN.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "请使用至少两个字符的搜索关键词"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "由于关键词太多，子句搜索已切换为「严格匹配」。"
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "请更精确的描述您的搜索，目前已是搜索极限。"
+
+#~ msgid "Could not perform search: "
+#~ msgstr "不能执行搜索： "
+
+#~ msgid "Popular Software"
+#~ msgstr "流行软件"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "订购 openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "一键安装"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "手动下载软件包"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "前往编译服务上的该项目"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[软件集]"
+
+#~ msgid "Search Results"
+#~ msgstr "搜索结果"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "没有在 openSUSE 编译服务上找到匹配您的查询的软件包。"
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d 集合和 %d 执行文件，来自 %d 源代码包"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "软件截图"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "搜索统计："
+
+#~ msgid "Download Statistics:"
+#~ msgstr "下载统计："
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "从 <a href=\"http://build.opensuse.org\">openSUSE 编译服务</a>搜索和安装软"
+#~ "件包："
+
+#~ msgid "Search options"
+#~ msgstr "搜索选项"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "包含用户的私人车库"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "排除调试包"

--- a/locale/zh_TW/software.po
+++ b/locale/zh_TW/software.po
@@ -1,0 +1,1196 @@
+# translation of software-opensuse-org.po to Chinese Traditional
+# @TITLE@
+# Copyright (C) 2006, SUSE Linux GmbH, Nuremberg
+#
+# This file is distributed under the same license as @PACKAGE@ package. FIRST
+#
+# swyear <swyear@gmail.com>, 2009, 2010.
+# tom <hallo.pizza.kalender@googlemail.com>, 2010.
+# tom <tom@opensuse.org>, 2010, 2011.
+# Ray Chen <swyear@opensuse.org>, 2012, 2013.
+# Ramax Lo <ramaxlo@gmail.com>, 2014, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: software-opensuse-org\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-31 16:19+0200\n"
+"PO-Revision-Date: 2015-11-04 11:48+0800\n"
+"Last-Translator: \n"
+"Language-Team: Chinese Traditional <kde-i18n-doc@kde.org>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid " and "
+msgstr " 和 "
+
+msgid "\"#{release} is not a supported release.\""
+msgstr "\"#{release} 不是一個支援的發行版。\""
+
+msgid "(hide)"
+msgstr "(隱藏)"
+
+msgid "(show)"
+msgstr "(顯示)"
+
+msgid "... and keep us informed"
+msgstr "... 並讓我們知道"
+
+msgid "... get other marketing stuff"
+msgstr "... 取得其他行銷玩意兒"
+
+msgid "4.7GB DVD (also suitable for USB stick)"
+msgstr "4.7GB DVD (也適用於 USB 隨身碟)"
+
+msgid "64 Bit PC"
+msgstr "64 位元 PC"
+
+msgid ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE "
+"startup guide</a>"
+msgstr ""
+"<a href=\"http://activedoc.opensuse.org/book/opensuse-start-up\">openSUSE 新"
+"手指引</a>"
+
+msgid ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> is an open "
+"standard that bundles the various ways (FTP/HTTP/BitTorrent) to get files "
+"into one format for easier downloads. This makes it good for downloading "
+"ISOs; particularly for people who can't use P2P because of restrictions from "
+"their ISP or University. It can deliver very fast download speeds since most "
+"clients support multiple connections, to multiple mirrors, automatically. In "
+"addition, it can do automatic error detection, and correction. It needs a "
+"special client to handle it though."
+msgstr ""
+"<a href=\"http://en.opensuse.org/SDB:Metalink\">Metalink</a> 是一個開放的標"
+"準，結合了多種的下載方式 (FTP/HTTP/BitTorrent) 成一種格式讓下載更容易。這讓他"
+"很適合下載 ISO;尤其對於那些受限於 ISP 或大學而無法使用 P2P 的人們。他可以提供"
+"非常快速的下載，因為大部分客戶端都支援自動多重連線到多重鏡像。此外，他還能自"
+"動偵測錯誤與修正。他需要一個特別的客戶端程式來處理他。"
+
+msgid "<a href=\"http://en.opensuse.org/openSUSE:License\">License</a>"
+msgstr "<a href=\"http://en.opensuse.org/openSUSE:License\">授權合約</a>"
+
+msgid "<a href='%s'>Release Notes</a>"
+msgstr "<a href='%s'>發行公告</a>"
+
+msgid "<b>official release</b>"
+msgstr "<b>官方釋出</b>"
+
+msgid "<b>official update</b>"
+msgstr "<b>官方更新</b>"
+
+msgid ""
+"A GNOME desktop you can run from %s or from USB stick.<br/>Can be installed "
+"as is (no upgrade)."
+msgstr ""
+"一個您可以由 %s 或 USB 隨身碟運行的 GNOME 桌面。<br/>也可以安裝（不是升級）。"
+
+msgid ""
+"A KDE desktop you can run from %s or from USB stick.<br/>Can be installed as "
+"is (no upgrade)."
+msgstr ""
+"一個您可以由 %s 或 USB 隨身碟運行的 KDE 桌面。<br/>也可以安裝（不是升級）。"
+
+msgid "Add repository and install manually"
+msgstr "加套件庫並手動安裝"
+
+msgid "Add-On Downloads (optional)"
+msgstr "附加下載 (選項)"
+
+msgid ""
+"After having successfully downloaded the ISO image(s), create a bootable USB "
+"stick or burn the image(s) to a DVD (or a CD if the chosen image fits)."
+msgstr ""
+"在成功下載 ISO 影像後，建立一個可開機的 USB 隨身碟或燒錄影像到 DVD (或 CD --"
+"如果您選的影像合適的話)。"
+
+msgid ""
+"All data is used only for sending openSUSE promotional material\n"
+"      and will not be spread to third parties. We store the data to\n"
+"      inform the users if a new version is available. All requests have\n"
+"      to be screened to fulfill the US export embargo. More information\n"
+"      about the embargo and a list of countries at wikipedia <a href='http://"
+"en.wikipedia.org/wiki/United_States_embargoes'>http://en.wikipedia.org/wiki/"
+"United_States_embargoes</a>."
+msgstr ""
+"所有資料僅用於發送 openSUSE 宣傳品\\n          並且不會散佈到第三方。我們儲存"
+"此資料用以\\n          提醒使用者是否有可用的新版。所有的需求\\n          都"
+"會被屏蔽以滿足 US 出口禁運條款。更多\\n          相關資訊，請參考維基百科說"
+"明 <a href='http://en.wikipedia.org/wiki/United_States_embargoes'>http://en."
+"wikipedia.org/wiki/United_States_embargoes</a>。"
+
+msgid "App Browser"
+msgstr "應用程式瀏覽器"
+
+msgid "Available Images"
+msgstr "可用的影像"
+
+msgid "BitTorrent"
+msgstr "BitTorrent"
+
+msgid ""
+"Boot from the DVD, CD or USB stick. In case your computer does not "
+"automatically boot from the chosen device, open the BIOS setup to allow "
+"booting from it."
+msgstr ""
+"用 DVD 、CD 或 USB 隨身碟開機。如果您的電腦不會自動由所選擇的裝置開機，請開"
+"啟 BIOS 設定允許由 CD 、DVD 或 USB 開機。"
+
+msgid "Bronze Sponsor"
+msgstr "青銅級贊助者"
+
+msgid "Browser incompatibility"
+msgstr "瀏覽器不相容性"
+
+msgid "Burn CD/DVD Image(s)"
+msgstr "燒錄 CD/DVD 影像"
+
+msgid "Categories"
+msgstr "分類"
+
+msgid "Category"
+msgstr "分類"
+
+msgid ""
+"Choose an installation medium by clicking it and hit the Download button to "
+"start the download. Optionally choose your computer type or an alternative "
+"download method."
+msgstr ""
+"選擇一個安裝媒體，然後按下載按鈕以開始下載。您也可以選擇您的電腦類型或其他下"
+"載方式。"
+
+msgid "Click here to display these alternative versions."
+msgstr "按此來顯示其他的版本。"
+
+msgid "Click to Download"
+msgstr "按此下載"
+
+msgid "Community"
+msgstr "連絡"
+
+msgid ""
+"Contains a large collection of software for desktop or server use.<br/"
+">Suitable for installation or upgrade."
+msgstr "包含了大批的軟體供桌面或伺服器使用。<br/>適用於安裝或升級。"
+
+msgid "Countdown"
+msgstr "倒數"
+
+msgid "Country"
+msgstr "國家"
+
+msgid "Development"
+msgstr "開發"
+
+msgid "Development Version"
+msgstr "開發版本"
+
+msgid "Development packages"
+msgstr "開發套件"
+
+msgid "Development-"
+msgstr "開發-"
+
+msgid "Direct Install"
+msgstr "直接安裝"
+
+msgid "Direct Link"
+msgstr "直接連結"
+
+msgid "Documentation"
+msgstr "文件"
+
+msgid "Don't show this warning the next time"
+msgstr "下次不要再顯示這則警告"
+
+msgid "Download"
+msgstr "下載"
+
+msgid "Download %s"
+msgstr "下載 %s"
+
+msgid "Download Help"
+msgstr "下載說明"
+
+msgid "Download Method"
+msgstr "下載方式"
+
+msgid "Download appliance from %s"
+msgstr "正在從 %s 下載應用"
+
+msgid "Download&nbsp;DVD"
+msgstr "下載&nbsp;DVD"
+
+msgid "Download&nbsp;GNOME"
+msgstr "下載&nbsp;GNOME"
+
+msgid "Download&nbsp;KDE"
+msgstr "下載&nbsp;KDE"
+
+msgid "Download&nbsp;Network"
+msgstr "下載&nbsp;網路"
+
+msgid "Download&nbsp;Rescue"
+msgstr "下載&nbsp;救援系統"
+
+msgid "Downloads"
+msgstr "下載"
+
+msgid ""
+"Downloads the installation system and all packages from online repositories."
+"<br/>Suitable for installation or upgrade."
+msgstr "從線上套件庫下載安裝系統與所有套件。<br/>適用於安裝或升級。"
+
+msgid "Expand all sections ('e')"
+msgstr "展開所有選項 ('e')"
+
+msgid "Extra Languages"
+msgstr "額外語言"
+
+msgid "Extra Languages (32 Bit)"
+msgstr "額外語言 (32 位元)"
+
+msgid "Extra Languages (64 Bit)"
+msgstr "額外語言 (64 位元)"
+
+msgid "For <strong>%s</strong> run the following as <strong>root</strong>:"
+msgstr "需要  <strong>%s</strong> ，用 <strong>root</strong> 執行："
+
+msgid "For <strong>%s</strong> run the following:"
+msgstr "需要  <strong>%s</strong> ，執行："
+
+msgid ""
+"For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following "
+"(note that the order of repositories in pacman.conf is important, since "
+"pacman always downloads the first found package):"
+msgstr ""
+"對於 <strong>Arch Linux</strong>，編輯 /etc/pacman.conf 並加入以下設定 (注意"
+"在 pacman.conf 中套件庫的順序是很重要的，因為 pacman 會下載第一個找到的套"
+"件)："
+
+msgid ""
+"For each ISO, we offer a checksum file with the corresponding SHA256 sum."
+msgstr "針對每一個 ISO ，我們提供了一個 checksum 檔案以及相對應的 SHA256 sum。"
+
+msgid ""
+"For extra security, you can use GPG to verify who signed those .sha256 "
+"files. It should be %s."
+msgstr ""
+"為更高等級的保全，您可以使用 GPG 來驗證誰簽署了這些 .sha256 檔。它應該是 %s。"
+
+msgid "Games"
+msgstr "遊戲"
+
+msgid "Get one of the specialized distributions built on openSUSE."
+msgstr "取得在 openSUSE 上建構的特別發行版本。"
+
+msgid "Getting Help"
+msgstr "取得幫助"
+
+msgid "Gold Sponsor"
+msgstr "黃金級贊助者"
+
+msgid "Grab binary packages directly"
+msgstr "直接抓取二進位套件"
+
+msgid "Header Logo"
+msgstr "頂部標誌"
+
+msgid "Help on Download Method"
+msgstr "下載方式說明"
+
+msgid "Help on Type of Computer"
+msgstr "電腦類型說明"
+
+msgid "How to Proceed"
+msgstr "如何進行"
+
+msgid ""
+"If you want to use a direct link but live in a place in the world where our "
+"download redirector has not enough information to redirect to the fastest "
+"mirror, you can pick a mirror yourself."
+msgstr ""
+"如果您想要使用直接連結，但住在我們的下載重導向沒有足夠資訊將您引導到最快鏡像"
+"的地方，您可以自己選擇一個鏡像。"
+
+msgid "Image:"
+msgstr "影像："
+
+msgid "Install package %s / %s"
+msgstr "安裝套件 %s / %s"
+
+msgid "Install pattern %s / %s"
+msgstr "安裝樣式 %s / %s"
+
+msgid "Install using One Click Install"
+msgstr "使用單鍵安裝"
+
+msgid "Installation Guides"
+msgstr "安裝指引"
+
+msgid "Installation Medium"
+msgstr "安裝媒體"
+
+msgid ""
+"Join the fast-growing community, put openSUSE into more hands by\n"
+"        getting the latest PromoDVD for your group, non-profit organization, "
+"school\n"
+"        university or event like LUG meetings, installfests, and "
+"conferences.\n"
+"        Promo DVDs help to increase awareness and visibility of openSUSE!"
+msgstr ""
+"參加快速成長的社群，將 openSUSE 放到更多人手上\\n        為您的小組，非營利組"
+"織，學校，大學 \\n        甚至像LUG(Linux user group) 聚會，安裝聚會，以及研"
+"討會申請宣傳 DVD。\\n        宣傳 DVD 有助於提升 openSUSE 的可見度！"
+
+msgid ""
+"Konqueror of KDE 3 is unfortunately unmaintained and its javascript "
+"implementation contains bugs that make it impossible to use with this page. "
+"Please make sure you have javascript disabled before you <a "
+"href='%s'>continue</a>."
+msgstr ""
+"KDE3 的 Konqueror 很不幸的已不再維護，而且他完成的 javascript 包含一些錯誤，"
+"造成他無法使用此頁面。 在您<a href='%s'>繼續</a>之前，請確認您停用了 "
+"javascript。"
+
+# label for language selection
+msgid "Language"
+msgstr "語言"
+
+msgid "Legacy 32 Bit PC"
+msgstr "舊型 32 位元 PC"
+
+msgid "Legacy 32&nbsp;Bit&nbsp;PC"
+msgstr "舊型 32&nbsp;位元&nbsp;PC"
+
+msgid "Live GNOME"
+msgstr "Live GNOME"
+
+msgid "Live KDE"
+msgstr "Live KDE"
+
+msgid ""
+"Many applications can verify the checksum of a download. To verify your "
+"download can be important as it verifies you really have got the ISO file "
+"you wanted to download and not some broken version."
+msgstr ""
+"很多應用程式可以確認下載的正確性。確認您的下載可以讓您確認您得到所要的 ISO 檔"
+"案而非損壞的版本。"
+
+msgid "Metalink"
+msgstr "Metalink"
+
+msgid "More information on burning the ISO file to CD/DVD"
+msgstr "關於燒錄 ISO 檔成 CD/DVD 的更多資訊"
+
+msgid ""
+"More information on creating a <a href='http://en.opensuse.org/"
+"Live_USB_stick'>bootable USB stick</a>"
+msgstr ""
+"關於建立 <a href='http://en.opensuse.org/Live_USB_stick'>可開機 USB 隨身碟</"
+"a> 的進一步資訊"
+
+msgid ""
+"More information on downloading openSUSE is available from the <a href="
+"\"http://en.opensuse.org/SDB:Download_help\">Download Help</a> and <a href="
+"\"http://en.opensuse.org/SDB:Network_installation\">Network Installation</a> "
+"pages in our <a href=\"http://en.opensuse.org/Portal:Documentation"
+"\">Documentation Wiki</a>."
+msgstr ""
+"更多關於下載 openSUSE 的資訊，可參考我們<a href=\"http://en.opensuse.org/"
+"Portal:Documentation\">文件 Wiki</a>的<a href=\"http://en.opensuse.org/SDB:"
+"Download_help\">下載說明</a> 以及 <a href=\"http://en.opensuse.org/SDB:"
+"Network_installation\">網路安裝</a> 頁面。"
+
+msgid ""
+"Most new computers support <a href=\"http://en.wikipedia.org/wiki/"
+"X86-64\">x86-64</a> (also known as AMD64 and Intel64), but some laptop "
+"processors and netbook processors do not support it. So you need to check "
+"wikipedia if you want to be sure your computer supports it."
+msgstr ""
+"大部分新的電腦支援 <a href=\"http://en.wikipedia.org/wiki/X86-64\">x86-64</"
+"a> (也被稱為 AMD64 和 Intel64)，但是有些筆記型電腦和迷你電腦處理器不支援。所"
+"以如果您想要確認您的電腦是否支援，您需要檢查一下 wikipedia。"
+
+msgid "Multimedia"
+msgstr "多媒體"
+
+msgid "Need help?"
+msgstr "需要幫助嗎？"
+
+msgid "Network"
+msgstr "網路"
+
+msgid "No appliance data for %s"
+msgstr "無 %s 的應用資料"
+
+msgid "No appliances found in project %s"
+msgstr "在專案 %s 未發現應用"
+
+msgid "No data for %s / %s"
+msgstr "%s / %s 無資料"
+
+msgid "No description found..."
+msgstr "沒有套件描述..."
+
+msgid "No downloads found for %s in project %s"
+msgstr "沒有發現 %s 的下載(在 %s 專案)"
+
+msgid "No packages found matching your search. "
+msgstr "沒有發現符合 搜尋條件的套件。"
+
+msgid "NonOSS CD"
+msgstr "NonOSS CD"
+
+msgid "OBS Backend not available"
+msgstr "OBS 後端無法使用"
+
+msgid "Official Manuals"
+msgstr "官方手冊"
+
+msgid ""
+"Only DVD and Network medias are fully tested. Alternatives, like live or "
+"rescue systems, are recommended for limited use only."
+msgstr ""
+"只有 DVD 與網路安裝媒體經過完整的測試。其他的版本如 live 或救援系統用媒體，建"
+"議只使用在特定的用途上。"
+
+msgid "Package %s not found..."
+msgstr "找不到套件 %s ..."
+
+msgid "Package Repositories"
+msgstr "套件庫"
+
+msgid "Package Search"
+msgstr "套件搜尋"
+
+msgid "Packages for %s:"
+msgstr "%s 的套件："
+
+msgid "Pick Mirror"
+msgstr "選擇鏡像"
+
+msgid "Platinum Sponsor"
+msgstr "白金級贊助者"
+
+msgid ""
+"Please be aware that the following packages are from unofficial "
+"repositories.\n"
+"  That means they are not reviewed by openSUSE and may contain unstable or "
+"experimental software."
+msgstr ""
+"請注意下列套件是由非官方套件庫所提供。\\n    這表示他們沒有被 openSUSE 所檢視"
+"過，可能會包含不穩定或實驗性的軟體。"
+
+msgid ""
+"Please enter a <b>brief</b> reason (in English!) why you need the DVDs and "
+"provide a link of the event/purpose."
+msgstr ""
+"請寫出一個 <b>簡明的</b> 理由 (用英文！) 為什麼您需要這些 DVD，並提供這個事"
+"件/目的的連結。"
+
+msgid ""
+"Please note that this is not the latest openSUSE release. You can get the "
+"latest version <a href='/'>here</a>. "
+msgstr ""
+"請注意這不是最新的 openSUSE 發行板。您可以由<a href='/'>這裡</a>取得最新的版"
+"本。"
+
+msgid ""
+"Promo DVDs and all the related artwork -labels and sleeve- can be\n"
+"        downloaded from the <a href=\"http://download.opensuse.org/promodvd/"
+"\">promodvd\n"
+"        download directory %s</a>. Keep in mind that this is a special "
+"version of openSUSE,\n"
+"        namely designed for promotional distribution."
+msgstr ""
+"推廣 DVD 和所有相關藝術作品 -標籤和封套- 可由\n"
+"        <a href=\"http://download.opensuse.org/promodvd/\">推廣 DVD\n"
+"        下載目錄 %s</a> 下載。請記得這是一個 openSUSE 的特別版，\n"
+"        顧名思義，是專為推廣發行設計的。"
+
+msgid "Related categories:"
+msgstr "相關分類："
+
+msgid "Released Version"
+msgstr "釋出版本"
+
+msgid "Reporting Bugs"
+msgstr "回報錯誤"
+
+msgid "Rescue"
+msgstr "救援系統"
+
+msgid ""
+"Rescue system that you can run from CD or from USB stick.<br/>Can not be "
+"used for installation or upgrade."
+msgstr "一個您可以由 CD 或 USB 隨身碟運行的救援系統。<br/>不可用來安裝或升級。"
+
+msgid "SHA256 checksum"
+msgstr "SHA256 checksum"
+
+msgid "Search"
+msgstr "搜尋"
+
+msgid "Select Your Operating System"
+msgstr "選擇您的作業系統"
+
+msgid "Select the image type"
+msgstr "選擇影像類型"
+
+msgid "Show"
+msgstr "顯示"
+
+msgid "Show development, language and debug packages"
+msgstr "顯示開發、語言及偵錯套件"
+
+msgid "Show distribution:"
+msgstr "顯示描述："
+
+msgid "Show more packages for unsupported distributions"
+msgstr "顯示更多套件(不支援的發行版本)"
+
+msgid "Show more..."
+msgstr "顯示更多..."
+
+msgid "Show other versions"
+msgstr "顯示其他版本"
+
+msgid "Show unstable packages"
+msgstr "顯示不穩定的套件"
+
+msgid "Show unsupported packages"
+msgstr "顯示不支援的套件"
+
+msgid "Silver Sponsor"
+msgstr "銀級贊助者"
+
+msgid ""
+"Some alternative media (eg. live and rescue systems) are also available, "
+"although they are less tested and recommended for limited use only."
+msgstr ""
+"一些其他的媒體 (例如 live 與救援系統) 也可供下載，然而它們並未經過完整測試，"
+"建議只使用在特定用途上。"
+
+msgid ""
+"Some of the live distributions based on openSUSE. Those interested in trying "
+"to build their own derivatives can take a look at <a href=\"http://"
+"susestudio.com/\">SUSE Studio</a>."
+msgstr ""
+"有些基於 openSUSE 的 Live 發行版本。對於想要嘗試建構自己的衍生產品的使用者可"
+"以參考一下<a href=\"http://susestudio.com/\">SUSE Studio</a>。"
+
+msgid "Source"
+msgstr "程式碼"
+
+msgid "Sponsored by"
+msgstr "贊助者："
+
+msgid "Sponsored by: AMD"
+msgstr "贊助者：AMD"
+
+msgid "Sponsored by: B1 Systems"
+msgstr "贊助者：B1 Systems"
+
+msgid "Sponsored by: Heinlein"
+msgstr "贊助者：Heinlein"
+
+msgid "Sponsored by: IP Exchange"
+msgstr "贊助者： IP Exchange"
+
+msgid "Sub-Packages"
+msgstr "子套件"
+
+msgid "Support"
+msgstr "支援"
+
+msgid ""
+"The installation process is available in many languages but, for most of "
+"them, the translation of the applications is not included in the image. If "
+"you want your openSUSE system to support some additional language, you need "
+"to download it from the Internet during the installation or any time after "
+"it. If you have easy access to the Internet you do not need this CD, but if "
+"you are planning to install openSUSE in some machine with no Internet "
+"connection, it will provide you access to all the available translations."
+msgstr ""
+"安裝程序可以選用許多的語言，但有許多語言的應用程式翻譯並未包含在此影像中。如"
+"果您希望您的 openSUSE 系統支援某些額外的語言，您需要在安裝過程或其他任何時候"
+"由網際網路下載其他語言支援。如果您可以輕鬆存取網際網路，您不需要這片 CD，但如"
+"果您計劃要將 openSUSE 安裝在沒有網路連線的機器，這片 CD 可以提供您所有可用的"
+"翻譯。"
+
+msgid "Then run the following as <strong>root</strong>"
+msgstr "然後用 <strong>root</strong> 執行："
+
+msgid ""
+"There is no openSUSE release in testing phase at the moment. <br/> If you "
+"want to use bleeding edge software, please use <a href='http://en.opensuse."
+"org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>."
+msgstr ""
+"目前沒有測試階段的 openSUSE 釋出版本。<br/>若您想要使用最新的軟體，請使用 <a "
+"href='http://en.opensuse.org/Portal:Tumbleweed'>openSUSE Tumbleweed</a>。"
+
+msgid ""
+"This CD contains free software distributed under proprietary licence not "
+"allowing its inclusion to main installation media together with free open-"
+"source software. All software from this CD could be downloaded from NON-OSS "
+"repository."
+msgstr ""
+"此 CD 包含了一些免費的軟體，這些軟體是以專利的授權發行，所以無法和自由的開源"
+"軟體一起包含在我們主要的安裝媒體上。所有此 CD 上的軟體都可以由 NON-OSS 套件庫"
+"中下載。"
+
+msgid ""
+"This version runs on all PCs including those that support 64 Bit. If you "
+"have more than 3 GB of RAM you should prefer the 64 Bit version though. "
+"openSUSE does not support processors before Pentium - the live CDs even "
+"support only i686 (Pentium Pro and later)."
+msgstr ""
+"此版本可以在所有 PC 上運行，包含那些支援 64 位元的。然而如果您有 3GB 以上的記"
+"憶體，您應該會較偏好使用 64 位元版本。openSUSE 不支援 Pentium 之前的處理器 - "
+"live CD 甚至僅支援 i686 (Pentium Pro 以及更新的）。"
+
+msgid "Type of Computer"
+msgstr "電腦類型"
+
+msgid "Unsupported distributions:"
+msgstr "不支援的發行版本："
+
+msgid ""
+"User manuals are available from <a href=\"http://activedoc.opensuse.org"
+"\">activedoc.opensuse.org</a>, for example the <a href=\"http://activedoc."
+"opensuse.org/book/opensuse-start-up/\">Official Start-Up Guide</a>."
+msgstr ""
+"使用者文件可由 <a href=\"http://activedoc.opensuse.org\">activedoc.opensuse."
+"org</a>取得，例如 <a href=\"http://activedoc.opensuse.org/book/opensuse-"
+"start-up/\">官方新手指引</a>。"
+
+msgid ""
+"Using <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> is "
+"recommended on slow links, especially when downloading the DVD image. "
+"BitTorrent downloads have several benefits, the clients protect against data "
+"corruption and you help relieving the load on the servers by participating "
+"in the upload - if enough people participate it will also be faster than the "
+"centralized servers - for everybody. Whatsmore, it allows you to stop the "
+"download at any time and resume it later."
+msgstr ""
+"使用 <a href=\"http://en.opensuse.org/SDB:BitTorrent\">BitTorrent</a> 是在緩"
+"慢連線的建議，尤其當在下載 DVD 影像時。BitTorrent 下載有數個好處，客戶端會保"
+"護資料免於錯誤，而且您可以藉由參與上傳而舒緩伺服器的負載 - 如果有夠多的人參"
+"與，他也將會比集中式伺服器快速 - 對每一個人。甚至，他允許您在任何時間停止下載"
+"並在之後繼續下載。"
+
+msgid "Verify your download before use"
+msgstr "使用前先確認您的下載"
+
+msgid "Version"
+msgstr "版本"
+
+msgid "We offer three different checksums:"
+msgstr "我們提供了三種不同的  checksums:"
+
+msgid ""
+"We would like you, to keep us informed about your usage of the DVDs, so we\n"
+"        can help you to promote your organization, event or school on our\n"
+"        <a href='http://news.opensuse.org' title='news.opensuse.org'>news "
+"page</a>\n"
+"        or other resources. (Hint! We love photos. Take lots of them!). "
+"Please contact us at\n"
+"        <a href='mailto:opensuse-marketing@opensuse.org'>opensuse-"
+"marketing@opensuse.org</a>\n"
+"        to discuss promotion and/or other ways we can assist you."
+msgstr ""
+"我們很希望您能讓我們知道您如何使用這些 DVD，使我們\\n        可以幫忙宣傳您的"
+"組織，活動，或學校，就在我們的\\n        <a href='http://news.opensuse.org' "
+"title='news.opensuse.org'>新聞頁面</a>\\n        或其他資源。 (提示！我們超愛"
+"照片，請儘量多拍一些！)。請用郵件列表\\n        <a href='mailto:opensuse-"
+"marketing@opensuse.org'>opensuse-marketing@opensuse.org</a>\\n        連繫我"
+"們或討論宣傳和/或 其他我們能幫助您的方式。"
+
+msgid ""
+"When downloading images other than the CD for network installation, it is "
+"<i>strongly</i> recommended to use a proper download manager to reduce the "
+"risk of corrupted data."
+msgstr ""
+"當下載影像（除了網路安裝 CD 外）時，我們 <i>強烈</i> 推薦您使用適當的下載管理"
+"員以減少資料錯誤的風險。"
+
+msgid ""
+"You can add the repository key to apt. Keep in mind that the owner of the "
+"key may distribute updates, packages and repositories that your system will "
+"trust (<a href=\"%s\">more information</a>). To add the key, run:"
+msgstr ""
+"您可以加入套件庫金鑰至 apt。請記住金鑰所有人也會分發您的系統將會信任的更新、"
+"套件和套件庫 (詳見<a href=\"%s\">更多資訊</a>)。要加入金鑰，請執行："
+
+msgid ""
+"You could try to extend your search to development packages or search for "
+"another base distribution (currently )."
+msgstr "您可以試著擴充您的搜尋到開發套件，或 搜尋其他的基礎發行版本(目前)。"
+
+msgid ""
+"You could verify the file in the process of downloading. For example a "
+"checksum (SHA256) will be used automatically if you choose <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> in the field above and use the "
+"add-on DownThemAll! in <a href='http://en.opensuse.org/Firefox'>Firefox</a>."
+msgstr ""
+"您可以在下載過程中確認檔案。例如，如果您在 <a href='http://en.opensuse.org/"
+"Firefox'>Firefox</a> 中使用 DownThemAll! 附加元件下載上方的 <a href='http://"
+"en.opensuse.org/SDB:Metalink'>Metalink</a> ，checksum (SHA256) 將自動被使用。"
+
+msgid "gpg signature"
+msgstr "gpg 簽名"
+
+msgid "http://doc.opensuse.org/"
+msgstr "http://doc.opensuse.org/"
+
+msgid "http://en.opensuse.org/Derivatives"
+msgstr "http://en.opensuse.org/Derivatives"
+
+msgid "http://en.opensuse.org/Package_repositories"
+msgstr "http://en.opensuse.org/Package_repositories"
+
+msgid "http://en.opensuse.org/Portal:Installation"
+msgstr "http://en.opensuse.org/Portal:Installation"
+
+msgid "http://en.opensuse.org/SDB:Download_help"
+msgstr "http://en.opensuse.org/SDB:Download_help"
+
+msgid "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+msgstr "http://en.opensuse.org/SDB:Download_help#Burn_the_ISO_image.28s.29"
+
+msgid "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+msgstr "http://en.opensuse.org/openSUSE:Submitting_bug_reports"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.2/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.3/"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.1"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2"
+
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+#, fuzzy
+#| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.2/"
+msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1/"
+
+msgid ""
+"is still the most commonly used checksum. Many ISO burners display it right "
+"before burning."
+msgstr "仍是最常被使用的 checksum。很多 ISO 燒錄軟體會在燒錄前顯示它。"
+
+msgid "is the less known but more secure checksum than md5."
+msgstr "是比較不這麼有名但是比 md5 更安全。"
+
+msgid "md5 checksum"
+msgstr "md5 checksum"
+
+msgid ""
+"offers the most security as you can verify who signed it. It should be <tt>"
+"%s</tt>."
+msgstr "提供了最安全的等級，您可以確認是誰簽署的。它應該是 <tt>%s</tt>。"
+
+msgid "openSUSE Countdown"
+msgstr "openSUSE  倒數計時器"
+
+msgid "openSUSE Derivatives"
+msgstr "openSUSE 衍生產品"
+
+msgid ""
+"openSUSE is available via http (direct link) or BitTorrent. The CD for "
+"network installation is only available via http."
+msgstr ""
+"openSUSE 可以經由 http (直接連結) 或 BitTorrent 取得。網路安裝 CD 僅能經由 "
+"http 取得。"
+
+msgid "openSUSE only supports PCs with 32 Bits and 64 Bits."
+msgstr "openSUSE 僅支援 32 位元與 64 位元的 PC"
+
+msgid "see Derivatives on wiki"
+msgstr "參考 wiki 上的衍生產品"
+
+msgid "sha1 checksum"
+msgstr "sha1 checksum"
+
+msgid "switch to"
+msgstr "切換到"
+
+#~ msgid "An internal error happened :-("
+#~ msgstr "發生內部錯誤 :-("
+
+#~ msgid "Please enter more than 2 characters"
+#~ msgstr "請輸入至少兩個字"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/42.1"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#, fuzzy
+#~| msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap42.1/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/12.1/"
+
+#~ msgid "Last searches:"
+#~ msgstr "上次搜尋："
+
+#~ msgid "Statistics"
+#~ msgstr "統計"
+
+#~ msgid "Top 1-click downloads:"
+#~ msgstr "最多單鍵下載："
+
+#~ msgid "Top searches without hits:"
+#~ msgstr "最常搜尋："
+
+#~ msgid "Top searches:"
+#~ msgstr "最常搜尋："
+
+#~ msgid "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+#~ msgstr "https://doc.opensuse.org/release-notes/x86_64/openSUSE/13.2/"
+
+#~ msgid ""
+#~ "We currently don't have a Factory Snapshot that is more recent than our "
+#~ "last openSUSE release. <br/>Please check <a href='http://en.opensuse.org/"
+#~ "Portal:Factory'>http://en.opensuse.org/Portal:Factory</a> for more "
+#~ "information."
+#~ msgstr ""
+#~ "目前我們沒有比最近 openSUSE 正式發行版更新的 Factory 快照。<br/>請察看 <a "
+#~ "href='http://en.opensuse.org/Portal:Factory'>http://en.opensuse.org/"
+#~ "Portal:Factory</a> 以獲得更多資訊。"
+
+#~ msgid "You can add the repository key to apt like this: "
+#~ msgstr "您可以新增套件庫金鑰到 apt 像這樣： "
+
+#~ msgid "4.7GB DVD"
+#~ msgstr "4.7GB DVD"
+
+#~ msgid ""
+#~ "Live CDs contain only four languages (English, German, Russian and "
+#~ "Italian). If you want to have support for remaining languages you need to "
+#~ "download it from the Internet during the installation or any time after "
+#~ "it. If you have easy access to the Internet or if you use DVD containing "
+#~ "all languages, you do not need this CD."
+#~ msgstr ""
+#~ "Live CD 僅包含四種語言（英文、德文、俄文及義大利文）。如果您想要有其他語言"
+#~ "的支援，您必須在安裝過程中或安裝完後的任何時間由網際網路下載。如果您可以輕"
+#~ "鬆存取網路或您使用了包含所有語言的 DVD，您就不需要此 CD。"
+
+#~ msgid ""
+#~ "After having successfully downloaded the ISO image(s), burn the image(s) "
+#~ "with your favorite burning application to a DVD or CD. Please do <em>not</"
+#~ "em> burn a data DVD/CD, but rather choose the option to burn an ISO image."
+#~ msgstr ""
+#~ "在您已成功下載 ISO 影像後，使用您最喜歡的燒錄應用程式燒錄影像成 DVD 或 "
+#~ "CD。 請千萬 <em>不要</em> 燒錄成資料 DVD/CD，而要選擇燒錄 ISO 影像的選項。"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.3/RELEASE-NOTES.en.html"
+
+#~ msgid "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+#~ msgstr ""
+#~ "http://www.suse.de/relnotes/i386/openSUSE/11.4/RELEASE-NOTES.en.html"
+
+#~ msgid "Please use search strings of at least 2 characters"
+#~ msgstr "搜尋字串請使用至少兩個字"
+
+#~ msgid "Switched to exact match due to too many hits on substring search."
+#~ msgstr "切換到完全符合，因為有太多筆搜尋結果"
+
+#~ msgid "Please be more precise in your search, search limit reached."
+#~ msgstr "請再更精確的描述您的搜尋。"
+
+#~ msgid "Could not perform search: "
+#~ msgstr "無法進行搜尋："
+
+#~ msgid "Popular Software"
+#~ msgstr "最受歡迎軟體"
+
+#~ msgid "Buy openSUSE"
+#~ msgstr "購買 openSUSE"
+
+#~ msgid "http://en.opensuse.org/Buy_openSUSE"
+#~ msgstr "http://en.opensuse.org/Buy_openSUSE"
+
+#~ msgid "1-Click Install"
+#~ msgstr "單鍵安裝"
+
+#~ msgid "Manual Package Download"
+#~ msgstr "手動套件下載"
+
+#~ msgid "Go to OBS Project"
+#~ msgstr "連到 OBS 計畫"
+
+#~ msgid "[Software collection]"
+#~ msgstr "[軟體集合]"
+
+#~ msgid "Search Results"
+#~ msgstr "搜尋結果"
+
+#~ msgid ""
+#~ "No packages found in the openSUSE build service that matched your query."
+#~ msgstr "在 openSUSE build service 中沒有發現符合您查詢的套件。"
+
+#~ msgid "%d collections and %d binaries from %d source packages"
+#~ msgstr "%d 個集合與 %d 個二位元檔由 %d 個來源套件"
+
+#~ msgid "Screenshot of  "
+#~ msgstr "螢幕截圖"
+
+#~ msgid "Search Statistics:"
+#~ msgstr "搜尋統計："
+
+#~ msgid "Download Statistics:"
+#~ msgstr "下載統計："
+
+#~ msgid ""
+#~ "Search and install software packages from the <a href=\"http://build."
+#~ "opensuse.org\">openSUSE Build Service</a>:"
+#~ msgstr ""
+#~ "由  <a href=\"http://build.opensuse.org\">openSUSE Build Service </a>搜尋"
+#~ "並安裝軟體套件："
+
+#~ msgid "Search options"
+#~ msgstr "搜尋選項"
+
+#~ msgid "Include users' home projects"
+#~ msgstr "包含使用者的 home projects"
+
+#~ msgid "Exclude debug packages"
+#~ msgstr "排除 debug 套件"
+
+#~ msgid "Additional Information"
+#~ msgstr "其他資訊"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2"
+#~ msgid "Buy openSUSE 11.3"
+#~ msgstr "購買 openSUSE 11.2"
+
+#, fuzzy
+#~| msgid "Buy openSUSE 11.2!"
+#~ msgid "Buy openSUSE 11.3!"
+#~ msgstr "購買 openSUSE 11.2！"
+
+#, fuzzy
+#~| msgid ""
+#~| "More information on downloading openSUSE is available from the <a href="
+#~| "\"http://en.opensuse.org/Download_Help\">Download Help.</a>"
+#~ msgid ""
+#~ "More information on downloading openSUSE is available from the <a href="
+#~ "\"http://en.opensuse.org/SDB:Download_help\">Download Help.</a>"
+#~ msgstr ""
+#~ "更多關於下載 openSUSE 的資訊，請參考 <a href=\"http://en.opensuse.org/"
+#~ "Download_Help\">下載說明</a>。"
+
+#~ msgid "Instructions are available as follows:"
+#~ msgstr "可在下面找到教學指引："
+
+#~ msgid "Installation from DVD/CD:"
+#~ msgstr "由 DVD/CD 安裝："
+
+#~ msgid "Official %s Start-Up guide"
+#~ msgstr "官方 %s 新手指引"
+
+#~ msgid "Step-by-step installation guide"
+#~ msgstr "詳細步驟安裝指引"
+
+# dialog title for nfs installation
+#~ msgid "Network Installation"
+#~ msgstr "網路安裝"
+
+#, fuzzy
+#~| msgid "http://en.opensuse.org/Derivatives"
+#~ msgid "http://en.opensuse.org/SDB:Network_installation"
+#~ msgstr "http://en.opensuse.org/Derivatives"
+
+#~ msgid "Internet Installation"
+#~ msgstr "網際網路安裝"
+
+#~ msgid "More information"
+#~ msgstr "更多資訊"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Local"
+#~ msgstr "http://en.opensuse.org/INSTALL_Local"
+
+#~ msgid "http://en.opensuse.org/INSTALL_Internet"
+#~ msgstr "http://en.opensuse.org/INSTALL_Internet"
+
+#~ msgid "Get Software"
+#~ msgstr "取得軟體"
+
+#~ msgid "Wiki"
+#~ msgstr "Wiki"
+
+#~ msgid "Build Software"
+#~ msgstr "建構軟體"
+
+#~ msgid "User Directory"
+#~ msgstr "使用者目錄"
+
+#~ msgid "Features"
+#~ msgstr "特色"
+
+#~ msgid "News"
+#~ msgstr "新聞"
+
+#~ msgid "Forums"
+#~ msgstr "論壇"
+
+#~ msgid "Shop"
+#~ msgstr "商店"
+
+#~ msgid "Software"
+#~ msgstr "軟體"
+
+#~ msgid "Software Search"
+#~ msgstr "軟體搜尋"
+
+#~ msgid "Update Repositories"
+#~ msgstr "更新套件庫"
+
+#~ msgid "Source Repository"
+#~ msgstr "原碼套件庫"
+
+# button label for other/more options
+#~ msgid "Other Options"
+#~ msgstr "其他選項"
+
+#~ msgid "Mirrors"
+#~ msgstr "鏡像"
+
+#, fuzzy
+#~ msgid "In other languages"
+#~ msgstr "選取語言。"
+
+#~ msgid "Get it"
+#~ msgstr "取得"
+
+#~ msgid "Search Build Service"
+#~ msgstr "搜尋 Build Service"
+
+#~ msgid ""
+#~ "Search for and install additional software packages from the openSUSE "
+#~ "Build Service."
+#~ msgstr "由 openSUSE Build Service 搜尋並安裝附加的軟體套件。"
+
+#~ msgid "Get openSUSE"
+#~ msgstr "取得 openSUSE"
+
+#~ msgid "Permanent link to this result"
+#~ msgstr "此結果的永久連結"
+
+#~ msgid "Nothing found"
+#~ msgstr "找不到喔"
+
+#~ msgid "Get Software from the openSUSE Build Service"
+#~ msgstr "由 openSUSE Build Service 取得軟體"
+
+#~ msgid "Searching"
+#~ msgstr "正在搜尋"
+
+#~ msgid ""
+#~ "Contains a large collection of software for desktop or server use. "
+#~ "Suitable for installation or upgrade."
+#~ msgstr "包含了大批的軟體收集供桌面或伺服器使用。適用於安裝或升級。"
+
+#~ msgid ""
+#~ "A GNOME desktop you can run from CD or from USB stick. Can be installed "
+#~ "as is (no upgrade)."
+#~ msgstr ""
+#~ "一個您可以由 CD 或 USB 隨身碟運行的 GNOME 桌面。也可以安裝（不是升級）。"
+
+#~ msgid ""
+#~ "A KDE desktop you can run from CD or from USB stick. Can be installed as "
+#~ "is (no upgrade)."
+#~ msgstr ""
+#~ "一個您可以由 CD 或 USB 隨身碟運行的 KDE 桌面。也可以安裝（不是升級）。"
+
+#~ msgid ""
+#~ "Downloads the installation system and all packages from online "
+#~ "repositories.  Suitable for installation or upgrade."
+#~ msgstr "從線上套件庫下載安裝系統與所有套件。適用於安裝或升級。"
+
+#~ msgid "Metalinks"
+#~ msgstr "Metalinks"
+
+#, fuzzy
+#~ msgid "Buy openSUSE 11.2!<br /> "
+#~ msgstr "購買 openSUSE 11.1！"
+
+#~ msgid ""
+#~ "For users new to Linux, the supported version of openSUSE may be the best "
+#~ "choice&mdash;you'll get complete end-user documentation, installable "
+#~ "media for 32 Bit and 64 Bit systems, plus 90 days of end-user "
+#~ "installation support."
+#~ msgstr ""
+#~ "對剛接觸 Linux 的新手，有支援版本的 openSUSE 是您的最佳選擇&mdash;您將得到"
+#~ "完整的終端使用者文件，32 位元與 64 位元的可安裝媒體，加上 90 天的終端使用"
+#~ "者安裝支援。"
+
+#~ msgid ""
+#~ "openSUSE 11.1 is available at several <a href=\"http://en.opensuse.org/"
+#~ "Buy_openSUSE\">online</a> shops or at local resellers."
+#~ msgstr ""
+#~ "openSUSE 11.1 可以在下列 <a href=\"http://en.opensuse.org/Buy_openSUSE\">"
+#~ "線上</a> 商店或地區經銷商購買。"
+
+#~ msgid "Expert view"
+#~ msgstr "專家檢視"
+
+#~ msgid ""
+#~ "x86: Computers with e.g. AMD&reg; Sempron or Intel&reg; Celeron&trade;, "
+#~ "almost all desktop computers dating 2004 or earlier. This version also "
+#~ "runs on 64bit PCs."
+#~ msgstr ""
+#~ "x86: 使用例如 AMD&reg; Sempron 或 Intel&reg; Celeron&trade;的電腦，幾乎所"
+#~ "有在 2004 或之前的桌上型電腦。這個版本也可以運行在 64位元 PC。"
+
+#~ msgid ""
+#~ "x86-64: Most new computers with e.g. AMD&reg;: Opteron&trade;, "
+#~ "Turion&trade; 64, Athlon&trade; 64, or Intel&reg;: Core&trade;2, "
+#~ "Pentium&reg; 4 6xx, Pentium&reg; D CPUs."
+#~ msgstr ""
+#~ "x86-64: 大部分新的使用例如 AMD&reg;: Opteron&trade;, Turion&trade; 64, "
+#~ "Athlon&trade; 64, 或 Intel&reg;: Core&trade;2, Pentium&reg; 4 6xx, "
+#~ "Pentium&reg; D CPU 的電腦。"
+
+#~ msgid ""
+#~ "The smallest medium (around 100MB) downloads installation system and "
+#~ "software from the online repositories."
+#~ msgstr "最小媒體(約 100MB) 從線上套件庫下載安裝系統與軟體。"
+
+#~ msgid ""
+#~ "To download a medium, choose from the installation ways, possibly change "
+#~ "the architecture and the download way and choose \"Save file\"."
+#~ msgstr ""
+#~ "要下載一個媒體，請由安裝方式選擇，可能您會要變更架構和下載方法，最後選擇 "
+#~ "\"儲存檔案\"。"
+
+#~ msgid "Help"
+#~ msgstr "說明"
+
+#~ msgid "Live CD with GNOME desktop"
+#~ msgstr "使用 GNOME 桌面的 Live CD"
+
+#~ msgid "Live CD with KDE desktop"
+#~ msgstr "使用 KDE 桌面的 Live CD"
+
+#~ msgid "Network installation for experts"
+#~ msgstr "專家使用網路安裝"


### PR DESCRIPTION
To get feedback. Do not merge yet. For the pull request to be complete it should also include `software.pot`, all the `software.po` files (one per language) and an adapted `.gitignore.`

@stanislav-brabec asked me to adapt software.o.o for its migration to Weblate.
- .pot and a .po file for each language will live in this repo.
- Weblate will automatically push .po files when translations are modified.
- To update the .po files the option `--previous` must be used when calling `msgmerge`
- No more `lcn-xxx.sh`

As said, if nobody opposes to the changes in the Rake tasks, I will add another commit adding the .po and .pot files.
