### PR TITLE
Leap 42.3 is stable version for aarch64 and ppc64le

### DIFF
--- a/app/views/distributions/leap.html.erb
+++ b/app/views/distributions/leap.html.erb
@@ -71,66 +71,66 @@
           <%= _('These ports are not officially supported, and they are not as stable as official distributions.') %>
         </div>
 
-        <h3 class="my-3">ppc64le (42.2)</h3>
+        <h3 class="my-3">ppc64le</h3>
         <div class="card-deck">
           <div class="card">
             <div class="card-block">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("DVD Image") %> (4.7GB)
+                <%= _("DVD Image") %> (4.2GB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
               <p class="card-text text-muted"><%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %></p>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-ppc64le-Build0156-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-ppc64le-Build0130-Media.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-ppc64le-Build0130-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-ppc64le-Build0130-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-ppc64le-Build0130-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
           <div class="card">
             <div class="card-block">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("Network Image") %> (85MB)
+                <%= _("Network Image") %> (71MB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For CD and USB stick") %></h6>
               <p class="card-text text-muted"><%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %></p>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-ppc64le-Build0156-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-ppc64le-Build0130-Media.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-ppc64le-Build0130-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-ppc64le-Build0130-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="http://download.opensuse.org/ports/ppc/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-ppc64le-Build0130-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
         </div><!-- /.card-deck -->
 
-        <h3 class="my-3">aarch64 (42.2)</h3>
+        <h3 class="my-3">aarch64</h3>
         <div class="card-deck">
           <div class="card">
             <div class="card-block">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("DVD Image") %> (4.7GB)
+                <%= _("DVD Image") %> (3.8GB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
               <p class="card-text text-muted"><%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %></p>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-aarch64-Build0212-Media.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-aarch64-Build0212-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-aarch64-Build0212-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-aarch64-Build0212-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-aarch64-Build0200-Media.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-aarch64-Build0200-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-aarch64-Build0200-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-DVD-aarch64-Build0200-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
           <div class="card">
             <div class="card-block">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("Network Image") %> (85MB)
+                <%= _("Network Image") %> (91MB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For CD and USB stick") %></h6>
               <p class="card-text text-muted"><%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %></p>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-aarch64-Build0212-Media.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-aarch64-Build0212-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-aarch64-Build0212-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-aarch64-Build0212-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-aarch64-Build0200-Media.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-aarch64-Build0200-Media.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-aarch64-Build0200-Media.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="http://download.opensuse.org/ports/aarch64/distribution/leap/<%= version %>/iso/openSUSE-Leap-<%= version %>-NET-aarch64-Build0200-Media.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
         </div><!-- /.card-deck -->


### PR DESCRIPTION
This patch revert commit #ffff4a0 that forced version 42.2
that overwrite previous commit #07a8e7d (for ppc64le)

WARNING-1: the "Metalink" and "Pick Mirror" are invalid links
How are they supposed to be created in related directories ?

WARNING-2: The iso file names still refer to build id
So denotes missing process (compared to x86-64)

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>