### PR TITLE
Do not crash if appdata is not available

### DIFF
--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -40,7 +40,13 @@ class Appdata
                   else
                     "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
                   end
-    Nokogiri::XML(Zlib::GzipReader.new(open(appdata_url)))
+    begin
+      Nokogiri::XML(Zlib::GzipReader.new(open(appdata_url)))
+    rescue StandardError => e
+      Rails.logger.error e
+      Rails.logger.error "Can't retrieve appdata from: '#{appdata_url}'"
+      Nokogiri::XML('<?xml version="1.0" encoding="UTF-8"?><components origin="appdata" version="0.8"></components>')
+    end
   end
 
 end

--- a/test/models/appdata_test.rb
+++ b/test/models/appdata_test.rb
@@ -8,4 +8,12 @@ class AppdataTest < ActiveSupport::TestCase
     assert_equal 4, pkg_list.size
     assert_equal ['0ad', '4pane', 'opera', 'steam'], pkg_list
   end
+
+  test 'Missing appdata should not raise anything' do
+    stub_content("download.opensuse.org/tumbleweed/repo/oss/suse/setup/descr/appdata.xml.gz", status: [404, "Not found"])
+    appdata = Appdata.get('factory')
+    # Should at least include the standard searches
+    assert_not_empty appdata[:apps]
+    assert_includes appdata[:apps].map { |e| e[:name] }, 'Opera'
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ class ActiveSupport::TestCase
     stub_remote_file("api.opensuse.org/published/openSUSE:13.1/standard/i586/pidgin-2.10.7-4.1.3.i586.rpm?view=fileinfo", "pidgin-fileinfo.xml")
     stub_content("api.opensuse.org/source/openSUSE:13.1/_attribute/OBS:QualityCategory", "<attributes/>")
   end
+
+  teardown do
+    WebMock.reset!
+  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,15 +12,16 @@ WebMock.disable_net_connect!(:allow_localhost => true)
 class ActiveSupport::TestCase
   # Helper to associate queries to OBS with the corresponding file in
   # test/support
-  def stub_content(url, body)
+  def stub_content(url, what = {})
+    what = { body: what } if what.is_a?(String)
     %w[http https].each do |protocol|
-      stub = stub_request(:any, "#{protocol}://#{url}").to_return(body: body)
+      stub = stub_request(:any, "#{protocol}://#{url}").to_return(what)
       stub.with(basic_auth: ['test', 'test']) if url =~ /^api/
     end
   end
 
   def stub_remote_file(url, filename)
-    stub_content(url, File.read(Rails.root.join('test', 'support', filename)))
+    stub_content(url, body: File.read(Rails.root.join('test', 'support', filename)))
   end
 
   setup do


### PR DESCRIPTION
Right now appdata is not available and that makes software.o.o to not be available.

This PR just makes the appdata data to not be included.

As an idea for the future, I would suggest injecting in the cache a key "appdata_down" while catching the error, that can be used in a status page or banner, so that we actually realize that appdata is missing.