### PR TITLE
Enable classes caching

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,4 +28,6 @@ SoftwareOO::Application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
     config.log_level = log_level
   end
+
+  config.cache_classes = true
 end


### PR DESCRIPTION
Fixes #225 (hopefully).

`config.cache_classes` seems to be currently disabled in production mode:

```
> RAILS_ENV=production rails c
Loading production environment (Rails 5.1.4)
2.4.1 :001 > Rails.application.config.cache_classes
 => nil 
```

I am running the site in production mode locally: `RACK_ENV=production RAILS_ENV=production rails s -b 0.0.0.0` (with memcached  also running).

I've slapped together a script to record RSS of the puma processes over time:

```bash
(watch -n 1 'ps aux | grep puma | grep cluster | grep -v grep | awk "{print \$6}" | tr "\\n" "," | sed "s/,\$/\n/" | tee -a data.csv' &) && siege -d 0.001 -r 1000 http://localhost:3000/ && killall watch
```

Here's the comparison of memory usage of 15000 requests served, with `config.cache_classes` enabled and disabled:

![image](https://user-images.githubusercontent.com/1793699/38986059-8fb09fae-43cb-11e8-94ba-5f0decc585ed.png)

If that's what's causing the memory issue, how often does `puma` need to be restarted at the moment? :confused: