### PR TITLE
Implement fallback to locale without underscore

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,9 +35,15 @@ class ApplicationController < ActionController::Base
 
   def set_language
     set_gettext_locale
-    unless LANGUAGES.include? FastGettext.locale
-      params[:locale] = FastGettext.default_locale
-      set_gettext_locale
+    requested_locale = FastGettext.locale
+    # if we don't have translations for the requested locale, try
+    # the short form without underscore
+    unless LANGUAGES.include? requested_locale
+      requested_locale = requested_locale.split('_').first
+      if LANGUAGES.include? requested_locale
+        params[:locale] = requested_locale
+        set_gettext_locale
+      end
     end
     @lang = FastGettext.locale
   end

--- a/app/views/layouts/jekyll.html.erb
+++ b/app/views/layouts/jekyll.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= @lang %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Some browsers seem to send e.g. 'de', while other send 'de_DE'.