### PR TITLE
Tumbleweed: get appdata filename from repomd.xml

### DIFF
--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -35,8 +35,13 @@ class Appdata
 
   # Get the appdata xml for a distribution
   def self.get_distribution(dist = 'factory', flavour = 'oss')
-    appdata_url = if dist == "factory"
-                    "http://download.opensuse.org/tumbleweed/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
+    appdata_url = case dist
+                  when "factory"
+                    index_url = "http://download.opensuse.org/tumbleweed/repo/#{flavour}/repodata/repomd.xml"
+                    repomd = Nokogiri::XML(open(index_url))
+                    repomd.remove_namespaces!
+                    href = repomd.xpath('/repomd/data[@type="appdata"]/location').attr('href').text
+                    "http://download.opensuse.org/tumbleweed/repo/#{flavour}/#{href}"
                   else
                     "http://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
                   end

--- a/test/models/appdata_test.rb
+++ b/test/models/appdata_test.rb
@@ -10,7 +10,7 @@ class AppdataTest < ActiveSupport::TestCase
   end
 
   test 'Missing appdata should not raise anything' do
-    stub_content("download.opensuse.org/tumbleweed/repo/oss/suse/setup/descr/appdata.xml.gz", status: [404, "Not found"])
+    stub_content("download.opensuse.org/tumbleweed/repo/oss/repodata/#{APPDATA_CHECKSUM}-appdata.xml.gz", status: [404, "Not found"])
     appdata = Appdata.get('factory')
     # Should at least include the standard searches
     assert_not_empty appdata[:apps]

