### PR TITLE
Add search result integration tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,13 +11,6 @@ AllCops:
     - 'script/**/*'
     - 'vendor/**/*'
 
-Metrics/BlockLength:
-  Exclude:
-    - 'test/test_helper.rb'
-Metrics/LineLength:
-  Exclude:
-    - 'test/test_helper.rb'
-
 # FIXME: Cop disabled as it Rubocop fails when enabling it. Enable it when the bug is solved.
 # Checks for array literals made up of word-like strings, that are not using the %w() syntax.    
 Style/WordArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,13 @@ AllCops:
     - 'script/**/*'
     - 'vendor/**/*'
 
+Metrics/BlockLength:
+  Exclude:
+    - 'test/test_helper.rb'
+Metrics/LineLength:
+  Exclude:
+    - 'test/test_helper.rb'
+
 # FIXME: Cop disabled as it Rubocop fails when enabling it. Enable it when the bug is solved.
 # Checks for array literals made up of word-like strings, that are not using the %w() syntax.    
 Style/WordArray:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ rvm:
 script:
   - 'bundle exec rubocop -D'
   - 'bundle exec rails test'
+  - 'bundle exec rails test:system'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 dist: trusty
 language: ruby
 cache: bundler
+addons:
+  firefox: latest
 rvm:
   - 2.4.3
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'faker'
   gem 'geckodriver-helper'
   gem 'rubocop', "~> 0.49.0"
   gem 'selenium-webdriver'

--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,9 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'poltergeist'
+  gem 'geckodriver-helper'
   gem 'rubocop', "~> 0.49.0"
+  gem 'selenium-webdriver'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,18 +44,21 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.3)
-    capybara (2.18.0)
+    capybara (3.0.3)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -81,6 +84,8 @@ GEM
     execjs (2.7.0)
     fast_gettext (1.6.0)
     ffi (1.9.23)
