### PR TITLE
Update chameleon theme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.{diff,md}]
+[*.{md}]
 trim_trailing_whitespace = false

--- a/app/views/distributions/_documentation.html.erb
+++ b/app/views/distributions/_documentation.html.erb
@@ -1,28 +1,24 @@
 <% version = '' if version.nil? %>
 <h2 id="documentation"><%= _('Documentation') %></h2>
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <a href="https://doc.opensuse.org/documentation/leap/startup/single-html/book.opensuse.startup/index.html">
-          openSUSE Startup Guide
-        </a>
-      </td>
-      <td>
-        <a href="https://doc.opensuse.org/release-notes/x86_64/openSUSE/<%= distro %>/<%= version %>">
-          <%= _('Release Notes') %>
-        </a>
-      </td>
-      <td>
-        <a href="https://en.opensuse.org/openSUSE:License">
-          <%= _('License') %>
-        </a>
-        </td>
-      <td>
-        <a href="https://doc.opensuse.org">
-          <%= _('Full Documentation') %>
-        </a>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<ul>
+  <li>
+    <a href="https://doc.opensuse.org/documentation/leap/startup/single-html/book.opensuse.startup/index.html">
+    <%= _('openSUSE Startup Guide') %>
+    </a>
+  </li>
+  <li>
+    <a href="https://doc.opensuse.org/release-notes/x86_64/openSUSE/<%= distro %>/<%= version %>">
+      <%= _('Release Notes') %>
+    </a>
+  </li>
+  <li>
+    <a href="https://en.opensuse.org/openSUSE:License">
+      <%= _('License') %>
+    </a>
+    </li>
+  <li>
+    <a href="https://doc.opensuse.org">
+      <%= _('Full Documentation') %>
+    </a>
+  </li>
+</ul>

--- a/app/views/distributions/_upgrade_table.html.erb
+++ b/app/views/distributions/_upgrade_table.html.erb
@@ -1,4 +1,4 @@
-<table>
+<table class="table">
   <thead>
     <tr>
       <th><%= _('From an older version or other Linux distro') %></th>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -13,7 +13,7 @@
   <div class="card-deck">
     <div class="card">
       <%= image_tag 'distributions/tumbleweed.svg', alt: "Tumbleweed Logo", class: "card-img-top" %>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">openSUSE Tumbleweed</h4>
         <p class="card-text"><%= _('Download openSUSE’s rolling release and always run the latest packages provided by the openSUSE Project.') %></p>
       </div>
@@ -23,7 +23,7 @@
     </div>
     <div class="card">
       <%= image_tag 'distributions/leap.svg', alt: "Leap Logo", class: "card-img-top" %>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">openSUSE Leap</h4>
         <p class="card-text"><%= _('Download openSUSE’s regular release and enjoy the benefits of both enterprise-grade engineering and community-developed innovation.') %></p>
       </div>
@@ -34,7 +34,7 @@
 <% if @testing_version %>
     <div class="card">
       <%= image_tag 'distributions/testing.svg', alt: "Testing Logo", class: "card-img-top" %>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">openSUSE Testing</h4>
         <p class="card-text"><%= _('Help test openSUSE’s next version of Leap by downloading the latest development milestone.') %></p>
       </div>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -12,7 +12,7 @@
 <div class="container mb-5">
   <div class="card-deck">
     <div class="card">
-      <%= image_tag 'distributions/tumbleweed.svg', alt: "Tumbleweed Logo", class: "card-img-top" %>
+      <%= image_tag 'distributions/tumbleweed.svg', alt: "Tumbleweed Logo", class: "card-img-top animated bounceIn", width: "256", height: "256" %>
       <div class="card-body">
         <h4 class="card-title">openSUSE Tumbleweed</h4>
         <p class="card-text"><%= _('Download openSUSE’s rolling release and always run the latest packages provided by the openSUSE Project.') %></p>
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div class="card">
-      <%= image_tag 'distributions/leap.svg', alt: "Leap Logo", class: "card-img-top" %>
+      <%= image_tag 'distributions/leap.svg', alt: "Leap Logo", class: "card-img-top animated bounceIn", width: "256", height: "256" %>
       <div class="card-body">
         <h4 class="card-title">openSUSE Leap</h4>
         <p class="card-text"><%= _('Download openSUSE’s regular release and enjoy the benefits of both enterprise-grade engineering and community-developed innovation.') %></p>