--- a/test/support/repomd-non-oss.xml
+++ b/test/support/repomd-non-oss.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>1522139085</revision>
+  <data type="primary">
+    <location href="repodata/4fceb0d5c15fea4025e4d605e3ac13745da04607335abdd01317acd72f668a89-primary.xml.gz"/>
+    <checksum type="sha256">4fceb0d5c15fea4025e4d605e3ac13745da04607335abdd01317acd72f668a89</checksum>
+    <timestamp>1522139085</timestamp>
+    <size>20321</size>
+    <open-size>151781</open-size>
+    <open-checksum type="sha256">e2bb1dec5a438d72709bc2f17ed814ef6516e01544d4707ee46eccc8870422ba</open-checksum>
+  </data>
+  <data type="filelists">
+    <location href="repodata/8ab924cf0b20e480b47e28124bcda6392346678ab77163e49d02a9ec54173773-filelists.xml.gz"/>
+    <checksum type="sha256">8ab924cf0b20e480b47e28124bcda6392346678ab77163e49d02a9ec54173773</checksum>
+    <timestamp>1522139085</timestamp>
+    <size>50926</size>
+    <open-size>669446</open-size>
+    <open-checksum type="sha256">9915f23ea62fa5a6476a4b80187b413def537d708481fff7ec18d7a3abda90e1</open-checksum>
+  </data>
+  <data type="other">
+    <location href="repodata/a4b55095d67b7cfec76dc159bd42ecb46210b95713a37b750c9e093d85e07285-other.xml.gz"/>
+    <checksum type="sha256">a4b55095d67b7cfec76dc159bd42ecb46210b95713a37b750c9e093d85e07285</checksum>
+    <timestamp>1522139085</timestamp>
+    <size>18239</size>
+    <open-size>110978</open-size>
+    <open-checksum type="sha256">51f474738d309b85b3c0cb2a4a595ae4aa022b8e232d7dffc9f7b0e661828cab</open-checksum>
+  </data>
+  <data type="susedata.cs">
+    <location href="repodata/69bd5ac5ecf055445bc7921ef701938004739a51e9add1a17e52dc17222d5c70-susedata.cs.xml.gz"/>
+    <checksum type="sha256">69bd5ac5ecf055445bc7921ef701938004739a51e9add1a17e52dc17222d5c70</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>2476</size>
+    <open-size>7082</open-size>
+    <open-checksum type="sha256">f77b58732b9af1207c4626556cacdf9f92978472c5a72e4c430ff02a56da407a</open-checksum>
+  </data>
+  <data type="susedata.de">
+    <location href="repodata/6693feb1973281924c990cc884fe208c7fae1a7859850e87b1d8d55301144c12-susedata.de.xml.gz"/>
+    <checksum type="sha256">6693feb1973281924c990cc884fe208c7fae1a7859850e87b1d8d55301144c12</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>1342</size>
+    <open-size>4457</open-size>
+    <open-checksum type="sha256">f859d31daeeca517e89ba1238be8d29711ff378504e06792f89f80cad39cb01a</open-checksum>
+  </data>
+  <data type="susedata.es">
+    <location href="repodata/157e5852297ec9b747afdc7b12fee4bd32de471883248987d3c87de5ca8b545a-susedata.es.xml.gz"/>
+    <checksum type="sha256">157e5852297ec9b747afdc7b12fee4bd32de471883248987d3c87de5ca8b545a</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>2472</size>
+    <open-size>7167</open-size>
+    <open-checksum type="sha256">12de06631fa1093648103eed91a00404562dfbf9eccbe38371c162a6531ae8a3</open-checksum>
+  </data>
+  <data type="susedata.fr">
+    <location href="repodata/43e6d66f91ebaa66f2288e9c383e2e2150e0dae59ebe9182afe05577b8e20c8d-susedata.fr.xml.gz"/>
+    <checksum type="sha256">43e6d66f91ebaa66f2288e9c383e2e2150e0dae59ebe9182afe05577b8e20c8d</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>1181</size>
+    <open-size>3166</open-size>
+    <open-checksum type="sha256">4ec2b79894e5079021d242e7062c875b8067d9a8a4b7b2a9c65bbed9c5d91657</open-checksum>
+  </data>
+  <data type="susedata.hu">
+    <location href="repodata/1b08853335065af96853ca82871ecb74bba1f6a36e9bbf7cdce31f2134d15afb-susedata.hu.xml.gz"/>
+    <checksum type="sha256">1b08853335065af96853ca82871ecb74bba1f6a36e9bbf7cdce31f2134d15afb</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>2596</size>
+    <open-size>7261</open-size>
+    <open-checksum type="sha256">f23e3d7963b61f19ddb42f91bafc985ccc59e1e36c3b6208e6820ce21f425fed</open-checksum>
+  </data>
+  <data type="susedata.it">
+    <location href="repodata/b15b8e3bba230a28358d297aabd5fbf2a710b9407519b32ccdf7ed8bd5e98872-susedata.it.xml.gz"/>
+    <checksum type="sha256">b15b8e3bba230a28358d297aabd5fbf2a710b9407519b32ccdf7ed8bd5e98872</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>488</size>
+    <open-size>1545</open-size>
+    <open-checksum type="sha256">38c1a96257265a4713c0b868ffec8ff57f0beec3cb8a9e0c7dec4d5aedee3c1e</open-checksum>
+  </data>
+  <data type="susedata.ja">
+    <location href="repodata/b85ab6420ec399e76f159f920b58dd72320f45de971bc93de9d49dbadb6ed950-susedata.ja.xml.gz"/>
+    <checksum type="sha256">b85ab6420ec399e76f159f920b58dd72320f45de971bc93de9d49dbadb6ed950</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>1559</size>
+    <open-size>4432</open-size>
+    <open-checksum type="sha256">6f88386b281fdf37acfc271c175d4f6f710c57bf420c75f357b7a942fa9294a8</open-checksum>
+  </data>
+  <data type="susedata.lt">
+    <location href="repodata/12cc157d49a8c3586bc30e13c48dc7627be287cbbf396996baae3b2d1330ceac-susedata.lt.xml.gz"/>
+    <checksum type="sha256">12cc157d49a8c3586bc30e13c48dc7627be287cbbf396996baae3b2d1330ceac</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>544</size>
+    <open-size>1555</open-size>
+    <open-checksum type="sha256">50d856905aac6d7e352ad96027ffc945f0271270b4fc13e6eaf4db579225448c</open-checksum>
+  </data>
+  <data type="susedata.nl">
+    <location href="repodata/15ea1ca15618efe292adc6a7bde7bf784bc8b0bde0fdc227471382ab264a9472-susedata.nl.xml.gz"/>
+    <checksum type="sha256">15ea1ca15618efe292adc6a7bde7bf784bc8b0bde0fdc227471382ab264a9472</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>526</size>
+    <open-size>1539</open-size>
+    <open-checksum type="sha256">046424dfa8b6772eb857dfc32ded6215b32d9b276b0f7306a28ba12c04c71841</open-checksum>
+  </data>
+  <data type="susedata.nn">
+    <location href="repodata/a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.nn.xml.gz"/>
+    <checksum type="sha256">a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>122</size>
+    <open-size>123</open-size>
+    <open-checksum type="sha256">743071394bef1495867b673ef088a678ce105740ee18b0cac194c5a267e1117d</open-checksum>
+  </data>
+  <data type="susedata.ru">
+    <location href="repodata/b641e01a142cf75c657197fdfef41281ab2fbdd241bed216268f0e71e68b09c0-susedata.ru.xml.gz"/>
+    <checksum type="sha256">b641e01a142cf75c657197fdfef41281ab2fbdd241bed216268f0e71e68b09c0</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>854</size>
+    <open-size>2893</open-size>
+    <open-checksum type="sha256">a59797e545f8c206225802ddb5e748a097130a6744ae7b19450f7b7219f41647</open-checksum>
+  </data>
+  <data type="susedata.uk">
+    <location href="repodata/5b3bb1504180fc9e31fa08231b45673f38a5e638d6c7c3cb37188f475ad98ed8-susedata.uk.xml.gz"/>
+    <checksum type="sha256">5b3bb1504180fc9e31fa08231b45673f38a5e638d6c7c3cb37188f475ad98ed8</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>611</size>
+    <open-size>1875</open-size>
+    <open-checksum type="sha256">8427ff51f0e5192299cca2184d6fc38ad98d43fe7060d76035907c0be45d1ba3</open-checksum>
+  </data>
+  <data type="susedata.zh_CN">
+    <location href="repodata/def6c31ef73b732ca0165fbbe9fe5da3ff71edf450a74c212d9fa91254ad9160-susedata.zh_CN.xml.gz"/>
+    <checksum type="sha256">def6c31ef73b732ca0165fbbe9fe5da3ff71edf450a74c212d9fa91254ad9160</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>582</size>
+    <open-size>1523</open-size>
+    <open-checksum type="sha256">f4a2b1e8de97c4c1387d8a0b921f93ff8962a1c523c4a70ea28307a5fd5c3378</open-checksum>
+  </data>
+  <data type="susedata">
+    <location href="repodata/0efc39cae0f4df055d93dd37c4ef023f3b7a7e85393e29c641351e9f1658f988-susedata.xml.gz"/>
+    <checksum type="sha256">0efc39cae0f4df055d93dd37c4ef023f3b7a7e85393e29c641351e9f1658f988</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>9532</size>
+    <open-size>43883</open-size>
+    <open-checksum type="sha256">23b4eb3c9a86c1dcaa0f8122c1a7be71e3b588e7ecb7156de8dbcbf8db81eaba</open-checksum>
+  </data>
+  <data type="appdata">
+    <location href="repodata/be1fe70d7bf5a73e1e0e9e4a8bd6ea84c752bef85b02b2e7ea97cb4ac232d353-appdata.xml.gz"/>
+    <checksum type="sha256">be1fe70d7bf5a73e1e0e9e4a8bd6ea84c752bef85b02b2e7ea97cb4ac232d353</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>1020</size>
+    <open-size>2288</open-size>
+    <open-checksum type="sha256">fd39b30aed985327e9578e6b950b99449bc4721f52f0e7343d1aa181b6d24005</open-checksum>
+  </data>
+  <data type="appdata-icons">
+    <location href="repodata/bbe82856ebc5244036fe07c335f0de913bf11d83c9f7c89029e4991d02321b48-appdata-icons.tar.gz"/>
+    <checksum type="sha256">bbe82856ebc5244036fe07c335f0de913bf11d83c9f7c89029e4991d02321b48</checksum>
+    <timestamp>1522139095</timestamp>
+    <size>6472</size>
+    <open-size>9216</open-size>
+    <open-checksum type="sha256">ea44469ebb31c9499e6860d73b12ed1ebcbaf6a59d09d94e74f7680a0c9ef7d7</open-checksum>
+  </data>
+</repomd>

