### PR TITLE
Don't skip set_distributions in distributions controller

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -1,5 +1,4 @@
 class DistributionsController < ApplicationController
-  skip_before_action :set_distributions
   before_action :set_parameters, only: %i[index testing]
 
   def set_parameters


### PR DESCRIPTION
The distributions page also has a search field, therefore needs the
distribution list.

closes #221