@@ -33,7 +33,7 @@
     </div>
 <% if @testing_version %>
     <div class="card">
-      <%= image_tag 'distributions/testing.svg', alt: "Testing Logo", class: "card-img-top" %>
+      <%= image_tag 'distributions/testing.svg', alt: "Testing Logo", class: "card-img-top animated bounceIn", width: "256", height: "256" %>
       <div class="card-body">
         <h4 class="card-title">openSUSE Testing</h4>
         <p class="card-text"><%= _('Help test openSUSE’s next version of Leap by downloading the latest development milestone.') %></p>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -28,7 +28,7 @@
         <p class="card-text"><%= _('Download openSUSE’s regular release and enjoy the benefits of both enterprise-grade engineering and community-developed innovation.') %></p>
       </div>
       <div class="card-footer">
-        <%= link_to _('Download'), leap_distributions_path, class: 'btn btn-primary' %>
+        <%= link_to _('Download'), leap_distributions_path, class: 'btn btn-success' %>
       </div>
     </div>
 <% if @testing_version %>
@@ -39,7 +39,7 @@
         <p class="card-text"><%= _('Help test openSUSE’s next version of Leap by downloading the latest development milestone.') %></p>
       </div>
       <div class="card-footer">
-        <%= link_to _('Download'), testing_distributions_path, class: 'btn btn-primary' %>
+        <%= link_to _('Download'), testing_distributions_path, class: 'btn btn-dark' %>
       </div>
     </div>
 <% end %>

--- a/app/views/distributions/leap.html.erb
+++ b/app/views/distributions/leap.html.erb
@@ -3,7 +3,7 @@
 <header class="download-home-header jumbotron jumbotron-fluid text-center">
   <div class="container">
     <div class="page-heading">
-      <%= image_tag 'distributions/leap.svg', alt: "Leap Logo" %>
+      <%= image_tag 'distributions/leap.svg', alt: "Leap Logo", class: "animated fadeInDown", width: "256", height: "256" %>
       <h1 class="display-3">
         openSUSE Leap <%= version %>
       </h1>

--- a/app/views/distributions/leap.html.erb
+++ b/app/views/distributions/leap.html.erb
@@ -35,7 +35,7 @@
         <h3 class="my-3">x86_64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.7GB)
@@ -49,7 +49,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (108MB)
@@ -74,7 +74,7 @@
         <h3 class="my-3">ppc64le</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.2GB)
@@ -88,7 +88,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (71MB)
@@ -106,7 +106,7 @@
         <h3 class="my-3">aarch64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (3.8GB)
@@ -120,7 +120,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (91MB)

--- a/app/views/distributions/testing.html.erb
+++ b/app/views/distributions/testing.html.erb
@@ -40,7 +40,7 @@
       <h3 class="my-3">x86_64</h3>
       <div class="card-deck">
         <div class="card">
-          <div class="card-block">
+          <div class="card-body">
             <h4 class="card-title">
               <span class="typcn typcn-download-outline"></span>
               <%= _("DVD Image") %> (4.7GB)
@@ -54,7 +54,7 @@
           </div>
         </div><!-- /.card -->
         <div class="card">
-          <div class="card-block">
+          <div class="card-body">
             <h4 class="card-title">
               <span class="typcn typcn-download-outline"></span>
               <%= _("Network Image") %> (120MB)
@@ -75,7 +75,7 @@
         <h3 class="my-3">x86_64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 GNOME (950MB)
@@ -88,7 +88,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 KDE (950MB)

--- a/app/views/distributions/testing.html.erb
+++ b/app/views/distributions/testing.html.erb
@@ -1,7 +1,7 @@
 <header class="download-home-header jumbotron jumbotron-fluid text-center">
   <div class="container">
     <div class="page-heading">
-      <%= image_tag 'distributions/testing.svg', alt: "Tumbleweed Logo", class: "animated jackInTheBox", width: "256", height: "256" %>
+      <%= image_tag 'distributions/testing.svg', alt: "Testing Logo", class: "animated jackInTheBox", width: "256", height: "256" %>
       <h1 class="display-3">
           openSUSE Leap <%= @testing_version %> <sup><%= @testing_state %></sup>
       </h1>