--- a/test/support/repomd.xml
+++ b/test/support/repomd.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>1522148810</revision>
+  <data type="primary">
+    <checksum type="sha256">76a8820491546cde34499c61d6ea44f5e1446e909e62212e1d3b3a820e2d62de</checksum>
+    <open-checksum type="sha256">ae4fbcbc29b7e71a7e7b624c3087836c018a911c31d9c6f873af6de8daaedc90</open-checksum>
+    <location href="repodata/76a8820491546cde34499c61d6ea44f5e1446e909e62212e1d3b3a820e2d62de-primary.xml.gz"/>
+    <timestamp>1522148810</timestamp>
+    <size>14659688</size>
+    <open-size>142695328</open-size>
+  </data>
+  <data type="filelists">
+    <checksum type="sha256">836a4baaec88ca28ba7002eb42b4131b67c45c9e7c6f3d5dd771e9e91c466198</checksum>
+    <open-checksum type="sha256">1cea7ea3e773c58fdf3b35a747effa7dfadbe9e240f23197e971c9aae108d6a3</open-checksum>
+    <location href="repodata/836a4baaec88ca28ba7002eb42b4131b67c45c9e7c6f3d5dd771e9e91c466198-filelists.xml.gz"/>
+    <timestamp>1522148810</timestamp>
+    <size>34459310</size>
+    <open-size>508545124</open-size>
+  </data>
+  <data type="other">
+    <checksum type="sha256">aec61d4d339e36a284c69352cbcdf850a9ceb9476a6ca481f34cc5edb9878534</checksum>
+    <open-checksum type="sha256">de17144152329ba25fdabfa024a820c48a057c233f447be43abaed8232968e58</open-checksum>
+    <location href="repodata/aec61d4d339e36a284c69352cbcdf850a9ceb9476a6ca481f34cc5edb9878534-other.xml.gz"/>
+    <timestamp>1522148810</timestamp>
+    <size>19513011</size>
+    <open-size>164618648</open-size>
+  </data>
+  <data type="appdata">
+    <checksum type="sha256">a63a63d45b002d5ff8f37c09315cda2c4a9d89ae698f56e95b92f1274332c157</checksum>
+    <open-checksum type="sha256">4f26cd6453a7793ac76eb6dca9837eed1c4b02eaa777abb5b117160706f24f72</open-checksum>
+    <location href="repodata/a63a63d45b002d5ff8f37c09315cda2c4a9d89ae698f56e95b92f1274332c157-appdata.xml.gz"/>
+    <timestamp>1522150159</timestamp>
+    <size>3226947</size>
+    <open-size>10798588</open-size>
+  </data>
+  <data type="appdata-icons">
+    <checksum type="sha256">f20ff43a432d1c72da2db18b1ee39b55bf3837e73a16ff08d49e982aff545c89</checksum>
+    <open-checksum type="sha256">9082054d2be14cbcc14cd8eb5523fc5ade10e69b766dc43fedcc28e7b0ff0ab5</open-checksum>
+    <location href="repodata/f20ff43a432d1c72da2db18b1ee39b55bf3837e73a16ff08d49e982aff545c89-appdata-icons.tar.gz"/>
+    <timestamp>1522150193</timestamp>
+    <size>3424205</size>
+    <open-size>4229632</open-size>
+  </data>
+  <data type="license">
+    <checksum type="sha256">e054d4758c7d0d5c76e58013f3d29783ea1da8334820e347c0093bc67e8a7f5c</checksum>
+    <open-checksum type="sha256">70a22fbaabf917173a42ea26de0a5ec7df811ad12a6fdd1c8c2bb95c50c415f2</open-checksum>
+    <location href="repodata/e054d4758c7d0d5c76e58013f3d29783ea1da8334820e347c0093bc67e8a7f5c-license.tar.gz"/>
+    <timestamp>1522150368</timestamp>
+    <size>61665</size>
+    <open-size>184320</open-size>
+  </data>
+  <data type="susedata">
+    <checksum type="sha256">3f5452d868a5532b8df62e5ed6428638e31f5e08b29a71af9e41f8f37ce5d8a8</checksum>
+    <open-checksum type="sha256">69ebbe654951819f2b496fb17871a4c16e20df9af79fd73c05006491c8ff4302</open-checksum>
+    <location href="repodata/3f5452d868a5532b8df62e5ed6428638e31f5e08b29a71af9e41f8f37ce5d8a8-susedata.xml.gz"/>
+    <timestamp>1522150363</timestamp>
+    <size>4193793</size>
+    <open-size>31755181</open-size>
+  </data>
+  <data type="susedata.cs">
+    <checksum type="sha256">b770869600a6e97a1474f99825e76b6f7282209cedf6fe5e51fd4a37520114c5</checksum>
+    <open-checksum type="sha256">bd75fe0bce17bdecf08835a279bb3c31fa75cc31a6996a8930905db4f2516faf</open-checksum>
+    <location href="repodata/b770869600a6e97a1474f99825e76b6f7282209cedf6fe5e51fd4a37520114c5-susedata.cs.xml.gz"/>
+    <timestamp>1522150333</timestamp>
+    <size>376492</size>
+    <open-size>1856214</open-size>
+  </data>
+  <data type="susedata.de">
+    <checksum type="sha256">e52f5cf6c045c2c7599c9ec1d04f64b3e42e590397d32a51728cb3f625302bc5</checksum>
+    <open-checksum type="sha256">95240d7ab8cf9a9bc89369aa5fb508cbfc9affe378bbd4c0e9b1cfebace6cfcb</open-checksum>
+    <location href="repodata/e52f5cf6c045c2c7599c9ec1d04f64b3e42e590397d32a51728cb3f625302bc5-susedata.de.xml.gz"/>
+    <timestamp>1522150335</timestamp>
+    <size>374160</size>
+    <open-size>1975351</open-size>
+  </data>
+  <data type="susedata.es">
+    <checksum type="sha256">3cc300caa759a0fab828efdd456ca1946dd40b03d9397f35159e3552cb3ad3b3</checksum>
+    <open-checksum type="sha256">2fb40c2c20bd09574cc39fb3e55f67a5f4707b8f0c15ec62f85ddced0ee5d3c5</open-checksum>
+    <location href="repodata/3cc300caa759a0fab828efdd456ca1946dd40b03d9397f35159e3552cb3ad3b3-susedata.es.xml.gz"/>
+    <timestamp>1522150336</timestamp>
+    <size>465273</size>
+    <open-size>2416731</open-size>
+  </data>
+  <data type="susedata.fr">
+    <checksum type="sha256">3e195d20939b71c4318f95c9b1838020e94515720e2fcbcc277abf1b4ba626cd</checksum>
+    <open-checksum type="sha256">39b4d93b7ced26c31cff3544da1a845360fb1b0202c59723f0f8dd6cda713ec2</open-checksum>
+    <location href="repodata/3e195d20939b71c4318f95c9b1838020e94515720e2fcbcc277abf1b4ba626cd-susedata.fr.xml.gz"/>
+    <timestamp>1522150337</timestamp>
+    <size>230958</size>
+    <open-size>1224011</open-size>
+  </data>
+  <data type="susedata.hu">
+    <checksum type="sha256">076efdd736f0dff67d3e2a88b17219e4f1fb0256cae67d6de70954402421f8df</checksum>
+    <open-checksum type="sha256">5f3fabbe00a6ee6118ed204aebbb3cc684e2d692fdc630c672b7b1385e9a4f39</open-checksum>
+    <location href="repodata/076efdd736f0dff67d3e2a88b17219e4f1fb0256cae67d6de70954402421f8df-susedata.hu.xml.gz"/>
+    <timestamp>1522150339</timestamp>
+    <size>595386</size>
+    <open-size>3010639</open-size>
+  </data>
+  <data type="susedata.it">
+    <checksum type="sha256">a3cb5669e41e91a23999448c6a681c4bde10936ecbfa20cefec9ff34e2aa83d2</checksum>
+    <open-checksum type="sha256">a02511e78e7114cae660f1e5bdbeb83f37aeb0dac6d67810334be3940573ff33</open-checksum>
+    <location href="repodata/a3cb5669e41e91a23999448c6a681c4bde10936ecbfa20cefec9ff34e2aa83d2-susedata.it.xml.gz"/>
+    <timestamp>1522150341</timestamp>
+    <size>1298167</size>
+    <open-size>6727184</open-size>
+  </data>
+  <data type="susedata.ja">
+    <checksum type="sha256">71abff45a5def42c7a2fc1d94c30c40d7c4682e5c0089fde43a1a99b9d802c08</checksum>
+    <open-checksum type="sha256">8bfb6467d8a7b4207295a9c1e3f2abd297c7dd05f20615a4d411bf5b4d30e91b</open-checksum>
+    <location href="repodata/71abff45a5def42c7a2fc1d94c30c40d7c4682e5c0089fde43a1a99b9d802c08-susedata.ja.xml.gz"/>
+    <timestamp>1522150343</timestamp>
+    <size>1938519</size>
+    <open-size>9705833</open-size>
+  </data>
+  <data type="susedata.lt">
+    <checksum type="sha256">05fe132e8b220e0bc45847cbc9f11640978f26221953c35505959abb4d15a9d3</checksum>
+    <open-checksum type="sha256">3eda9bf3dbf0a3696181cb5f49e3cc31ad8046b2f16b9f3da332df287c5e1787</open-checksum>
+    <location href="repodata/05fe132e8b220e0bc45847cbc9f11640978f26221953c35505959abb4d15a9d3-susedata.lt.xml.gz"/>
+    <timestamp>1522150344</timestamp>
+    <size>63663</size>
+    <open-size>332971</open-size>
+  </data>
+  <data type="susedata.nl">
+    <checksum type="sha256">0d4b96aa43b5a1523ab52b91778bd597396af93b09ff3796ef33d42856e5dc39</checksum>
+    <open-checksum type="sha256">aabcceca8eae0e9a73122df7658f7b92c80cb5ea053991ec8222d49b870fd45f</open-checksum>
+    <location href="repodata/0d4b96aa43b5a1523ab52b91778bd597396af93b09ff3796ef33d42856e5dc39-susedata.nl.xml.gz"/>
+    <timestamp>1522150345</timestamp>
+    <size>142750</size>
+    <open-size>718922</open-size>
+  </data>
+  <data type="susedata.nn">
+    <checksum type="sha256">582d7d3fb936d49d86fb2a25d1f504f185edde9f6da90163fd2501a43d95b260</checksum>
+    <open-checksum type="sha256">35cfffc6cf6f1829b89159cd63acfdf0398c1efe041b0c313e398e3786e93841</open-checksum>
+    <location href="repodata/582d7d3fb936d49d86fb2a25d1f504f185edde9f6da90163fd2501a43d95b260-susedata.nn.xml.gz"/>
+    <timestamp>1522150346</timestamp>
+    <size>12753</size>
+    <open-size>80179</open-size>
+  </data>
+  <data type="susedata.ru">
+    <checksum type="sha256">5b31102fda87c8b97d2724298a49acf2752153af4a73adcc06573bad42676553</checksum>
+    <open-checksum type="sha256">274742e913faae67d705cfb9d07c2fe362ef2fa3233a22da1d4ef63284acc7c0</open-checksum>
+    <location href="repodata/5b31102fda87c8b97d2724298a49acf2752153af4a73adcc06573bad42676553-susedata.ru.xml.gz"/>
+    <timestamp>1522150349</timestamp>
+    <size>2165488</size>
+    <open-size>11648895</open-size>
+  </data>
+  <data type="susedata.uk">
+    <checksum type="sha256">f412e26af0f5d6e8387bf7fa80b014eacec3cc92019bccfefb8ccb609a01be37</checksum>
+    <open-checksum type="sha256">910a631e3a133a2017881b2458cf7bc9b7cd5248bbbb49f2078182a0b2919c31</open-checksum>
+    <location href="repodata/f412e26af0f5d6e8387bf7fa80b014eacec3cc92019bccfefb8ccb609a01be37-susedata.uk.xml.gz"/>
+    <timestamp>1522150354</timestamp>
+    <size>526483</size>
+    <open-size>2915402</open-size>
+  </data>
+  <data type="susedata.zh_CN">
+    <checksum type="sha256">5686949e65e062a98cd9860238dad0f16e3fa3bcadeb58b6188d0598e7e34264</checksum>
+    <open-checksum type="sha256">45c51148af6309cbd2a8b132d123148716806366f37ac29a72e5eca81183b4c1</open-checksum>
+    <location href="repodata/5686949e65e062a98cd9860238dad0f16e3fa3bcadeb58b6188d0598e7e34264-susedata.zh_CN.xml.gz"/>
+    <timestamp>1522150355</timestamp>
+    <size>205784</size>
+    <open-size>1111428</open-size>
+  </data>
+</repomd>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,11 +24,17 @@ class ActiveSupport::TestCase
     stub_content(url, body: File.read(Rails.root.join('test', 'support', filename)))
   end
 
