### PR TITLE
Enable cops related to whitespaces and blank lines

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -890,17 +890,6 @@ Style/TernaryParentheses:
   Exclude:
     - 'app/controllers/search_controller.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: final_newline, final_blank_line
-Style/TrailingBlankLines:
-  Exclude:
-    - 'Rakefile'
-    - 'app/controllers/package_controller.rb'
-    - 'test/integration/download_distro_test.rb'
-    - 'test/integration/package_information_test.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -875,13 +875,6 @@ Style/SymbolProc:
     - 'app/models/seeker.rb'
     - 'lib/activexml/node.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-Style/Tab:
-  Exclude:
-    - 'lib/activexml/node.rb'
-    - 'lib/activexml/transport.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, AllowSafeAssignment.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -909,21 +909,6 @@ Style/TrailingCommaInLiteral:
   Exclude:
     - 'app/controllers/package_controller.rb'
 
-# Offense count: 30
-# Cop supports --auto-correct.
-Style/TrailingWhitespace:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/download_controller.rb'
-    - 'app/controllers/main_controller.rb'
-    - 'app/controllers/package_controller.rb'
-    - 'app/helpers/package_helper.rb'
-    - 'app/models/seeker.rb'
-    - 'lib/activexml/node.rb'
-    - 'lib/activexml/transport.rb'
-    - 'test/integration/download_distro_test.rb'
-    - 'test/integration/package_information_test.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, Whitelist.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -731,17 +731,6 @@ Style/SingleLineMethods:
   Exclude:
     - 'test/functional/search_controller_test.rb'
 
-# Offense count: 21
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: space, no_space
-Style/SpaceAroundEqualsInParameterDefault:
-  Exclude:
-    - 'app/models/appdata.rb'
-    - 'app/models/seeker.rb'
-    - 'lib/activexml/node.rb'
-    - 'lib/activexml/transport.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/SpaceAroundKeyword:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -812,13 +812,6 @@ Style/SpaceInsideBlockBraces:
     - 'lib/activexml/node.rb'
     - 'lib/activexml/transport.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/SpaceInsideBrackets:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/package_controller.rb'
-
 # Offense count: 29
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SupportedStylesForEmptyBraces.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -812,18 +812,6 @@ Style/SpaceInsideBlockBraces:
     - 'lib/activexml/node.rb'
     - 'lib/activexml/transport.rb'
 
-# Offense count: 29
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SupportedStylesForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Style/SpaceInsideHashLiteralBraces:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/download_controller.rb'
-    - 'app/controllers/package_controller.rb'
-    - 'lib/activexml/transport.rb'
-
 # Offense count: 446
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -831,22 +831,6 @@ Style/SpaceInsideHashLiteralBraces:
     - 'app/controllers/package_controller.rb'
     - 'lib/activexml/transport.rb'
 
-# Offense count: 181
-# Cop supports --auto-correct.
-Style/SpaceInsideParens:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/download_controller.rb'
-    - 'app/controllers/main_controller.rb'
-    - 'app/controllers/package_controller.rb'
-    - 'app/helpers/package_helper.rb'
-    - 'app/models/appdata.rb'
-    - 'app/models/screenshot.rb'
-    - 'app/models/seeker.rb'
-    - 'lib/activexml/node.rb'
-    - 'lib/activexml/transport.rb'
-    - 'lib/api_connect.rb'
-
 # Offense count: 446
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -731,17 +731,6 @@ Style/SingleLineMethods:
   Exclude:
     - 'test/functional/search_controller_test.rb'
 
-# Offense count: 15
-# Cop supports --auto-correct.
-Style/SpaceAfterComma:
-  Exclude:
-    - 'app/controllers/download_controller.rb'
-    - 'app/helpers/package_helper.rb'
-    - 'app/helpers/search_helper.rb'
-    - 'app/models/seeker.rb'
-    - 'lib/activexml/matcher.rb'
-    - 'lib/activexml/transport.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 Style/SpaceAfterMethodName:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -731,13 +731,6 @@ Style/SingleLineMethods:
   Exclude:
     - 'test/functional/search_controller_test.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/SpaceAfterMethodName:
-  Exclude:
-    - 'app/helpers/package_helper.rb'
-    - 'lib/activexml/node.rb'
-
 # Offense count: 21
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -738,20 +738,6 @@ Style/SpaceAroundKeyword:
     - 'app/models/seeker.rb'
     - 'lib/activexml/node.rb'
 
-# Offense count: 26
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment.
-Style/SpaceAroundOperators:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/download_controller.rb'
-    - 'app/controllers/package_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/package_helper.rb'
-    - 'app/models/seeker.rb'
-    - 'lib/activexml/matcher.rb'
-    - 'lib/activexml/node.rb'
-
 # Offense count: 44
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,3 @@ require File.expand_path('../config/application', __FILE__)
 SoftwareOO::Application.load_tasks
 
 require(File.join(File.dirname(__FILE__), 'config', 'boot'))
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_baseproject
-    unless ( @distributions.blank? || @distributions.select{|d| d[:project] == cookies[:search_baseproject]}.blank? )
+    unless (@distributions.blank? || @distributions.select{|d| d[:project] == cookies[:search_baseproject]}.blank?)
       @baseproject = cookies[:search_baseproject]
     end
   end
@@ -129,9 +129,9 @@ class ApplicationController < ActionController::Base
     @search_unsupported = params[:search_unsupported] unless params[:search_unsupported].blank?
     #FIXME: remove @search_unsupported when redesigning search options
     @search_unsupported = "true"
-    @search_devel = ( @search_devel == "true" ? true : false )
+    @search_devel = (@search_devel == "true" ? true : false)
     @search_project = params[:search_project]
-    @search_unsupported = ( @search_unsupported == "true" ? true : false )
+    @search_unsupported = (@search_unsupported == "true" ? true : false)
     @exclude_debug = @search_devel ? false : true
     @exclude_filter = @search_unsupported ? nil : 'home:'
     cookies[:search_devel] = { :value => @search_devel, :expires => 1.year.from_now }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   before_filter :set_language
   before_filter :set_distributions
   before_filter :set_baseproject
-  
+
   helper :all # include all helpers, all the time
   require "rexml/document"
 
@@ -70,7 +70,7 @@ class ApplicationController < ActionController::Base
       doc = REXML::Document.new response.body
       doc.elements.each("distributions/distribution") { |element|
         dist = Hash[:name => element.elements['name'].text, :project => element.elements['project'].text,
-          :reponame => element.elements['reponame'].text, :repository => element.elements['repository'].text, 
+          :reponame => element.elements['reponame'].text, :repository => element.elements['repository'].text,
           :dist_id => element.attributes['id'].sub(".", "") ]
         @distributions << dist
         logger.debug "Added Distribution: #{dist[:name]}"
@@ -107,7 +107,6 @@ class ApplicationController < ActionController::Base
       end
     end
   end
-  
 
   def valid_package_name? name
     name =~ /^[[:alnum:]][-+\w\.:\@]*$/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,7 +97,7 @@ class ApplicationController < ActionController::Base
         json
       end
     end
-    render({:content_type => "application/javascript", :body => response}.merge(options))
+    render({ :content_type => "application/javascript", :body => response }.merge(options))
   end
 
   def required_parameters(*parameters)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,11 +71,11 @@ class ApplicationController < ActionController::Base
       doc.elements.each("distributions/distribution") { |element|
         dist = Hash[:name => element.elements['name'].text, :project => element.elements['project'].text,
           :reponame => element.elements['reponame'].text, :repository => element.elements['repository'].text,
-          :dist_id => element.attributes['id'].sub(".", "") ]
+          :dist_id => element.attributes['id'].sub(".", "")]
         @distributions << dist
         logger.debug "Added Distribution: #{dist[:name]}"
       }