@@ -18,59 +18,24 @@
         <%= _('Help test the next version of openSUSE Leap!') %>
       </div>
 
-    <!-- Nav tabs -->
-    <ul class="nav nav-tabs nav-justified" role="tablist">
-      <li class="nav-item">
-        <a class="nav-link active" data-toggle="tab" href="#official-ports" role="tab">
-          <%= _("Installation") %>
-          <span class="badge badge-success">x86_64</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" data-toggle="tab" href="#livecd-ports" role="tab">
-          <%= _("Live") %>
-          <span class="badge badge-success">x86_64</span>
-        </a>
-      </li>
-    </ul>
+      <!-- Nav tabs -->
+      <ul class="nav nav-tabs nav-justified" role="tablist">
+        <li class="nav-item">
+          <a class="nav-link active" data-toggle="tab" href="#official-ports" role="tab">
+            <%= _("Installation") %>
+            <span class="badge badge-success">x86_64</span>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" data-toggle="tab" href="#livecd-ports" role="tab">
+            <%= _("Live") %>
+            <span class="badge badge-success">x86_64</span>
+          </a>
+        </li>
+      </ul>
 
-    <div class="tab-content">
-      <div class="tab-pane active" id="official-ports" role="tabpanel">
-
-      <h3 class="my-3">x86_64</h3>
-      <div class="card-deck">
-        <div class="card">
-          <div class="card-body">
-            <h4 class="card-title">
-              <span class="typcn typcn-download-outline"></span>
-              <%= _("DVD Image") %> (4.7GB)
-            </h4>
-            <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
-            <p class="card-text text-muted"><%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %></p>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
-          </div>
-        </div><!-- /.card -->
-        <div class="card">
-          <div class="card-body">
-            <h4 class="card-title">
-              <span class="typcn typcn-download-outline"></span>
-              <%= _("Network Image") %> (120MB)
-            </h4>
-            <h6 class="card-subtitle mb-2 text-muted"><%= _("For CD and USB stick") %></h6>
-            <p class="card-text text-muted"><%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %></p>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-            <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
-          </div>
-        </div><!-- /.card -->
-      </div><!-- /.card-deck -->
-      </div><!-- /.tab-pane -->
-
-      <div class="tab-pane" id="livecd-ports" role="tabpanel">
+      <div class="tab-content">
+        <div class="tab-pane active" id="official-ports" role="tabpanel">
 
         <h3 class="my-3">x86_64</h3>
         <div class="card-deck">
@@ -78,30 +43,65 @@
             <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                GNOME (950MB)