+  APPDATA_CHECKSUM = "a63a63d45b002d5ff8f37c09315cda2c4a9d89ae698f56e95b92f1274332c157".freeze
+  APPDATA_NON_OSS_CHECKSUM = "be1fe70d7bf5a73e1e0e9e4a8bd6ea84c752bef85b02b2e7ea97cb4ac232d353".freeze
+
   setup do
     # stub OBS using WebMock
     stub_remote_file("api.opensuse.org/public/distributions?", "distributions.xml")
-    stub_remote_file("download.opensuse.org/tumbleweed/repo/oss/suse/setup/descr/appdata.xml.gz", "appdata.xml.gz")
-    stub_remote_file("download.opensuse.org/tumbleweed/repo/non-oss/suse/setup/descr/appdata.xml.gz", "appdata-non-oss.xml.gz")
+    stub_remote_file("download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml", "repomd.xml")
+    stub_remote_file("download.opensuse.org/tumbleweed/repo/non-oss/repodata/repomd.xml", "repomd-non-oss.xml")
+
+    stub_remote_file("download.opensuse.org/tumbleweed/repo/oss/repodata/#{APPDATA_CHECKSUM}-appdata.xml.gz", "appdata.xml.gz")
+    stub_remote_file("download.opensuse.org/tumbleweed/repo/non-oss/repodata/#{APPDATA_NON_OSS_CHECKSUM}-appdata.xml.gz", "appdata-non-oss.xml.gz")
     stub_remote_file("api.opensuse.org/search/published/binary/id?match=@name%20=%20'pidgin'%20", "pidgin.xml")
     stub_remote_file("api.opensuse.org/published/openSUSE:13.1/standard/i586/pidgin-2.10.7-4.1.3.i586.rpm?view=fileinfo", "pidgin-fileinfo.xml")
     stub_content("api.opensuse.org/source/openSUSE:13.1/_attribute/OBS:QualityCategory", "<attributes/>")


### PR DESCRIPTION
Factory now generates appdata with a different filename, just like any other repodata file. This PR changes the Appdata classes to gather the name from the 'repomd.xml' index file, if the distribution is factory.

Addresses: https://github.com/openSUSE/software-o-o/issues/232