### PR TITLE
Use new OBS URL scheme for project/show and package/show

### DIFF
--- a/app/views/package/_download_rows.html.erb
+++ b/app/views/package/_download_rows.html.erb
@@ -9,9 +9,9 @@
     end
 
     if result.last.first.package.nil?
-      pkg_link = "https://build.opensuse.org/project/show?project=#{CGI.escape result.first}"
+      pkg_link = "https://build.opensuse.org/project/show/#{CGI.escape result.first}"
     else
-      pkg_link =  "https://build.opensuse.org/package/show?project=#{CGI.escape result.first}&package=#{CGI.escape result.last.first.package}"
+      pkg_link =  "https://build.opensuse.org/package/show/#{CGI.escape result.first}/#{CGI.escape result.last.first.package}"
     end -%>
     <%= link_to name, pkg_link %>
 


### PR DESCRIPTION
OBS does not support project/show?project= and package/show?project=&package=
schemes anymore. THis commit fixes those URLs.

I might have missed a few other instances of the same issue.
Also note that I didn't test this change.