### PR TITLE
Allow to optionally enable rbtrace to generate heap dumps in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,6 @@ group :test do
   gem 'rubocop', "~> 0.49.0"
   gem 'webmock'
 end
+
+# Debugging gems
+gem 'rbtrace', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    msgpack (1.2.4)
     multi_json (1.12.2)
     nio4r (2.1.0)
     nokogiri (1.8.2)
@@ -155,6 +156,10 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rbtrace (0.4.10)
+      ffi (>= 1.0.6)
+      msgpack (>= 0.4.3)
+      trollop (>= 1.16.2)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -182,6 +187,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    trollop (2.1.2)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -219,6 +225,7 @@ DEPENDENCIES
   puma
   rails (~> 5.1.4)
   rails-i18n
+  rbtrace
   rubocop (~> 0.49.0)
   sass-rails (~> 5.0.7)
   uglifier (>= 1.3.0)
@@ -226,4 +233,4 @@ DEPENDENCIES
   xmlhash (>= 1.2.2)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Puma will honor other variables too:
 * `RAILS_MAX_THREADS`
 * `PORT`
 * `RACK_ENV`
+* `SOFTWARE_O_O_RBTRACE`
+
+### Debugging
+
+* If `SOFTWARE_O_O_RBTRACE` is set, you can use [rbtrace](https://github.com/tmm1/rbtrace) to debug the application.
 
 ### Memcache
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,3 +7,13 @@ preload_app!
 rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  if ENV['SOFTWARE_O_O_RBTRACE']
+    # Trace objects to generate heap dump in production
+    puts "Enabling rbtrace and object allocation tracing"
+    require 'rbtrace'
+    require 'objspace'
+    ObjectSpace.trace_object_allocations_start
+  end
+end


### PR DESCRIPTION
While working on https://github.com/openSUSE/software-o-o/issues/225, we have collected lot of data on development instances. Lot of it has been misleading eg. the effect of cache_classes.

This PR allows us to set `SOFTWARE_O_O_RBTRACE` in `/etc/software_opensuse_org.conf` and the app will be started with allocation tracing enabled, and rbtrace can be used to generate live dumps of the heap.