+                <%= _("DVD Image") %> (4.7GB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <p class="card-text text-muted"><%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %></p>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-DVD-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
           <div class="card">
             <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                KDE (950MB)
+                <%= _("Network Image") %> (120MB)
               </h4>
-              <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-              <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              <h6 class="card-subtitle mb-2 text-muted"><%= _("For CD and USB stick") %></h6>
+              <p class="card-text text-muted"><%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %></p>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+              <a href="https://download.opensuse.org/distribution/leap/<%= @testing_version %>/iso/openSUSE-Leap-<%= @testing_version %>-NET-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
         </div><!-- /.card-deck -->
-      </div><!-- /.tab-pane -->
+        </div><!-- /.tab-pane -->
+
+        <div class="tab-pane" id="livecd-ports" role="tabpanel">
+
+          <h3 class="my-3">x86_64</h3>
+          <div class="card-deck">
+            <div class="card">
+              <div class="card-body">
+                <h4 class="card-title">
+                  <span class="typcn typcn-download-outline"></span>
+                  GNOME (950MB)
+                </h4>
+                <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-GNOME-Live-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              </div>
+            </div><!-- /.card -->
+            <div class="card">
+              <div class="card-body">
+                <h4 class="card-title">
+                  <span class="typcn typcn-download-outline"></span>
+                  KDE (950MB)
+                </h4>
+                <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
+                <a href="https://download.opensuse.org/distribution/leap/15.0/live/openSUSE-Leap-15.0-KDE-Live-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
+              </div>
+            </div><!-- /.card -->
+          </div><!-- /.card-deck -->
+        </div><!-- /.tab-pane -->
 
       </div><!-- /.tab-content -->
 

--- a/app/views/distributions/testing.html.erb
+++ b/app/views/distributions/testing.html.erb
@@ -1,7 +1,7 @@
 <header class="download-home-header jumbotron jumbotron-fluid text-center">
   <div class="container">
     <div class="page-heading">
-      <%= image_tag 'distributions/testing.svg', alt: "Tumbleweed Logo" %>
+      <%= image_tag 'distributions/testing.svg', alt: "Tumbleweed Logo", class: "animated jackInTheBox", width: "256", height: "256" %>
       <h1 class="display-3">
           openSUSE Leap <%= @testing_version %> <sup><%= @testing_state %></sup>
       </h1>

--- a/app/views/distributions/tumbleweed.html.erb
+++ b/app/views/distributions/tumbleweed.html.erb
@@ -73,10 +73,10 @@
             <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("Kubic DVD/USB Stick") %> (1.6GB)
+                <%= _("Kubic Image") %> (1.6GB)
               </h4>
-              <h6 class="card-subtitle mb-2 text-muted"><%= _("For CD and USB stick") %></h6>
-              <p class="card-text text-muted"><%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %></p>
+              <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
+              <p class="card-text text-muted"><%= _("Container as a Service Platform based on Kubernetes atop openSUSE MicroOS.") %></p>
               <a href="https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
               <a href="https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
               <a href="https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>

--- a/app/views/distributions/tumbleweed.html.erb
+++ b/app/views/distributions/tumbleweed.html.erb
@@ -42,7 +42,7 @@
         <h3 class="my-3">x86_64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.7GB)
@@ -56,7 +56,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (85MB)
@@ -70,7 +70,7 @@
             </div>
           </div><!-- /.card -->
 	  <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Kubic DVD/USB Stick") %> (1.6GB)
@@ -88,7 +88,7 @@
         <h3 class="my-3">i586</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.7GB)
@@ -102,7 +102,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (85MB)
@@ -127,7 +127,7 @@
         <h3 class="my-3">ppc64le</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.7GB)
@@ -141,7 +141,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (85MB)
@@ -159,7 +159,7 @@
         <h3 class="my-3">ppc64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("DVD Image") %> (4.7GB)
@@ -173,7 +173,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 <%= _("Network Image") %> (85MB)
@@ -205,7 +205,7 @@
         <h3 class="my-3">x86_64</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 GNOME LiveCD (950MB)
@@ -217,7 +217,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 KDE LiveCD (950MB)
@@ -229,7 +229,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 Rescue LiveCD (650MB)
@@ -245,7 +245,7 @@
         <h3 class="my-3">i586</h3>
         <div class="card-deck">
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 GNOME LiveCD (950MB)
@@ -257,7 +257,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 KDE LiveCD (950MB)
@@ -269,7 +269,7 @@
             </div>
           </div><!-- /.card -->
           <div class="card">
-            <div class="card-block">
+            <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
                 Rescue LiveCD (650MB)

--- a/app/views/distributions/tumbleweed.html.erb
+++ b/app/views/distributions/tumbleweed.html.erb
@@ -69,7 +69,7 @@
               <a href="https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
-	  <div class="card">
+	        <div class="card">
             <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
@@ -192,14 +192,15 @@
       <div class="tab-pane" id="livecd-ports" role="tabpanel">
 
         <div class="alert alert-warning my-3">
-          <%= _('Please be aware of the following limitations of the live images:') %><br>
-	  <ul>
-	    <li> <%= _('They cannot be used to install or upgrade Tumbleweed. Please use the %{tumbleweed_media} instead.') %
-	    { tumbleweed_media: link_to(s_('Tumbleweed installation media'), tumbleweed_distributions_path) } %></li>
-	    <li><%= _('They have a limited package and driver selection, so cannot be considered an accurate reflection as to whether Tumbleweed will work on your hardware or not.') %></li>
+          <p><%= _('Please be aware of the following limitations of the live images:') %></p>
+	        <ul>
+	          <li><%= _('They cannot be used to install or upgrade Tumbleweed. Please use the %{tumbleweed_media} instead.') %
+	            { tumbleweed_media: link_to(s_('Tumbleweed installation media'), tumbleweed_distributions_path) } %></li>
+	          <li><%= _('They have a limited package and driver selection, so cannot be considered an accurate reflection as to whether Tumbleweed will work on your hardware or not.') %></li>
             <li><%= _('They are not tested as thoroughly as the %{tumbleweed_media}.') %
