### PR TITLE
Put "ALL Distributions" as first setting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
         @distributions << dist
         logger.debug "Added Distribution: #{dist[:name]}"
       }
-      @distributions << Hash[:name => "ALL Distributions", :project => 'ALL']
+      @distributions.unshift(Hash[:name => "ALL Distributions", :project => 'ALL'])
     rescue Exception => e
       logger.error "Error while loading distributions: " + e.to_s
       @distributions = nil


### PR DESCRIPTION
The option to search all distributions is easier to find if it is on top
of the list rather than the very end.