### PR TITLE
Fix #100 and #120

### DIFF
--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -43,7 +43,7 @@ class PackageController < ApplicationController
     @packages.each do |package|
 
       if ( package.repository.match(/Tumbleweed/) || (package.project == "openSUSE:Tumbleweed") )
-        package.baseproject = "openSUSE:Tumbleweed"
+        package.baseproject = "openSUSE:Factory"
       elsif ( package.project.match( /openSUSE:Evergreen/ ) )
         package.baseproject = package.project
       elsif ( package.repository.match( /^Factory$/i ) )

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 class Appdata
 
   def self.get dist="factory"
@@ -39,17 +41,11 @@ class Appdata
     else
       appdata_url = "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
     end
-    begin
-      appdata = ApiConnect::get appdata_url
-    rescue
-      # never ever die when remote is not working or file is not there
-    end
-    zipfilename = File.join( Rails.root.join('tmp'), "appdata-" + dist + ".xml.gz" )
     filename = File.join( Rails.root.join('tmp'), "appdata-" + dist + ".xml" )
-    File.open(zipfilename, "w+", :encoding => 'ascii-8bit') do |f|
-      f.write(appdata.body) if appdata
-    end 
-    `gunzip -f #{zipfilename}`
+    open(filename, 'wb') do |file|
+      # Gzip data will be automatically decompressed with open-uri
+      file << open(appdata_url).read
+    end
     xmlfile = File.open(filename)
     doc = Nokogiri::XML(xmlfile)
     xmlfile.close


### PR DESCRIPTION
Move "Tumbleweed" from unsupported to supported distrobutions while won't produce duplicate "Tumbleweed" with Factory. In result, Tumbleweed has higher priority than Factory. If a OBS project provides both Tumbleweed and Factory builds, Tumbleweed build will be used.

![spectacle r18360](https://cloud.githubusercontent.com/assets/5836790/21962046/67570f0a-db23-11e6-92d5-bd2fe0d10f87.png)

Fix #100 
Fix #120