-	    { tumbleweed_media: link_to(s_('Tumbleweed installation media'), tumbleweed_distributions_path) } %></li>
-	    <li><%= _('Please review %{openqa}\'s test results if you want an indication whether these live medias are working as expected.') % { openqa: link_to('openQA', 'https://openqa.opensuse.org/') } %></li>
+	            { tumbleweed_media: link_to(s_('Tumbleweed installation media'), tumbleweed_distributions_path) } %></li>
+            <li><%= _('Please review %{openqa}\'s test results if you want an indication whether these live medias are working as expected.') % { openqa: link_to('openQA', 'https://openqa.opensuse.org/') } %></li>
+          </ul>
         </div>
 
         <h3 class="my-3">x86_64</h3>
@@ -282,6 +283,7 @@
           </div><!-- /.card -->
         </div><!-- /.card-deck -->
       </div><!-- /#unofficial-ports.tab-pane -->
+    </div><!-- /.tab-content -->
   </div><!-- /.container -->
 </section>
 

--- a/app/views/distributions/tumbleweed.html.erb
+++ b/app/views/distributions/tumbleweed.html.erb
@@ -1,7 +1,7 @@
 <header class="download-home-header jumbotron jumbotron-fluid text-center">
   <div class="container">
     <div class="page-heading">
-      <%= image_tag 'distributions/tumbleweed.svg', alt: "Tumbleweed Logo" %>
+      <%= image_tag 'distributions/tumbleweed.svg', alt: "Tumbleweed Logo", class: "animated zoomInDown", width: "256", height: "256" %>
       <h1 class="display-3">
         openSUSE Tumbleweed
       </h1>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -53,7 +53,7 @@
           Language <!-- This label should not be translated! -->
           <div class="dropup dropup_language-menu d-inline-block">
             <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="false" aria-expanded="false">
-              <span class="selected-language"><%= LANGUAGE_NAMES[FastGettext.locale] %></span>
+              <span class="selected-language"><%= LANGUAGE_NAMES[@lang] %></span>
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu dropdown-menu-right">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -45,24 +45,22 @@
           </div>
       </div>
 
-      <div class="row">
-        <div class="col-md-6">
+      <div class="footer-copyright-language-row">
+        <div class="footer-copyright">
           &copy; 2011&ndash;2017 <%= _("openSUSE contributors") %>
         </div>
-        <div class="col-md-6 text-right">
+        <div class="footer-language">
           Language <!-- This label should not be translated! -->
-          <div class="dropup dropup_language-menu d-inline-block">
-            <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="false" aria-expanded="false">
+          <div class="btn-group dropup language-menu">
+            <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="false" aria-expanded="false">
               <span class="selected-language"><%= LANGUAGE_NAMES[@lang] %></span>
               <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-right">
+            <div class="dropdown-menu dropdown-menu-right">
               <% LANGUAGES.sort.each do |lang| %>
-                <li class="dropdown-item">
-                  <%= link_to LANGUAGE_NAMES[lang], params.permit.merge(:locale => lang) %>
-                </li>
+                <%= link_to LANGUAGE_NAMES[lang], params.permit.merge(:locale => lang), class: "dropdown-item" %>
               <% end -%>
-            </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,3 +1,15 @@
+<%
+puts case @lang
+when 'zh_CN'
+  wiki_url = 'https://zh.opensuse.org/'
+when 'zh_TW'
+  wiki_url = 'https://zh-tw.opensuse.org/'
+when 'pt_BR'
+  wiki_url = 'https://pt.opensuse.org/'
+else
+  wiki_url = 'https://' + @lang + '.opensuse.org/'
+end
+%>
 <nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
 
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -20,7 +32,7 @@
                 <a class="nav-link" href="https://doc.opensuse.org/"><%= _("Documentation") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="https://en.opensuse.org/"><%= _("Wiki") %></a>
