### PR TITLE
Fix retrieval of appdata (again)

### DIFF
--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -1,5 +1,3 @@
-require 'open-uri'
-
 class Appdata
 
   def self.get dist="factory"
@@ -37,10 +35,7 @@ class Appdata
   # Get the appdata xml for a distribution
   def self.get_distribution dist="factory", flavour="oss"
     if dist == "factory"
-      appdata_regex = /appdata-\S{32}.xml.gz/
-      tumbleweed_contents = open("http://download.opensuse.org/tumbleweed/repo/#{flavour}/content") {|f| f.read }
-      appdata_filename = tumbleweed_contents.match(appdata_regex)
-      appdata_url = "http://download.opensuse.org/tumbleweed/repo/#{flavour}/suse/setup/descr/#{appdata_filename}"
+      appdata_url = "http://download.opensuse.org/tumbleweed/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
     else
       appdata_url = "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
     end


### PR DESCRIPTION
The hash needed to be removed from the filename again, as zypp and its
logic to find appdata did not work at all

In order to achieve the original goal of being able to mirror appdata.xml.gz
more logic was added to OBS and a symlink technique is being employed.