### PR TITLE
change doc links to a bulleted list

### DIFF
--- a/app/views/distributions/_documentation.html.erb
+++ b/app/views/distributions/_documentation.html.erb
@@ -1,28 +1,24 @@
 <% version = '' if version.nil? %>
 <h2 id="documentation"><%= _('Documentation') %></h2>
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <a href="https://doc.opensuse.org/documentation/leap/startup/single-html/book.opensuse.startup/index.html">
-          openSUSE Startup Guide
-        </a>
-      </td>
-      <td>
-        <a href="https://doc.opensuse.org/release-notes/x86_64/openSUSE/<%= distro %>/<%= version %>">
-          <%= _('Release Notes') %>
-        </a>
-      </td>
-      <td>
-        <a href="https://en.opensuse.org/openSUSE:License">
-          <%= _('License') %>
-        </a>
-        </td>
-      <td>
-        <a href="https://doc.opensuse.org">
-          <%= _('Full Documentation') %>
-        </a>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<ul>
+  <li>
+    <a href="https://doc.opensuse.org/documentation/leap/startup/single-html/book.opensuse.startup/index.html">
+      openSUSE Startup Guide
+    </a>
+  </li>
+  <li>
+    <a href="https://doc.opensuse.org/release-notes/x86_64/openSUSE/<%= distro %>/<%= version %>">
+      <%= _('Release Notes') %>
+    </a>
+  </li>
+  <li>
+    <a href="https://en.opensuse.org/openSUSE:License">
+      <%= _('License') %>
+    </a>
+  </li>
+  <li>
+    <a href="https://doc.opensuse.org">
+      <%= _('Full Documentation') %>
+    </a>
+  </li>
+</ul>


### PR DESCRIPTION
This was written on a train and has ~~not been tested yet~~ now been tested.

The documentation links were marked up as `<td>` cells within a single row, so there was no visual separation between them, which was confusing.  So change them to items in a bulleted list.

Fixes #253.