-      @distributions << Hash[:name => "ALL Distributions", :project => 'ALL' ]
+      @distributions << Hash[:name => "ALL Distributions", :project => 'ALL']
     rescue Exception => e
       logger.error "Error while loading distributions: " + e.to_s
       @distributions = nil

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -19,7 +19,7 @@ class DownloadController < ApplicationController
       xpath = "/directory/entry"
       if api_result_images
         doc = REXML::Document.new api_result_images.body
-        data = Hash.new 
+        data = Hash.new
         doc.elements.each(xpath) do |e|
           filename = e.attributes['name']
           if (File.extname(filename) == '.bz2')
@@ -79,7 +79,6 @@ class DownloadController < ApplicationController
     render_page :package
   end
 
-  
   def pattern
     required_parameters :project, :pattern
     @project = params[:project]

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -23,7 +23,7 @@ class DownloadController < ApplicationController
         doc.elements.each(xpath) do |e|
           filename = e.attributes['name']
           if (File.extname(filename) == '.bz2')
-            data[filename] = {:flavor => get_image_type(filename)}
+            data[filename] = { :flavor => get_image_type(filename) }
           end
 
         end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -23,7 +23,7 @@ class DownloadController < ApplicationController
         doc.elements.each(xpath) do |e|
           filename = e.attributes['name']
           if (File.extname(filename) == '.bz2')
-            data[filename] = {:flavor => get_image_type( filename )}
+            data[filename] = {:flavor => get_image_type(filename)}
           end
 
         end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -177,7 +177,7 @@ class DownloadController < ApplicationController
       head :forbidden
     else
       # collect distro types from @data
-      @flavors = @data.values.collect { |i| i[:flavor] }.uniq.sort{|x,y| x.downcase <=> y.downcase }
+      @flavors = @data.values.collect { |i| i[:flavor] }.uniq.sort{|x, y| x.downcase <=> y.downcase }
     end
   end
 

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -10,7 +10,7 @@ class MainController < ApplicationController
     path = "/published/#{params[:project]}/#{params[:repository]}/#{params[:arch]}/#{params[:binary]}?view=ymp"
     DownloadHistory.create :query => params[:query], :base => params[:base],
       :ymp => path
-    res =  Rails.cache.fetch( "ymp_#{path}", :expires_in => 1.hour) do
+    res =  Rails.cache.fetch("ymp_#{path}", :expires_in => 1.hour) do
       ApiConnect::get(path)
     end
     render :body => res.body, :content_type => res.content_type
@@ -193,7 +193,7 @@ class MainController < ApplicationController
     if request.user_agent && request.user_agent.index('Mozilla/5.0 (compatible; Konqueror/3')
       notice = _("Konqueror of KDE 3 is unfortunately unmaintained and its javascript implementation contains bugs that " +
           "make it impossible to use with this page. Please make sure you have javascript disabled before you " +
-          "<a href='%s'>continue</a>.") % url_for( :action => 'release', :release => release, :locale => FastGettext.locale )
+          "<a href='%s'>continue</a>.") % url_for(:action => 'release', :release => release, :locale => FastGettext.locale)
       notice = notice.html_safe
       render :template => "main/redirect_with_notice", :locals => { :notice => notice }
       return

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -254,7 +254,7 @@ class MainController < ApplicationController
               end
 
     suffix = ".iso"
-    
+
     case
     when params[:protocol] == "torrent"
       if params[:medium] != "net"

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -10,7 +10,7 @@ class PackageController < ApplicationController
     required_parameters :package
     @pkgname = params[:package]
     raise MissingParameterError, "Invalid parameter package" unless valid_package_name? @pkgname
-    
+
     @search_term = params[:search_term]
     @base_appdata_project = "openSUSE:Factory"
 
@@ -99,7 +99,7 @@ class PackageController < ApplicationController
   end
 
   private
-  
+
   def image pkgname, type, image_url
     response.headers['Cache-Control'] = "public, max-age=#{2.months.to_i}"
     response.headers['Content-Disposition'] = 'inline'
@@ -120,4 +120,4 @@ class PackageController < ApplicationController
   end
 
 end
- 
+

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -27,7 +27,7 @@ class PackageController < ApplicationController
                        end
 
     pkg_appdata = @appdata[:apps].select{|app| app[:pkgname].downcase == @pkgname.downcase}
-    if ( !pkg_appdata.first.blank? )
+    if (!pkg_appdata.first.blank?)
       @name = pkg_appdata.first[:name]
       @appcategories = pkg_appdata.first[:categories]
       @homepage = pkg_appdata.first[:homepage]
@@ -42,18 +42,18 @@ class PackageController < ApplicationController
 
     @packages.each do |package|
 
-      if ( package.repository.match(/Tumbleweed/) || (package.project == "openSUSE:Tumbleweed") )
+      if (package.repository.match(/Tumbleweed/) || (package.project == "openSUSE:Tumbleweed"))
         package.baseproject = "openSUSE:Factory"
-      elsif ( package.project.match( /openSUSE:Evergreen/ ) )
+      elsif (package.project.match(/openSUSE:Evergreen/))
         package.baseproject = package.project
-      elsif ( package.repository.match( /^Factory$/i ) )
+      elsif (package.repository.match(/^Factory$/i))
         package.baseproject = "openSUSE:Factory"
-      elsif ( package.repository.match( /^\d{2}\.\d$/ ) )
+      elsif (package.repository.match(/^\d{2}\.\d$/))
         package.baseproject = "openSUSE:" + package.repository
-      elsif ( !(@distributions.map{|d| d[:reponame]}.include? package.repository) &&
+      elsif (!(@distributions.map{|d| d[:reponame]}.include? package.repository) &&
             (package.repository != "standard") &&
             (package.repository != "snapshot") &&
-            (!package.repository.match(/_Update$/)) )
+            (!package.repository.match(/_Update$/)))
         logger.info("Found non-std repo: #{package.repository}")
         package.baseproject = package.repository.gsub("_", ":")
       end
@@ -75,9 +75,9 @@ class PackageController < ApplicationController
     raise MissingParameterError, "Invalid parameter category" unless valid_package_name? @category
 
     mapping = @main_sections.select{|s| s[:id].downcase == @category.downcase }
-    categories = ( mapping.blank? ? [@category] : mapping.first[:categories] )
+    categories = (mapping.blank? ? [@category] : mapping.first[:categories])
 
-    app_pkgs = @appdata[:apps].select{|app| !( app[:categories].map{|c| c.downcase} & categories.map{|c| c.downcase} ).blank? }
+    app_pkgs = @appdata[:apps].select{|app| !(app[:categories].map{|c| c.downcase} & categories.map{|c| c.downcase}).blank? }
     @packagenames = app_pkgs.map{|p| p[:pkgname]}.uniq.sort_by {|x| @appdata[:apps].select{|a| a[:pkgname] == x}.first[:name] }
 
     app_categories = app_pkgs.map{|p| p[:categories]}.flatten

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -114,7 +114,7 @@ class PackageController < ApplicationController
       {:name => "Education & Science", :id => "Education", :categories => ["Education", "Science"]},
       {:name => "Development", :id => "Development", :categories => ["Development"]},
       {:name => "Office & Productivity", :id => "Office", :categories => ["Office"]},