+    geckodriver-helper (0.0.5)
+      archive-zip (~> 0.7)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -92,6 +97,7 @@ GEM
     hashie (3.5.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -114,17 +120,13 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pkg-config (1.3.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (3.0.2)
     puma (3.11.4)
@@ -176,6 +178,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -184,6 +187,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.11.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -201,7 +207,7 @@ GEM
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.2)
-    webmock (3.3.0)
+    webmock (3.4.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -221,6 +227,7 @@ DEPENDENCIES
   compass-rails
   dalli
   fast_gettext (>= 0.7.0)
+  geckodriver-helper
   gettext (>= 1.9.3)
   gettext_i18n_rails (>= 0.4.3)
   hashie
@@ -229,13 +236,13 @@ DEPENDENCIES
   mini_magick
   minitest
   nokogiri
-  poltergeist
   puma
   rails (~> 5.2)
   rails-i18n
   rbtrace
   rubocop (~> 0.49.0)
   sass-rails
+  selenium-webdriver
   uglifier
   webmock
   xmlhash (>= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     dalli (2.7.8)
     erubi (1.7.1)
     execjs (2.7.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     fast_gettext (1.6.0)
     ffi (1.9.23)
     geckodriver-helper (0.0.5)
@@ -226,6 +228,7 @@ DEPENDENCIES
   capybara
   compass-rails
   dalli
+  faker
   fast_gettext (>= 0.7.0)
   geckodriver-helper
   gettext (>= 1.9.3)

--- a/app/views/search/_find_form.html.erb
+++ b/app/views/search/_find_form.html.erb
@@ -3,7 +3,6 @@
     <%= form_tag( {:controller => 'search', :action => :index}, :method => :get ) do %>
       <div class="d-flex justify-content-center">
         <%= text_field_tag 'q', @search_term, :size => 30, :id => "search-form", :class => 'form-control mr-2', :placeholder => _('Search packages...'), :autocomplete => "off", :autofocus => true %>
-
         <button type="submit" class="btn btn-primary mr-2 hidden-sm-down">
           <span class="typcn typcn-lg typcn-zoom-outline"></span>
           <span class="hidden-xs-down"><%= _("Search") %></span>

--- a/test/integration/validate_configuration_test.rb
+++ b/test/integration/validate_configuration_test.rb
@@ -7,9 +7,9 @@ class ValidateConfigurationTest < ActionDispatch::IntegrationTest
     Rails.configuration.x.api_username = nil
     Rails.configuration.x.opensuse_cookie = nil
 
-    visit '/'
-    page.assert_text 'The authentication to the OBS API has not been configured correctly.'
-    assert_equal 503, page.status_code
+    get '/'
+    assert_includes body, 'The authentication to the OBS API has not been configured correctly.'
+    assert_equal 503, status
 
     # Restore normal configuration values for other tests
     Rails.configuration.x = x

--- a/test/system/package_information_test.rb
+++ b/test/system/package_information_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 
-class PackageInformationTest < ActionDispatch::IntegrationTest
-
+class PackageInformationTest < ActionDispatch::SystemTestCase
   def test_package_information
     # Check that package information is displayed
     visit '/package/pidgin'

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class SearchResultsTest < ActionDispatch::SystemTestCase
+  def test_default_searches
+    stub_search_random('nvidia', 'openSUSE:Leap:42.3')
+    visit '/'
+    page.fill_in 'q', with: 'nvidia'
+    page.find('button[type="submit"]').click
+
+    page.assert_text 'for instructions how to configure your NVIDIA graphics card'
+  end
+
+  def test_non_existing_packages
+    stub_search_random('paralapapiricoipi', 'openSUSE:Leap:42.3', matches: 0)
+    visit '/'
+    page.fill_in 'q', with: 'paralapapiricoipi'
+    page.find('button[type="submit"]').click
+
+    page.assert_text 'No packages found matching your search.'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,7 +82,7 @@ class ActiveSupport::TestCase
     contains-ic(@name, '#{term}') and path/project='#{baseproject}' and
       not(contains-ic(@name, '-debuginfo')) and not(contains-ic(@name, '-debugsource')) and
       not(contains-ic(@name, '-devel')) and not(contains-ic(@name, '-lang'))
-    }
+    }.squish
     stub_content("api.opensuse.org/search/published/binary/id?match=#{URI.escape(xpath)}", builder.to_xml)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,10 +31,9 @@ class ActiveSupport::TestCase
   # Stubs a search for a term and a project with random data
   # opts :matches sets the number of results, otherwise random
   def stub_search_random(term, baseproject, opts = {})
-    xpath = "contains-ic(@name,%20'#{term}')%20and%20path/project='#{baseproject}'%20and%20not(contains-ic(@name,%20'-debuginfo'))%20and%20not(contains-ic(@name,%20'-debugsource'))%20and%20not(contains-ic(@name,%20'-devel'))%20and%20not(contains-ic(@name,%20'-lang'))"
-
     matches = (opts[:matches] || (1..10).to_a.sample).to_i
 
+    # rubocop:disable Metrics/BlockLength
     builder = Nokogiri::XML::Builder.new do |xml|
       xml.collection(matches: matches) do
         matches.times.each do
@@ -77,7 +76,14 @@ class ActiveSupport::TestCase
         end
       end
     end
-    stub_content("api.opensuse.org/search/published/binary/id?match=#{xpath}", builder.to_xml)
+    # rubocop:enable Metrics/BlockLength
+
+    xpath = %{
+    contains-ic(@name, '#{term}') and path/project='#{baseproject}' and
+      not(contains-ic(@name, '-debuginfo')) and not(contains-ic(@name, '-debugsource')) and
+      not(contains-ic(@name, '-devel')) and not(contains-ic(@name, '-lang'))
+    }
+    stub_content("api.opensuse.org/search/published/binary/id?match=#{URI.escape(xpath)}", builder.to_xml)
   end
 
   APPDATA_CHECKSUM = "a63a63d45b002d5ff8f37c09315cda2c4a9d89ae698f56e95b92f1274332c157".freeze

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'capybara/rails'
 class ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_firefox, screen_size: [1400, 1400]
 end
-Capybara.default_driver = :poltergeist
 
 require 'webmock/minitest'
 # Prevent webmock to prevent capybara to connect to localhost

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,9 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 require 'capybara/rails'
-require 'capybara/poltergeist'
-Capybara.default_driver = :poltergeist
+class ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_firefox, screen_size: [1400, 1400]
+end
 
 require 'webmock/minitest'
 # Prevent webmock to prevent capybara to connect to localhost
@@ -42,15 +43,5 @@ class ActiveSupport::TestCase
 
   teardown do
     WebMock.reset!
-  end
-end
-
-class ActionDispatch::IntegrationTest
-  # Make the Capybara DSL available in all integration tests
-  include Capybara::DSL
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end


### PR DESCRIPTION
This PR adds integration tests for the search of "known" searches, which include hints described in a config file (`config/default_searches.yml`), like `nvidia`, and also tests for searches without results.

To get there, it adds a helper that allow to mock searches with random data.

```ruby
stub_search_random('nvidia', 'openSUSE:Leap:42.3')
```

This produces the following in the Capybara/Poltergeist virtual browser:

![screenshot](https://user-images.githubusercontent.com/15332/39625304-1ef3206a-4f9d-11e8-8c1e-07241bda18a3.png)

![screenshot2](https://user-images.githubusercontent.com/15332/39625303-1ed97c0a-4f9d-11e8-8ec9-4352580b916d.png)