+                <a class="nav-link" href="<%= wiki_url %>"><%= _("Wiki") %></a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://forums.opensuse.org/"><%= _("Forums") %></a>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav id="global-navbar" class="navbar navbar-toggleable navbar-inverse bg-inverse">
+<nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
 
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,20 +1,20 @@
 <%
 puts case @lang
 when 'zh_CN'
-  @wiki_url = 'https://zh.opensuse.org/'
+  wiki_url = 'https://zh.opensuse.org/'
 when 'zh_TW'
-  @wiki_url = 'https://zh-tw.opensuse.org/'
+  wiki_url = 'https://zh-tw.opensuse.org/'
 when 'pt_BR'
-  @wiki_url = 'https://pt.opensuse.org/'
+  wiki_url = 'https://pt.opensuse.org/'
 else
-  @wiki_url = 'https://' + @lang + '.opensuse.org/'
+  wiki_url = "https://#{@lang}.opensuse.org/"
 end
 
 puts case @lang
 when 'zh_CN'
-  @forum_url = 'https://forum.suse.org.cn/'
+  forum_url = 'https://forum.suse.org.cn/'
 else
-  @forum_url = 'https://forums.opensuse.org/'
+  forum_url = 'https://forums.opensuse.org/'
 end
 %>
 <nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
@@ -39,10 +39,10 @@ end
                 <a class="nav-link" href="https://doc.opensuse.org/"><%= _("Documentation") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="<%= @wiki_url %>"><%= _("Wiki") %></a>
+                <a class="nav-link" href="<%= wiki_url %>"><%= _("Wiki") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="<%= @forum_url %>"><%= _("Forums") %></a>
+                <a class="nav-link" href="<%= forum_url %>"><%= _("Forums") %></a>
             </li>
         </ul>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,20 +1,20 @@
 <%
 puts case @lang
 when 'zh_CN'
-  wiki_url = 'https://zh.opensuse.org/'
+  @wiki_url = 'https://zh.opensuse.org/'
 when 'zh_TW'
-  wiki_url = 'https://zh-tw.opensuse.org/'
+  @wiki_url = 'https://zh-tw.opensuse.org/'
 when 'pt_BR'
-  wiki_url = 'https://pt.opensuse.org/'
+  @wiki_url = 'https://pt.opensuse.org/'
 else
-  wiki_url = 'https://' + @lang + '.opensuse.org/'
+  @wiki_url = 'https://' + @lang + '.opensuse.org/'
 end
 
 puts case @lang
 when 'zh_CN'
-  forum_url = 'https://forum.suse.org.cn/'
+  @forum_url = 'https://forum.suse.org.cn/'
 else
-  forum_url = 'https://forums.opensuse.org/'
+  @forum_url = 'https://forums.opensuse.org/'
 end
 %>
 <nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
@@ -39,10 +39,10 @@ end
                 <a class="nav-link" href="https://doc.opensuse.org/"><%= _("Documentation") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="<%= wiki_url %>"><%= _("Wiki") %></a>
+                <a class="nav-link" href="<%= @wiki_url %>"><%= _("Wiki") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="<%= forum_url %>"><%= _("Forums") %></a>
+                <a class="nav-link" href="<%= @forum_url %>"><%= _("Forums") %></a>
             </li>
         </ul>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -9,6 +9,13 @@ when 'pt_BR'
 else
   wiki_url = 'https://' + @lang + '.opensuse.org/'
 end
+
+puts case @lang
+when 'zh_CN'
+  forum_url = 'https://forum.suse.org.cn/'
+else
+  forum_url = 'https://forums.opensuse.org/'
+end
 %>
 <nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
 
@@ -35,7 +42,7 @@ end
                 <a class="nav-link" href="<%= wiki_url %>"><%= _("Wiki") %></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="https://forums.opensuse.org/"><%= _("Forums") %></a>
+                <a class="nav-link" href="<%= forum_url %>"><%= _("Forums") %></a>
             </li>
         </ul>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -19,15 +19,17 @@ end
 %>
 <nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark bg-dark">
 
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
+  <a class="navbar-brand" href="https://www.opensuse.org/">
+    <img src="/chameleon/images/logo/logo-white.svg" width="48" height="30" class="d-inline-block align-top" alt="openSUSE Logo">
+  </a>
 
-    <a class="navbar-brand" href="https://www.opensuse.org/">
-        <img src="/chameleon/images/logo/logo-white.svg" width="48" height="30" class="d-inline-block align-top" alt="openSUSE Logo">
-    </a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#global-navbar-content" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
 
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+
+    <div class="collapse navbar-collapse" id="global-navbar-content">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item <%= 'active' if defined?(activenav) && (activenav == 'download') %>">
                 <a class="nav-link" href="/"><%= _("Download") %></a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.dup.sub! '_', '-' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= @lang %>" lang="<%= @lang %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.sub! '_', '-' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.dup.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/download.html.erb
+++ b/app/views/layouts/download.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.dup.sub! '_', '-' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= @lang %>" lang="<%= @lang %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/download.html.erb
+++ b/app/views/layouts/download.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.sub! '_', '-' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.dup.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/download.html.erb
+++ b/app/views/layouts/download.html.erb
@@ -77,18 +77,6 @@
       <%= render(:partial => "layouts/flash", :object => flash) %>
     <% end %>
 
-
-    <% unless @hide_search_box %>
-      <%# Caching is really crucial in the front page (at release date, at least) %>
-    <% if controller.controller_name == "main" && controller.action_name == "release" %>
-        <% cache :locale => @lang, :baseproject => (@baseproject || default_baseproject) do %>
-          <%= render :partial => 'search/find_form' %>
-        <% end %>
-      <% else %>
-        <%= render :partial => 'search/find_form' %>
-      <% end %>
-    <% end %>
-
     <%= yield %>
 
     <%= render :partial => "layouts/footer" %>

--- a/app/views/layouts/download.html.erb
+++ b/app/views/layouts/download.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="<%= @lang.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/jekyll.html.erb
+++ b/app/views/layouts/jekyll.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= @lang.dup.sub! '_', '-' %>">
+<html lang="<%= @lang %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/jekyll.html.erb
+++ b/app/views/layouts/jekyll.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= @lang %>">
+<html lang="<%= @lang.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/jekyll.html.erb
+++ b/app/views/layouts/jekyll.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= @lang.sub! '_', '-' %>">
+<html lang="<%= @lang.dup.sub! '_', '-' %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/package/_download_rows.html.erb
+++ b/app/views/package/_download_rows.html.erb
@@ -14,7 +14,7 @@
   end -%>
   
   <div class="card mb-2">
-    <div class="card-block row">
+    <div class="card-body row">
       
       <div class="col-md-6">
         <%= link_to name, pkg_link %>
@@ -63,6 +63,6 @@
         </div>
 
       </div><!-- /.col- -->
-    </div><!-- /.card-block -->
+    </div><!-- /.card-body -->
   </div><!-- /.card -->
 <% end -%>

--- a/app/views/search/_find_form.html.erb
+++ b/app/views/search/_find_form.html.erb
@@ -1,20 +1,20 @@
 <div class="search-box py-5">
   <div class="container">
-    <%= form_tag( {:controller => 'search', :action => :index}, :method => :get ) do %>
-      <div class="d-flex justify-content-center">
-        <%= text_field_tag 'q', @search_term, :size => 30, :id => "search-form", :class => 'form-control mr-2', :placeholder => 'Search packages...', :autocomplete => "off", :autofocus => true %>
-        
-        <button type="submit" class="btn btn-primary mr-2 hidden-sm-down">
+    <%= form_tag( {:controller => 'search', :action => :index}, :method => :get, :class => 'd-sm-flex align-items-center' ) do %>
+      <%= text_field_tag 'q', @search_term, :size => 30, :id => "search-form", :class => 'form-control mr-2 mb-2', :placeholder => 'Search packages...', :autocomplete => "off", :autofocus => true %>
+
+      <div class="d-flex mb-2">
+        <button type="submit" class="btn btn-primary mr-2">
           <span class="typcn typcn-lg typcn-zoom-outline"></span>
-          <span class="hidden-xs-down">Search</span>
-        </button>
-        
-        <button type="button" class="btn btn-link" data-toggle="modal" data-target="#search-config-modal">
-            <span class="typcn typcn-lg typcn-spanner-outline"></span>
-            <span class="hidden-xs-down">Settings</span>
+          Search
         </button>
 
