### PR TITLE
Fall back to 'en' when locale is invalid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,10 +50,8 @@ class ApplicationController < ActionController::Base
     # the short form without underscore
     unless LANGUAGES.include? requested_locale
       requested_locale = requested_locale.split('_').first
-      if LANGUAGES.include? requested_locale
-        params[:locale] = requested_locale
-        set_gettext_locale
-      end
+      params[:locale] = LANGUAGES.include?(requested_locale) ? requested_locale : 'en'
+      set_gettext_locale
     end
     @lang = FastGettext.locale
   end


### PR DESCRIPTION
Fixes #186. Description of the cause of the issue here: https://github.com/openSUSE/software-o-o/issues/186#issuecomment-382741412

Currently when the locale is not found (e.g., `foo_bar` or `foo`), the code splits it using the underscore as the delimiter and tries to use the first piece (`foo`). However if it's invalid it just proceeds to use the invalid locale.

With this change it will fall back to English locale.