### PR TITLE
Set correct Leap 42.2 urls for ppc64le isos

### DIFF
--- a/app/views/distributions/leap_ports.html.erb
+++ b/app/views/distributions/leap_ports.html.erb
@@ -32,48 +32,38 @@
         <tbody>
           <tr>
             <td>DVD/USB Stick</td>
-            <td>4.7GB</td>
+            <td>3.8GB</td>
             <td>
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso">
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.iso">
                 <%= _('Direct Link') %>
               </a>
               |
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso.torrent">
                 BitTorrent
-              </a>
               |
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso.meta4">
                 Metalink
-              </a>
               |
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso?mirrorlist">
                 <%= _('Pick Mirror') %>
-              </a>
             </td>
             <td>
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso.sha256">
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.sha256">
                 SHA256
               </a>
             </td>
           </tr>
           <tr>
             <td><%= _('Network') %> CD/USB Stick</td>
-            <td>85MB</td>
+            <td>67MB</td>
             <td>
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso">
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.iso">
                 <%= _('Direct Link') %>
               </a>
               |
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso.meta4">
                 Metalink
-              </a>
               |
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso?mirrorlist">
                 <%= _('Pick Mirror') %>
-              </a>
             </td>
             <td>
-              <a href="http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso.sha256">
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.sha256">
                 SHA256
               </a>
             </td>


### PR DESCRIPTION
a first patch to address issue 20400
https://progress.opensuse.org/issues/20400

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>