### PR TITLE
Remove left over class call to fix direct download option

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -134,7 +134,6 @@ class DownloadController < ApplicationController
 
   def ymp_with_arch_and_version
     path = "/published/#{params[:project]}/#{params[:repository]}/#{params[:arch]}/#{params[:binary]}?view=ymp"
-    DownloadHistory.create :query => params[:query], :base => params[:base], :ymp => path
     res = Rails.cache.fetch("ymp_#{path}", :expires_in => 1.hour) do
       ApiConnect::get(path)
     end
@@ -143,7 +142,6 @@ class DownloadController < ApplicationController
 
   def ymp_without_arch_and_version
     path = "/published/#{params[:project]}/#{params[:repository]}/#{params[:package]}?view=ymp"
-    DownloadHistory.create :query => params[:query], :base => params[:base], :ymp => path
     res = Rails.cache.fetch("ymp_#{path}", :expires_in => 1.hour) do
       ApiConnect::get(path)
     end


### PR DESCRIPTION
Since the DownloadHistory class got removed by this commit 0d3396f6075761db08c9387565c5faeaf6d42274 there is an "uninitialized constant" error when using the direct download option with yast. 