### PR TITLE
Honour RAILS_LOG_TO_STDOUT in config/environments/production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,4 +22,9 @@ SoftwareOO::Application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
 end


### PR DESCRIPTION
12-factor apps should log to `STDOUT`, so that the platform can capture the logs in a standard way.

This is already the case for newly created applications:
https://github.com/rails/rails/commit/e9b96f0d666adfd3484641a4a55feb1c774d3378

(software-o-o was created prior to this change).

With this change, Rails will still log by default to log/production.log, but if the platform sets `RAILS_LOG_TO_STDOUT`, it will be able to capture the logs.

In the same way, if the systemd unit `.service` file sets

```
Environment="RAILS_LOG_TO_STDOUT=1"
```

Then you will be able to control/see the logs with journalctl.