-      {:name => "Tools", :id => "Tools", :categories => [ "Network", "Settings", "System", "Utility"]},
+      {:name => "Tools", :id => "Tools", :categories => ["Network", "Settings", "System", "Utility"]},
       {:name => "Multimedia", :id => "Multimedia", :categories => ["AudioVideo", "Audio", "Video", "Graphics"]},
     ]
   end

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -62,7 +62,7 @@ class PackageController < ApplicationController
     @official_projects = @distributions.map{|d| d[:project]}
     #get extra distributions that are not in the default distribution list
     @extra_packages = @packages.reject{|p| @distributions.map{|d| d[:project]}.include? p.baseproject }
-    @extra_dists = @extra_packages.map{|p| p.baseproject}.reject{|d| d.nil?}.uniq.map{|d| {:project => d}}
+    @extra_dists = @extra_packages.map{|p| p.baseproject}.reject{|d| d.nil?}.uniq.map{|d| { :project => d }}
 
   end
 
@@ -81,7 +81,7 @@ class PackageController < ApplicationController
     @packagenames = app_pkgs.map{|p| p[:pkgname]}.uniq.sort_by {|x| @appdata[:apps].select{|a| a[:pkgname] == x}.first[:name] }
 
     app_categories = app_pkgs.map{|p| p[:categories]}.flatten
-    @related_categories = app_categories.uniq.map{|c| {:name => c, :weight => app_categories.select {|v| v == c }.size } }
+    @related_categories = app_categories.uniq.map{|c| { :name => c, :weight => app_categories.select {|v| v == c }.size } }
     @related_categories = @related_categories.sort_by { |c| c[:weight] }.reverse.reject{|c| categories.include? c[:name] }
     @related_categories = @related_categories.reject{|c| ["GNOME", "KDE", "Qt", "GTK"].include? c[:name] }
 
@@ -110,12 +110,12 @@ class PackageController < ApplicationController
 
   def set_categories
     @main_sections = [
-      {:name => "Games", :id => "Games", :categories => ["Game"]},
-      {:name => "Education & Science", :id => "Education", :categories => ["Education", "Science"]},
-      {:name => "Development", :id => "Development", :categories => ["Development"]},
-      {:name => "Office & Productivity", :id => "Office", :categories => ["Office"]},
-      {:name => "Tools", :id => "Tools", :categories => ["Network", "Settings", "System", "Utility"]},
-      {:name => "Multimedia", :id => "Multimedia", :categories => ["AudioVideo", "Audio", "Video", "Graphics"]},
+      { :name => "Games", :id => "Games", :categories => ["Game"] },
+      { :name => "Education & Science", :id => "Education", :categories => ["Education", "Science"] },
+      { :name => "Development", :id => "Development", :categories => ["Development"] },
+      { :name => "Office & Productivity", :id => "Office", :categories => ["Office"] },
+      { :name => "Tools", :id => "Tools", :categories => ["Network", "Settings", "System", "Utility"] },
+      { :name => "Multimedia", :id => "Multimedia", :categories => ["AudioVideo", "Audio", "Video", "Graphics"] },
     ]
   end
 

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -120,4 +120,3 @@ class PackageController < ApplicationController
   end
 
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,17 +21,17 @@ module ApplicationHelper
   def fuzzy_time_string(time)
     return "unknown date" if time.blank?
     return "now" if time_diff(time) < 60
-    diff = Integer(time_diff(time)/60) # now minutes
+    diff = Integer(time_diff(time) / 60) # now minutes
     return diff.to_s + (diff == 1 ? " min ago" : " mins ago") if diff < 60
-    diff = Integer(diff/60) # now hours
+    diff = Integer(diff / 60) # now hours
     return diff.to_s + (diff == 1 ? " hour ago" : " hours ago") if diff < 24
-    diff = Integer(diff/24) # now days
+    diff = Integer(diff / 24) # now days
     return diff.to_s + (diff == 1 ? " day ago" : " days ago") if diff < 14
-    diff = Integer(diff/7) # now weeks
+    diff = Integer(diff / 7) # now weeks
     return diff.to_s + (diff == 1 ? " week ago" : " weeks ago") if diff < 9
-    diff = Integer(diff/4.1) # roughly months
+    diff = Integer(diff / 4.1) # roughly months
     return diff.to_s + " months ago" if diff < 24
-    diff = Integer(diff/12) # years
+    diff = Integer(diff / 12) # years
     return diff.to_s + " years ago"
   end
 

--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -29,7 +29,7 @@ module PackageHelper
     txt
   end
 
-  def create_links (txt)
+  def create_links(txt)
     txt = txt.gsub(/(https?:\/\/[-_A-Za-z0-9\/\(\)\[\]:,.;?&+@#%=~|]+[^),. <"'\n\r])/m, '<a href="\1">\1</a> ')
     txt
   end

--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -19,7 +19,7 @@ module PackageHelper
   end
 
   def shorten(text, chars)
-    text.length > chars ? text[0, chars-2] + "..." : text
+    text.length > chars ? text[0, chars - 2] + "..." : text
   end
 
   def prepare_desc txt

--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -1,16 +1,15 @@
 module PackageHelper
-  
   def human_arch arch
     case arch
-    when ( "i586" ) then 
+    when ( "i586" ) then
       "32 Bit"
     when ( "i386" ) then
       "32 Bit"
-    when ("x86_64") then 
+    when ("x86_64") then
       "64 Bit"
     when ("amd64") then
       "64 Bit"
-    when ("src") then 
+    when ("src") then
       _("Source")
     when ("nosrc") then
       _("Source")

--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -1,9 +1,9 @@
 module PackageHelper
   def human_arch arch
     case arch
-    when ( "i586" ) then
+    when ("i586") then
       "32 Bit"
-    when ( "i386" ) then
+    when ("i386") then
       "32 Bit"
     when ("x86_64") then
       "64 Bit"

--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -19,7 +19,7 @@ module PackageHelper
   end
 
   def shorten(text, chars)
-    text.length > chars ? text[0,chars-2] + "..." : text
+    text.length > chars ? text[0, chars-2] + "..." : text
   end
 
   def prepare_desc txt

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -2,7 +2,7 @@
 module SearchHelper
 
   def prepare_desc(desc)
-    desc.gsub(/([\w.]+)@([\w.]+)/,'\1 [at] xxx').gsub(/\n/, "<br/>")
+    desc.gsub(/([\w.]+)@([\w.]+)/, '\1 [at] xxx').gsub(/\n/, "<br/>")
   end
 
   def default_baseproject

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -2,7 +2,7 @@ require 'open-uri'
 
 class Appdata
 
-  def self.get dist="factory"
+  def self.get dist = "factory"
     data = Hash.new
     xml = Appdata.get_distribution dist, "oss"
     data = add_appdata data, xml
@@ -33,7 +33,7 @@ class Appdata
   end
 
   # Get the appdata xml for a distribution
-  def self.get_distribution dist="factory", flavour="oss"
+  def self.get_distribution dist = "factory", flavour = "oss"
     appdata_url = if dist == "factory"
                     "http://download.opensuse.org/tumbleweed/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
                   else

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -39,7 +39,7 @@ class Appdata
                   else
                     "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
                   end
-    filename = File.join( Rails.root.join('tmp'), "appdata-" + dist + ".xml" )
+    filename = File.join(Rails.root.join('tmp'), "appdata-" + dist + ".xml")
     open(filename, 'wb') do |file|
       # Gzip data will be automatically decompressed with open-uri
       file << open(appdata_url).read

--- a/app/models/screenshot.rb
+++ b/app/models/screenshot.rb
@@ -124,7 +124,7 @@ protected
 
   def thumbnail_file_path(fullpath: true)
     file = "thumbnails/#{pkg_name}.png"
-    fullpath ? File.join( Rails.root, "public", "images", file) : file
+    fullpath ? File.join(Rails.root, "public", "images", file) : file
   end
 
   def default_file_path(type, fullpath: true)

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -78,7 +78,7 @@ class Seeker < ActiveXML::Node
     # page index starts with 1
     def page(idx)
       return [] if idx > page_count
-      page = self[@page_length*(idx-1), @page_length]
+      page = self[@page_length * (idx - 1), @page_length]
       page.each do |item|
         item.description
       end
@@ -86,7 +86,7 @@ class Seeker < ActiveXML::Node
     end
 
     def page_count
-      ((self.length-1)/@page_length)+1
+      ((self.length - 1) / @page_length) + 1
     end
 
     def add_binlist(binlist)
@@ -207,8 +207,8 @@ class Seeker < ActiveXML::Node
       def calculate_relevance
         quoted_query = Regexp.quote @query
         @relevance_calculated = true
-        @relevance += 15 if name =~/^#{quoted_query}$/i
-        @relevance += 5 if name =~/^#{quoted_query}/i
+        @relevance += 15 if name =~ /^#{quoted_query}$/i
+        @relevance += 5 if name =~ /^#{quoted_query}/i
         @relevance += 15 if project =~ /^openSUSE:/i
         @relevance += 5 if project =~ /^#{quoted_query}$/i
         @relevance += 2 if project =~ /^#{quoted_query}/i
@@ -362,7 +362,7 @@ class Seeker < ActiveXML::Node
       end
 
       def __key
-        @__key ||= @fragment_type.to_s+"|"+%w(project repository name).map{|x| self[x]}.join('|')
+        @__key ||= @fragment_type.to_s + "|" + %w(project repository name).map{|x| self[x]}.join('|')
       end
 
       def dump

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -8,7 +8,7 @@ class Seeker < ActiveXML::Node
     cache_key += "_#{exclude_filter}" if exclude_filter
     cache_key += "_#{exclude_debug}" if exclude_debug
     cache_key += "_#{project}" if project
-    cache_key = 'searchresult_' + Digest::MD5.hexdigest( cache_key ).to_s
+    cache_key = 'searchresult_' + Digest::MD5.hexdigest(cache_key).to_s
     Rails.cache.fetch(cache_key, :expires_in => 120.minutes) do
       SearchResult.search(query, baseproject, project, exclude_filter, exclude_debug)
     end
@@ -26,10 +26,10 @@ class Seeker < ActiveXML::Node
       xpath_items = Array.new
       xpath_items << "@project = '#{project}' " unless project.blank?
       substring_words = words.select{|word| !word.match(/^".+"$/) }.map{|word| "'#{word.gsub(/['"()]/, "")}'"}.join(", ")
-      unless ( substring_words.blank? )
+      unless (substring_words.blank?)
         xpath_items << "contains-ic(@name, " + substring_words + ")"
       end
-      words.select{|word| word.match(/^".+"$/) }.map{|word| word.gsub( "\"", "" ) }.each do |word|
+      words.select{|word| word.match(/^".+"$/) }.map{|word| word.gsub("\"", "") }.each do |word|
         xpath_items << "@name = '#{word.gsub(/['"()]/, "")}' "
       end
       xpath_items << "path/project='#{baseproject}'" unless baseproject.blank?
@@ -41,14 +41,14 @@ class Seeker < ActiveXML::Node
 
       bin = Seeker.find :binary, :match => xpath
       #pat = Seeker.find :pattern, :match => xpath
-      raise "Backend not responding" if( bin.nil? )
+      raise "Backend not responding" if(bin.nil?)
 
       result = new(query)
       #result.add_patlist(pat)
       result.add_binlist(bin)
 
       # remove this hack when the backend can filter for project names