+        <button type="button" class="btn btn-link" data-toggle="modal" data-target="#search-config-modal">
+          <span class="typcn typcn-lg typcn-spanner-outline"></span>
+          Settings
+        </button>
       </div>
+
 
       <div class="modal fade" id="search-config-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">

--- a/app/views/search/_find_results.html.erb
+++ b/app/views/search/_find_results.html.erb
@@ -48,7 +48,7 @@
 
               <a class="card-img-top" style="background-image: url(<%= thumb_url %>)" href="<%= url_for :controller => :package, :action => :show, :package => package, :protocol => 'https' %>">
               </a>
-              <div class="card-block">
+              <div class="card-body">
                 <h4 class="card-title"><%= link_to highlight(package_name, @search_term), :controller => :package, :action => :show, :package => package  %></h4>
                 <p class="card-text">
                   <% 

--- a/config/initializers/languages.rb
+++ b/config/initializers/languages.rb
@@ -8,14 +8,43 @@ Dir.glob("#{Rails.root.join('locale')}/*/software.po").each { |file|
    LANGUAGES << lang
 }
 
-LANGUAGE_NAMES = {'en' => 'English', 'de' => 'Deutsch', 'bg' => 'български', 'da' => 'dansk',
-                  'cs' => 'čeština', 'es' => 'español', 'fi' => 'suomi', 'fr' => 'français',
-                  'gl' => 'Galego', 'hu' => 'magyar', 'ja' => '日本語', 'it' => 'italiano',
-                  'km' => 'ភាសាខ្មែរ', 'ko' => '한국어 [韓國語]', 'lt' => 'lietuvių kalba', 'nb' => 'Bokmål',
-                  'nl' => 'Nederlands', 'pl' => 'polski', 'ro' => 'român', 'ru' => 'Русский язык',
-                  'sk' => 'slovenčina', 'th' => 'ภาษาไทย', 'uk' => 'Українська', 'wa' => 'walon',
-                  'pt_BR' => 'português', 'zh_TW' => '台語', 'zh_CN' => '简体中文',
-                  'el' => 'ελληνικά', 'ar' => 'العربية', 'ca' => 'Català'}
+LANGUAGE_NAMES = {
+  'ar' => 'العربية',
+  'bg' => 'български',
+  'ca' => 'Català',
+  'cs' => 'čeština',
+  'da' => 'dansk',
+  'de' => 'Deutsch',
+  'el' => 'ελληνικά',
+  'en' => 'English',
+  'es' => 'español',
+  'fa' => 'زبان فارسی',
+  'fi' => 'suomi',
+  'fr' => 'français',
+  'gl' => 'Galego',
+  'hi' => 'हिन्दी',
+  'hu' => 'magyar',
+  'id' => 'Bahasa Indonesia',
+  'it' => 'italiano',
+  'ja' => '日本語',
+  'km' => 'ភាសាខ្មែរ',
+  'ko' => '한국어 [韓國語]',
+  'lt' => 'lietuvių kalba',
+  'nb' => 'Bokmål',
+  'nl' => 'Nederlands',
+  'nn' => 'Norsk',
+  'pl' => 'polski',
+  'pt_BR' => 'português',
+  'ro' => 'român',
+  'ru' => 'Русский язык',
+  'sk' => 'slovenčina',
+  'sv' => 'Svenska',
+  'th' => 'ภาษาไทย',
+  'uk' => 'Українська',
+  'wa' => 'walon',
+  'zh_TW' => '繁體中文',
+  'zh_CN' => '简体中文',
+}
 
 # Use po files for development/test...
 FastGettext.add_text_domain('software', path: 'locale', type: :po, ignore_fuzzy: true, report_warning: false) unless Rails.env.production?


### PR DESCRIPTION
1. Update to Bootstrap v4.1.0. jQuery to latest version.
2. Removed search bar from download pages. So download & software pages have different functions.
3. Fix #228 (Bootstrap updates).
4. Add language code to HTML and better CJK typeface.
5. Align footer copyright text with language dropdown button. Add missing language names.
6. Add some attractive animation to Tumbleweed and Leap logo.
7. Link to different language wikis based on user's language choice.
8. Link to Chinese forum for Simple Chinese user.
9. Some small style improvements.