### PR TITLE
Better feedback on a wrongly configured (OBS auth) instance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ require 'net/https'
 
 class ApplicationController < ActionController::Base
 
+  before_action :validate_configuration
   before_action :set_language
   before_action :set_distributions
   before_action :set_baseproject
@@ -30,6 +31,16 @@ class ApplicationController < ActionController::Base
         logger.error exception.backtrace.join("\n")
       end
     render :template => 'error', :formats => [:html], :layout => layout, :status => 400
+  end
+
+  def validate_configuration
+    config = Rails.configuration.x
+    layout = request.xhr? ? false : "application"
+
+    if config.api_username.blank? && config.opensuse_cookie.blank?
+      @message = _("The authentication to the OBS API has not been configured correctly.")
+      render :template => 'error', :formats => [:html], :layout => layout, :status => 503
+    end
   end
 
   def set_language

--- a/app/views/error.html.erb
+++ b/app/views/error.html.erb
@@ -1,11 +1,8 @@
-<% @page_title = "Error" -%>
+<% @page_title = "Error" if @page_title.blank? -%>
 
-<div class="box box-shadow">
-  <h2 class="box-header">
-    <span class="alignleft"><%= @page_title -%></span></h2>
-  <div>
-
+<div class="container">
+  <h2Y<%= @page_title -%></h2>
+  <div class="alert alert-danger">
     <p><%=h @message %></p>
-
   </div>
 </div>

--- a/config/options.yml
+++ b/config/options.yml
@@ -2,21 +2,17 @@ defaults: &defaults
   api_host: https://api.opensuse.org
   api_username: test
   api_password: test
-  relative_url_root: 
-
+  relative_url_root:
 development:
   <<: *defaults
   api_username: wiki_hermes
   api_password: w_h_p1
-
 test:
   <<: *defaults
-  # only for production use
-  #opensuse_cookie: 
 production:
   <<: *defaults
-  relative_url_root: 
+  relative_url_root:
   api_username: <%= ENV['API_USERNAME'] %>
   api_password: <%= ENV['API_PASSWORD'] %>
   use_static: software.o.o
-  opensuse_cookie: <%= ENV['OPENSUSE_COOKIE'] %> 
+  opensuse_cookie: <%= ENV['OPENSUSE_COOKIE'] %>

--- a/test/integration/package_information_test.rb
+++ b/test/integration/package_information_test.rb
@@ -5,7 +5,7 @@ class PackageInformationTest < ActionDispatch::IntegrationTest
   def test_package_information
     # Check that package information is displayed
     visit '/package/pidgin'
-    assert page.has_content? 'Multiprotocol Instant Messaging Client'
-    assert page.has_content? 'Pidgin is a chat program'
+    page.assert_text 'Multiprotocol Instant Messaging Client'
+    page.assert_text 'Pidgin is a chat program'
   end
 end

--- a/test/integration/validate_configuration_test.rb
+++ b/test/integration/validate_configuration_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class ValidateConfigurationTest < ActionDispatch::IntegrationTest
+  def test_validate_configuration
+    # Fake that authentication is not configured
+    x = Rails.configuration.x.clone
+    Rails.configuration.x.api_username = nil
+    Rails.configuration.x.opensuse_cookie = nil
+
+    visit '/'
+    page.assert_text 'The authentication to the OBS API has not been configured correctly.'
+    assert_equal 503, page.status_code
+
+    # Restore normal configuration values for other tests
+    Rails.configuration.x = x
+  end
+end


### PR DESCRIPTION
Before, if both the API username and the production secret cookie where not configured, this resulted in the app to go on, and then search to fail vomiting an exception to the UI.

This PR validates that at least one authentication method is configured (it does not validate that it authenticates correctly). If there is no authentication method configured, it displays the following message:

![screenshot from 2018-02-04 10-56-23](https://user-images.githubusercontent.com/15332/35776327-80255d56-099a-11e8-9921-9281ff1ccde3.png)

A future improvement could be using some javascript in the error template to disable the search field and button.