-      result.reject!{|res| /#{exclude_filter}/.match( res.project ) } if (!exclude_filter.blank? && project.blank?)
+      result.reject!{|res| /#{exclude_filter}/.match(res.project) } if (!exclude_filter.blank? && project.blank?)
       result.sort! {|x,y| y.relevance <=> x.relevance}
       logger.info "Seeker found #{result.size} results"
       return result

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -2,7 +2,7 @@ require 'digest/md5'
 
 class Seeker < ActiveXML::Node
 
-  def self.prepare_result(query, baseproject=nil, project=nil, exclude_filter=nil, exclude_debug=false)
+  def self.prepare_result(query, baseproject = nil, project = nil, exclude_filter = nil, exclude_debug = false)
     cache_key = query
     cache_key += "_#{baseproject}" if baseproject
     cache_key += "_#{exclude_filter}" if exclude_filter
@@ -17,7 +17,7 @@ class Seeker < ActiveXML::Node
   class InvalidSearchTerm < Exception; end
 
   class SearchResult < Array
-    def self.search(query, baseproject, project=nil, exclude_filter=nil, exclude_debug=false)
+    def self.search(query, baseproject, project = nil, exclude_filter = nil, exclude_debug = false)
       words = query.split(" ").select {|part| !part.match(/^[0-9_\.-]+$/) }
       versrel = query.split(" ").select {|part| part.match(/^[0-9_\.-]+$/) }
       logger.debug "splitted words and versrel: #{words.inspect} #{versrel.inspect}"

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -49,7 +49,7 @@ class Seeker < ActiveXML::Node
 
       # remove this hack when the backend can filter for project names
       result.reject!{|res| /#{exclude_filter}/.match(res.project) } if (!exclude_filter.blank? && project.blank?)
-      result.sort! {|x,y| y.relevance <=> x.relevance}
+      result.sort! {|x, y| y.relevance <=> x.relevance}
       logger.info "Seeker found #{result.size} results"
       return result
     end
@@ -78,7 +78,7 @@ class Seeker < ActiveXML::Node
     # page index starts with 1
     def page(idx)
       return [] if idx > page_count
-      page = self[@page_length*(idx-1),@page_length]
+      page = self[@page_length*(idx-1), @page_length]
       page.each do |item|
         item.description
       end
@@ -367,7 +367,7 @@ class Seeker < ActiveXML::Node
 
       def dump
         out = "<ul>"
-        each do |key,val|
+        each do |key, val|
           out << "<li><b>#{key}:</b> #{val}</li>x"
         end
         out << "</ul>"
@@ -375,14 +375,14 @@ class Seeker < ActiveXML::Node
       end
 
       def type(*args)
-        method_missing(:type,*args)
+        method_missing(:type, *args)
       end
 
-      def method_missing(symbol,*args,&block)
+      def method_missing(symbol, *args, &block)
         if self.has_key? symbol.to_s
           return self[symbol.to_s]
         end
-        super(symbol,*args,&block)
+        super(symbol, *args, &block)
       end
     end
 

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -35,7 +35,7 @@ class Seeker < ActiveXML::Node
       xpath_items << "path/project='#{baseproject}'" unless baseproject.blank?
       xpath_items << "not(contains-ic(@project, '#{exclude_filter}'))" if (!exclude_filter.blank? && project.blank?)
       xpath_items << versrel.map {|part| "starts-with(@versrel,'#{part}')"}.join(" and ") unless versrel.blank?
-      xpath_items << "not(contains-ic(@name, '-debuginfo')) and not(contains-ic(@name, '-debugsource')) " + 
+      xpath_items << "not(contains-ic(@name, '-debuginfo')) and not(contains-ic(@name, '-debugsource')) " +
         "and not(contains-ic(@name, '-devel')) and not(contains-ic(@name, '-lang'))" if exclude_debug
       xpath = xpath_items.join(' and ')
 
@@ -185,7 +185,7 @@ class Seeker < ActiveXML::Node
       def logger
         Rails.logger
       end
-      
+
       private
 
       def cache_data(element)
@@ -316,7 +316,7 @@ class Seeker < ActiveXML::Node
         @quality = "" unless @quality
         @quality
       end
-      
+
     end
 
     class Pattern < Item
@@ -329,7 +329,7 @@ class Seeker < ActiveXML::Node
         # pattern bonus
         @relevance += 20
       end
-      
+
       def cache_specific_data(element)
         @filename = element.filename.to_s
         @filepath = element.filepath.to_s

--- a/lib/activexml/matcher.rb
+++ b/lib/activexml/matcher.rb
@@ -238,7 +238,7 @@ module NodeMatcher #:nodoc:
       end
 
       if conditions[:before]
-        return false unless siblings[self_index+1..-1].detect do |s|
+        return false unless siblings[self_index + 1..-1].detect do |s|
           s != node && match(s, conditions[:before])
         end
       end

--- a/lib/activexml/matcher.rb
+++ b/lib/activexml/matcher.rb
@@ -6,7 +6,7 @@ module NodeMatcher #:nodoc:
       super()
       hash = { :content => hash } unless Hash === hash
       hash = keys_to_symbols(hash)
-      hash.each do |k,v|
+      hash.each do |k, v|
         case k
         when :tag, :content then
           # keys are valid, and require no further processing
@@ -17,7 +17,7 @@ module NodeMatcher #:nodoc:
           hash[k] = Conditions.new(v)
         when :children
           hash[k] = v = keys_to_symbols(v)
-          v.each do |key,value|
+          v.each do |key, value|
             case key
             when :count, :greater_than, :less_than
               # keys are valid, and require no further processing
@@ -244,7 +244,7 @@ module NodeMatcher #:nodoc:
       end
 
       if conditions[:after]
-        return false unless siblings[0,self_index].detect do |s|
+        return false unless siblings[0, self_index].detect do |s|
           s != node && match(s, conditions[:after])
         end
       end

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -8,7 +8,7 @@ module ActiveXML
   class NotFoundError < GeneralError; end
   class CreationError < GeneralError; end
   class ParseError < GeneralError; end
-  
+
   class Node
 
     @@elements = {}
@@ -148,7 +148,7 @@ module ActiveXML
               [objdata, params, obj.to_hash]
             end
 	    if fromcache
-	      logger.debug "returning #{args.inspect} from rails cache #{cache_key}"  
+	      logger.debug "returning #{args.inspect} from rails cache #{cache_key}"
 	    end
           else
             objdata, params = ActiveXML::transport.find( self, *args)
@@ -338,7 +338,7 @@ module ActiveXML
       #puts "to_hash #{self.class} #{x}"
       @hash_cache
     end
-    
+
     def to_json(*a)
       to_hash.to_json(*a)
     end
@@ -477,7 +477,7 @@ module ActiveXML
       return node
     end
 
-    def value( symbol ) 
+    def value( symbol )
       symbols = symbol.to_s
 
       if @hash_cache
@@ -498,11 +498,11 @@ module ActiveXML
       return @value_cache[symbols] = nil
     end
 
-    def find( symbol, &block ) 
+    def find( symbol, &block )
       symbols = symbol.to_s
       _data.xpath(symbols).each do |e|
         block.call(create_node_with_relations(e))
-      end 
+      end
     end
 
     def method_missing( symbol, *args, &block )
@@ -536,7 +536,7 @@ module ActiveXML
     end
 
     def move_after other
-      raise "NO GOOD IDEA!" unless _data.document == other.internal_data.document	    
+      raise "NO GOOD IDEA!" unless _data.document == other.internal_data.document
       # the naming of the API is a bit strange IMO
       _data.before(other.internal_data)
     end
@@ -546,7 +546,7 @@ module ActiveXML
       # the naming of the API is a bit strange IMO
       _data.after(other.internal_data)
     end
-    
+
     def find_matching(conds)
       return self if NodeMatcher.match(self, conds) == true
       self.each do |c|

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -65,7 +65,7 @@ module ActiveXML
       #transport object, gets defined according to configuration when Base is subclassed
       attr_reader :transport
 
-      def inherited( subclass )
+      def inherited(subclass)
         # called when a subclass is defined
         #Rails.logger.debug "Initializing ActiveXML model #{subclass}"
         subclass.instance_variable_set "@default_find_parameter", @default_find_parameter
@@ -74,7 +74,7 @@ module ActiveXML
 
       # setup the default parameter for find calls. If the first parameter to <Model>.find is a string,
       # the value of this string is used as value f
-      def default_find_parameter( sym )
+      def default_find_parameter(sym)
         @default_find_parameter = sym
       end
 
@@ -89,7 +89,7 @@ module ActiveXML
         @error
       end
 
-      def prepare_args( args )
+      def prepare_args(args)
         if args[0].kind_of? String
           args[1] ||= {}
           first_arg = args.shift
@@ -117,18 +117,18 @@ module ActiveXML
         return args
       end
 
-      def calc_key( args )
+      def calc_key(args)
         #Rails.logger.debug "Cache key for #{args.inspect}"
-        self.name + "_" + Digest::MD5.hexdigest( "2" + args.to_s )
+        self.name + "_" + Digest::MD5.hexdigest("2" + args.to_s)
       end
 
       def free_object_cache
         @@object_cache = {}
       end
 
-      def find_priv(cache_time, *args )
+      def find_priv(cache_time, *args)
         args = prepare_args(args)
-        cache_key = calc_key( args )
+        cache_key = calc_key(args)
         if cache_time
           obj = @@object_cache[cache_key]
           if obj
@@ -143,20 +143,20 @@ module ActiveXML
             fromcache = true
             objdata, params, objhash = Rails.cache.fetch(cache_key, :expires_in => cache_time) do
               fromcache = false
-              objdata, params = ActiveXML::transport.find( self, *args)
-              obj = self.new( objdata )
+              objdata, params = ActiveXML::transport.find(self, *args)
+              obj = self.new(objdata)
               [objdata, params, obj.to_hash]
             end
       if fromcache
         logger.debug "returning #{args.inspect} from rails cache #{cache_key}"
       end
           else
-            objdata, params = ActiveXML::transport.find( self, *args)
+            objdata, params = ActiveXML::transport.find(self, *args)
           end
-          obj = self.new( objdata ) unless obj
-          obj.instance_variable_set( '@cache_key', cache_key ) if cache_key
-          obj.instance_variable_set( '@init_options', params )
-          obj.instance_variable_set( '@hash_cache', objhash) if objhash
+          obj = self.new(objdata) unless obj
+          obj.instance_variable_set('@cache_key', cache_key) if cache_key
+          obj.instance_variable_set('@init_options', params)
+          obj.instance_variable_set('@hash_cache', objhash) if objhash
           @@object_cache[cache_key] = obj
           return obj
         rescue ActiveXML::Transport::NotFoundError
@@ -165,11 +165,11 @@ module ActiveXML
         end
       end
 
-      def find( *args )
-        find_priv(nil, *args )
+      def find(*args)
+        find_priv(nil, *args)
       end
 
-      def find_cached( *args )
+      def find_cached(*args)
         expires_in = 30.minutes
         if args.last.kind_of?(Hash) and args.last[:expires_in]
           expires_in = args.last[:expires_in]
@@ -178,13 +178,13 @@ module ActiveXML
         find_priv(expires_in, *args)
       end
 
-      def find_hashed( *args )
-        ret = find_cached( *args )
+      def find_hashed(*args)
+        ret = find_cached(*args)
         return {} unless ret
         ret.to_hash
       end
 
-      def free_cache( *args )
+      def free_cache(*args)
         # modify copy of args as it might be still used in the calling method
         free_args = args.dup
         options = free_args.last if free_args.last.kind_of?(Hash)
@@ -192,18 +192,18 @@ module ActiveXML
           free_args[free_args.length-1] = free_args.last.dup
           free_args.last.delete :expires_in
         end
-  free_args = prepare_args( free_args )
-        key = calc_key( free_args )
+  free_args = prepare_args(free_args)
+        key = calc_key(free_args)
   logger.debug "free_cache #{free_args.inspect} #{key}"
         @@object_cache.delete key
-        Rails.cache.delete( key )
+        Rails.cache.delete(key)
       end
 
     end
 
     #instance methods
 
-    def initialize( data )
+    def initialize(data)
       @init_options = {}
       if data.kind_of? Nokogiri::XML::Node
         @data = data
@@ -244,7 +244,7 @@ module ActiveXML
     end
     private :parse
 
-    def raw_data=( data )
+    def raw_data=(data)
       if data.kind_of? Nokogiri::XML::Node
         @data = data.clone
       else
@@ -385,7 +385,7 @@ module ActiveXML
       Node.new(xmlnode)
     end
 
-    def add_element ( element, attrs=nil )
+    def add_element (element, attrs=nil)
       raise "First argument must be an element name" if element.nil?
       el = _data.document.create_element(element)
       _data.add_child(el)
@@ -417,18 +417,18 @@ module ActiveXML
     #tests if a child element exists matching the given query.
     #query can either be an element name, an xpath, or any object
     #whose to_s method evaluates to an element name or xpath
-    def has_element?( query )
+    def has_element?(query)
       if @hash_cache && query.kind_of?(Symbol)
         return @hash_cache.has_key? query.to_s
       end
-      !find_first( query ).nil?
+      !find_first(query).nil?
     end
 
     def has_elements?
       return !_data.element_children.empty?
     end
 
-    def has_attribute?( query )
+    def has_attribute?(query)
       if @hash_cache && query.kind_of?(Symbol)
         return @hash_cache.has_key? query.to_s
       end
@@ -439,12 +439,12 @@ module ActiveXML
       !_data.attribute_nodes.empty?
     end
 
-    def delete_attribute( name )
+    def delete_attribute(name)
       cleanup_cache
       _data.remove_attribute(name.to_s)
     end
 
-    def delete_element( elem )
+    def delete_element(elem)
       if elem.kind_of? Node
         raise "NO GOOD IDEA!" unless _data.document == elem.internal_data.document
         elem.internal_data.remove
@@ -461,12 +461,12 @@ module ActiveXML
       cleanup_cache
     end
 
-    def set_attribute( name, value)
+    def set_attribute(name, value)
       cleanup_cache
       _data[name] = value
     end
 
-    def create_node_with_relations( element )
+    def create_node_with_relations(element)
       #FIXME: relation stuff should be taken into an extra module
       #puts element.name
       klass = self.class.get_class(element.name)
@@ -477,7 +477,7 @@ module ActiveXML
       return node
     end
 
-    def value( symbol )
+    def value(symbol)
       symbols = symbol.to_s
 
       if @hash_cache
@@ -498,18 +498,18 @@ module ActiveXML
       return @value_cache[symbols] = nil
     end
 
-    def find( symbol, &block )
+    def find(symbol, &block)
       symbols = symbol.to_s
       _data.xpath(symbols).each do |e|
         block.call(create_node_with_relations(e))
       end
     end
 
-    def method_missing( symbol, *args, &block )
+    def method_missing(symbol, *args, &block)
       #puts "called method: #{symbol}(#{args.map do |a| a.inspect end.join ', '})"
 
       symbols = symbol.to_s
-      if( symbols =~ /^each_(.*)$/ )
+      if(symbols =~ /^each_(.*)$/)
         elem = $1
         return [] if not has_element? elem
         result = Array.new
@@ -565,7 +565,7 @@ module ActiveXML
     @@object_cache = {}
 
     def name
-      method_missing( :name )
+      method_missing(:name)
     end
 
     def marshal_dump

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -385,7 +385,7 @@ module ActiveXML
       Node.new(xmlnode)
     end
 
-    def add_element(element, attrs=nil)
+    def add_element(element, attrs = nil)
       raise "First argument must be an element name" if element.nil?
       el = _data.document.create_element(element)
       _data.add_child(el)
@@ -576,7 +576,7 @@ module ActiveXML
       Rails.logger
     end
 
-    def save(opt={})
+    def save(opt = {})
       if opt[:create]
         @raw_data = ActiveXML::transport.create self, opt
         @data = nil
@@ -588,7 +588,7 @@ module ActiveXML
       return true
     end
 
-    def delete(opt={})
+    def delete(opt = {})
       #Rails.logger.debug "Delete #{self.class}, opt: #{opt.inspect}"
       ActiveXML::transport.delete self, opt
       free_cache

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -189,7 +189,7 @@ module ActiveXML
         free_args = args.dup
         options = free_args.last if free_args.last.kind_of?(Hash)
         if options && options[:expires_in]
-          free_args[free_args.length-1] = free_args.last.dup
+          free_args[free_args.length - 1] = free_args.last.dup
           free_args.last.delete :expires_in
         end
   free_args = prepare_args(free_args)
@@ -390,7 +390,7 @@ module ActiveXML
       el = _data.document.create_element(element)
       _data.add_child(el)
       attrs.each do |key, value|
-        el[key.to_s]=value.to_s
+        el[key.to_s] = value.to_s
       end if attrs.kind_of? Hash
       # you never know
       cleanup_cache

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -48,7 +48,7 @@ module ActiveXML
         doc
       end
 
-      def handles_xml_element (*elements)
+      def handles_xml_element(*elements)
         elements.each do |elem|
           @@elements[elem] = self
         end
@@ -281,7 +281,7 @@ module ActiveXML
       _data.content
     end
 
-    def text= (what)
+    def text=(what)
       _data.content = what
     end
 
@@ -385,7 +385,7 @@ module ActiveXML
       Node.new(xmlnode)
     end
 
-    def add_element (element, attrs=nil)
+    def add_element(element, attrs=nil)
       raise "First argument must be an element name" if element.nil?
       el = _data.document.create_element(element)
       _data.add_child(el)

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -134,7 +134,7 @@ module ActiveXML
           if obj
             logger.debug "returning #{args.inspect} from object_cache"
             return obj
-	  end
+    end
         end
 
         objhash = nil
@@ -147,9 +147,9 @@ module ActiveXML
               obj = self.new( objdata )
               [objdata, params, obj.to_hash]
             end
-	    if fromcache
-	      logger.debug "returning #{args.inspect} from rails cache #{cache_key}"
-	    end
+      if fromcache
+        logger.debug "returning #{args.inspect} from rails cache #{cache_key}"
+      end
           else
             objdata, params = ActiveXML::transport.find( self, *args)
           end
@@ -192,9 +192,9 @@ module ActiveXML
           free_args[free_args.length-1] = free_args.last.dup
           free_args.last.delete :expires_in
         end
-	free_args = prepare_args( free_args )
+  free_args = prepare_args( free_args )
         key = calc_key( free_args )
-	logger.debug "free_cache #{free_args.inspect} #{key}"
+  logger.debug "free_cache #{free_args.inspect} #{key}"
         @@object_cache.delete key
         Rails.cache.delete( key )
       end

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -63,7 +63,7 @@ module ActiveXML
     end
 
     def connect(model, target, opt={})
-      opt.each do |key,value|
+      opt.each do |key, value|
         opt[key] = URI(opt[key])
         replace_server_if_needed(opt[key])
       end

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -16,7 +16,7 @@ module ActiveXML
 
         #Rails.logger.debug "extract #{exception.class} #{exception.message}"
         begin
-          @xml = Xmlhash.parse( exception.message )
+          @xml = Xmlhash.parse(exception.message)
         rescue TypeError
           Rails.logger.error "Couldn't parse error xml: #{self.message[0..120]}"
         end
@@ -62,36 +62,36 @@ module ActiveXML
       Rails.logger
     end
 
-    def connect( model, target, opt={} )
+    def connect(model, target, opt={})
       opt.each do |key,value|
         opt[key] = URI(opt[key])
-        replace_server_if_needed( opt[key] )
+        replace_server_if_needed(opt[key])
       end
 
-      uri = URI( target )
-      replace_server_if_needed( uri )
+      uri = URI(target)
+      replace_server_if_needed(uri)
       #logger.debug "setting up transport for model #{model}: #{uri} opts: #{opt}"
       @mapping[model] = {:target_uri => uri, :opt => opt}
     end
 
-    def replace_server_if_needed( uri )
+    def replace_server_if_needed(uri)
       unless uri.host
         uri.scheme, uri.host, uri.port = @schema, @host, @port
       end
     end
 
-    def target_for( model )
+    def target_for(model)
       #logger.debug "retrieving target_uri for model '#{model.inspect}'"
       raise "Model #{model.inspect} is not configured" if not @mapping.has_key? model
       @mapping[model][:target_uri]
     end
 
-    def options_for( model )
+    def options_for(model)
       #logger.debug "retrieving option hash for model '#{model.inspect}'"
       @mapping[model][:opt]
     end
 
-    def initialize( schema, host, port )
+    def initialize(schema, host, port)
       @schema = schema
       @host = host
       @port = port
@@ -109,21 +109,21 @@ module ActiveXML
       @target_uri = uri
     end
 
-    def login( user, password )
+    def login(user, password)
       @http_header ||= Hash.new
-      @http_header['Authorization'] = 'Basic ' + Base64.encode64( "#{user}:#{password}" )
+      @http_header['Authorization'] = 'Basic ' + Base64.encode64("#{user}:#{password}")
     end
 
     # returns object
-    def find( model, *args )
+    def find(model, *args)
 
       logger.debug "[REST] find( #{model.inspect}, #{args.inspect} )"
       params = Hash.new
       data = nil
       own_mimetype = nil
       symbolified_model = model.name.downcase.to_sym
-      uri = target_for( symbolified_model )
-      options = options_for( symbolified_model )
+      uri = target_for(symbolified_model)
+      options = options_for(symbolified_model)
       case args[0]
       when Symbol
         #logger.debug "Transport.find: using symbol"
@@ -152,7 +152,7 @@ module ActiveXML
       logger.debug "params #{params.inspect}"
       logger.debug "uri is: #{uri}"
 
-      url = substitute_uri( uri, params )
+      url = substitute_uri(uri, params)
       if own_mimetype
         data = url.query
         url.query = nil
@@ -160,13 +160,13 @@ module ActiveXML
       #use get-method if no conditions defined <- no post-data is set.
       if data.nil?
         #logger.debug"[REST] Transport.find using GET-method"
-        objdata = http_do( 'get', url, :timeout => 300 )
+        objdata = http_do('get', url, :timeout => 300)
         raise RuntimeError.new("GET to %s returned no data" % url) if objdata.empty?
       else
         #use post-method
         logger.debug"[REST] Transport.find using POST-method"
         #logger.debug"[REST] POST-data as xml: #{data.to_s}"
-        objdata = http_do( 'post', url, :data => data.to_s, :content_type => own_mimetype)
+        objdata = http_do('post', url, :data => data.to_s, :content_type => own_mimetype)
         raise RuntimeError.new("POST to %s returned no data" % url) if objdata.empty?
       end
       objdata = objdata.force_encoding("UTF-8")
@@ -175,25 +175,25 @@ module ActiveXML
 
     def create(object, opt={})
       logger.debug "creating object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
-      url = substituted_uri_for( object, :create, opt )
+      url = substituted_uri_for(object, :create, opt)
       http_do 'post', url, :data => object.dump_xml
     end
 
     def save(object, opt={})
       logger.debug "saving object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
-      url = substituted_uri_for( object )
+      url = substituted_uri_for(object)
       http_do 'put', url, :data => object.dump_xml
     end
 
     def delete(object, opt={})
       logger.debug "delete object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
-      url = substituted_uri_for( object, :delete, opt )
+      url = substituted_uri_for(object, :delete, opt)
       http_do 'delete', url
     end
 
     # defines an additional header that is passed to the REST server on every subsequent request
     # e.g.: set_additional_header( "X-Username", "margarethe" )
-    def set_additional_header( key, value )
+    def set_additional_header(key, value)
       if value.nil? and @http_header.has_key? key
         @http_header[key] = nil
       end
@@ -202,14 +202,14 @@ module ActiveXML
     end
 
     # delete a header field set with set_additional_header
-    def delete_additional_header( key )
+    def delete_additional_header(key)
       if @http_header.has_key? key
         @http_header.delete key
       end
     end
 
     # TODO: get rid of this very thin wrapper
-    def direct_http( url, opt={} )
+    def direct_http(url, opt={})
       defaults = {:method => "GET"}
       opt = defaults.merge opt
 
@@ -219,7 +219,7 @@ module ActiveXML
     end
 
     #replaces the parameter parts in the uri from the config file with the correct values
-    def substitute_uri( uri, params )
+    def substitute_uri(uri, params)
 
       #logger.debug "[REST] reducing args: #{params.inspect}"
       params.delete(:conditions)
@@ -268,18 +268,18 @@ module ActiveXML
       return u
     end
 
-    def substituted_uri_for( object, path_id=nil, opt={} )
+    def substituted_uri_for(object, path_id=nil, opt={})
       symbolified_model = object.class.name.downcase.to_sym
       options = options_for(symbolified_model)
       uri = if path_id and options.has_key? path_id
         options[path_id]
             else
-        target_for( symbolified_model )
+        target_for(symbolified_model)
             end
-      substitute_uri( uri, object.instance_variable_get("@init_options").merge(opt) )
+      substitute_uri(uri, object.instance_variable_get("@init_options").merge(opt))
     end
 
-    def http_do( method, url, opt={} )
+    def http_do(method, url, opt={})
       # protect two http transactions happening at the same time - we're not thread safe here
       @mutex.lock
       defaults = {:timeout => 60}
@@ -386,10 +386,10 @@ module ActiveXML
         @mutex.unlock
       end
 
-      return handle_response( http_response )
+      return handle_response(http_response)
     end
 
-    def handle_response( http_response )
+    def handle_response(http_response)
       case http_response
       when Net::HTTPSuccess, Net::HTTPRedirection
         return http_response.read_body.force_encoding("UTF-8")

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -10,7 +10,7 @@ module ActiveXML
   class Transport
 
     class Error < StandardError
-      
+
       def parse!
         return @xml if @xml
 
@@ -408,6 +408,6 @@ module ActiveXML
       message = http_response.to_s if message.blank?
       raise Error, message.force_encoding("UTF-8")
     end
-    
+
   end
 end

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -20,7 +20,7 @@ module ActiveXML
         rescue TypeError
           Rails.logger.error "Couldn't parse error xml: #{self.message[0..120]}"
         end
-  @xml ||= {'summary' => self.message[0..120], 'code' => '500'}
+  @xml ||= { 'summary' => self.message[0..120], 'code' => '500' }
       end
 
       def api_exception
@@ -71,7 +71,7 @@ module ActiveXML
       uri = URI(target)
       replace_server_if_needed(uri)
       #logger.debug "setting up transport for model #{model}: #{uri} opts: #{opt}"
-      @mapping[model] = {:target_uri => uri, :opt => opt}
+      @mapping[model] = { :target_uri => uri, :opt => opt }
     end
 
     def replace_server_if_needed(uri)
@@ -96,7 +96,7 @@ module ActiveXML
       @host = host
       @port = port
       @default_servers ||= Hash.new
-      @http_header = {"Content-Type" => "text/plain", 'Accept-Encoding' => 'identity'}
+      @http_header = { "Content-Type" => "text/plain", 'Accept-Encoding' => 'identity' }
       # stores mapping information
       # key: symbolified model name
       # value: hash with keys :target_uri and :opt (arguments to connect method)
@@ -210,7 +210,7 @@ module ActiveXML
 
     # TODO: get rid of this very thin wrapper
     def direct_http(url, opt={})
-      defaults = {:method => "GET"}
+      defaults = { :method => "GET" }
       opt = defaults.merge opt
 
       logger.debug "--> direct_http url: #{url.inspect}"
@@ -282,7 +282,7 @@ module ActiveXML
     def http_do(method, url, opt={})
       # protect two http transactions happening at the same time - we're not thread safe here
       @mutex.lock
-      defaults = {:timeout => 60}
+      defaults = { :timeout => 60 }
       opt = defaults.merge opt
       max_retries = 1
 

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -20,7 +20,7 @@ module ActiveXML
         rescue TypeError
           Rails.logger.error "Couldn't parse error xml: #{self.message[0..120]}"
         end
-	@xml ||= {'summary' => self.message[0..120], 'code' => '500'}
+  @xml ||= {'summary' => self.message[0..120], 'code' => '500'}
       end
 
       def api_exception
@@ -31,7 +31,7 @@ module ActiveXML
       def summary
         parse!
         if @xml.has_key? 'summary'
-	  return @xml['summary']
+    return @xml['summary']
         else
           return self.message
         end
@@ -302,11 +302,11 @@ module ActiveXML
       when :put, :post, :delete
         @http.finish if @http && @http.started?
         @http = nil
-	keepalive = false
+  keepalive = false
       when :get
         # if the http existed before, we shall retry
         max_retries = 2 if @http
-	keepalive = true
+  keepalive = true
       end
       retries = 0
       begin
@@ -318,7 +318,7 @@ module ActiveXML
         end
         @http.read_timeout = opt[:timeout]
 
-	raise "url.path.nil" if url.path.nil?
+  raise "url.path.nil" if url.path.nil?
         path = url.path
         path += "?" + url.query if url.query
         logger.debug "http_do ##{retries}: method: #{method} url: " +

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -62,7 +62,7 @@ module ActiveXML
       Rails.logger
     end
 
-    def connect(model, target, opt={})
+    def connect(model, target, opt = {})
       opt.each do |key, value|
         opt[key] = URI(opt[key])
         replace_server_if_needed(opt[key])
@@ -173,19 +173,19 @@ module ActiveXML
       return [objdata, params]
     end
 
-    def create(object, opt={})
+    def create(object, opt = {})
       logger.debug "creating object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
       url = substituted_uri_for(object, :create, opt)
       http_do 'post', url, :data => object.dump_xml
     end
 
-    def save(object, opt={})
+    def save(object, opt = {})
       logger.debug "saving object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
       url = substituted_uri_for(object)
       http_do 'put', url, :data => object.dump_xml
     end
 
-    def delete(object, opt={})
+    def delete(object, opt = {})
       logger.debug "delete object #{object.class} (#{object.init_options.inspect}) to api:\n #{object.dump_xml}"
       url = substituted_uri_for(object, :delete, opt)
       http_do 'delete', url
@@ -209,7 +209,7 @@ module ActiveXML
     end
 
     # TODO: get rid of this very thin wrapper
-    def direct_http(url, opt={})
+    def direct_http(url, opt = {})
       defaults = { :method => "GET" }
       opt = defaults.merge opt
 
@@ -268,7 +268,7 @@ module ActiveXML
       return u
     end
 
-    def substituted_uri_for(object, path_id=nil, opt={})
+    def substituted_uri_for(object, path_id = nil, opt = {})
       symbolified_model = object.class.name.downcase.to_sym
       options = options_for(symbolified_model)
       uri = if path_id and options.has_key? path_id
@@ -279,7 +279,7 @@ module ActiveXML
       substitute_uri(uri, object.instance_variable_get("@init_options").merge(opt))
     end
 
-    def http_do(method, url, opt={})
+    def http_do(method, url, opt = {})
       # protect two http transactions happening at the same time - we're not thread safe here
       @mutex.lock
       defaults = { :timeout => 60 }

--- a/lib/api_connect.rb
+++ b/lib/api_connect.rb
@@ -4,7 +4,7 @@ class ApiConnect
 
   def self.get(path, limit = 10)
     uri_str = "#{CONFIG['api_host']}/#{path}".gsub(' ', '%20')
-    uri_str = path if path.match( /^http/ )
+    uri_str = path if path.match(/^http/)
     uri = URI.parse(uri_str)
     logger.debug "Loading from api: #{uri_str}"
     begin

--- a/test/integration/download_distro_test.rb
+++ b/test/integration/download_distro_test.rb
@@ -51,4 +51,3 @@ class DownloadDistroTest < ActionDispatch::IntegrationTest
     assert page.has_content? 'Download Rescue'
   end
 end
-

--- a/test/integration/download_distro_test.rb
+++ b/test/integration/download_distro_test.rb
@@ -13,7 +13,7 @@ class DownloadDistroTest < ActionDispatch::IntegrationTest
     choose '64 Bit PC'
     click_button "download_button"
     assert_match /^http:\/\/download.*DVD-x86_64.iso.torrent$/, evaluate_script("mylink")
-  end  
+  end
 
   def test_download_metalink
     find('#ci_gnome').click
@@ -21,7 +21,7 @@ class DownloadDistroTest < ActionDispatch::IntegrationTest
     choose 'i686'
     click_button "download_button"
     assert_match /^http:\/\/download.*GNOME-Live.*-i686.iso.meta4$/, evaluate_script("mylink")
-  end  
+  end
 
   def test_network_bittorrent
     # Choose kde BitTorrent download

--- a/test/integration/package_information_test.rb
+++ b/test/integration/package_information_test.rb
@@ -9,4 +9,3 @@ class PackageInformationTest < ActionDispatch::IntegrationTest
     assert page.has_content? 'InstantMessaging'
   end
 end
-

--- a/test/integration/package_information_test.rb
+++ b/test/integration/package_information_test.rb
@@ -7,6 +7,6 @@ class PackageInformationTest < ActionDispatch::IntegrationTest
     visit '/package/pidgin'
     assert page.has_content? 'Pidgin'
     assert page.has_content? 'InstantMessaging'
-  end  
+  end
 end
 


### PR DESCRIPTION
Enable cops related to whitespaces and blank lines and correct the offenses. The offenses were
automatically solved with the `auto-correct` option. :bowtie: 