### PR TITLE
Replace PhantomJS with Headless Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 dist: trusty
 language: ruby
 cache: bundler
+addons:
+  firefox: latest
 rvm:
   - 2.4.3
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,9 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'poltergeist'
+  gem 'geckodriver-helper'
   gem 'rubocop', "~> 0.49.0"
+  gem 'selenium-webdriver'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,18 +44,21 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.3)
-    capybara (2.18.0)
+    capybara (3.0.3)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -81,6 +84,8 @@ GEM
     execjs (2.7.0)
     fast_gettext (1.6.0)
     ffi (1.9.23)
+    geckodriver-helper (0.0.5)
+      archive-zip (~> 0.7)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -92,6 +97,7 @@ GEM
     hashie (3.5.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -114,17 +120,13 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pkg-config (1.3.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (3.0.2)
     puma (3.11.4)
@@ -176,6 +178,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -184,6 +187,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.11.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -201,7 +207,7 @@ GEM
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.2)
-    webmock (3.3.0)
+    webmock (3.4.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -221,6 +227,7 @@ DEPENDENCIES
   compass-rails
   dalli
   fast_gettext (>= 0.7.0)
+  geckodriver-helper
   gettext (>= 1.9.3)
   gettext_i18n_rails (>= 0.4.3)
   hashie
@@ -229,13 +236,13 @@ DEPENDENCIES
   mini_magick
   minitest
   nokogiri
-  poltergeist
   puma
   rails (~> 5.2)
   rails-i18n
   rbtrace
   rubocop (~> 0.49.0)
   sass-rails
+  selenium-webdriver
   uglifier
   webmock
   xmlhash (>= 1.2.2)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,13 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 require 'capybara/rails'
-require 'capybara/poltergeist'
-Capybara.default_driver = :poltergeist
+Capybara.register_driver :firefox_headless do |app|
+  options = ::Selenium::WebDriver::Firefox::Options.new
+  options.args << '--headless'
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+end
+Capybara.default_driver = :firefox_headless
 
 require 'webmock/minitest'
 # Prevent webmock to prevent capybara to connect to localhost


### PR DESCRIPTION
When Headless Chrome was released, PhantomJS was [deprecated/abandoned](https://groups.google.com/forum/m/#!topic/phantomjs/9aI5d-LDuNE), as it did not make sense anymore.

Since Firefox 56, headless mode is also supported, and there is a nifty gem that installs the binary of the selenium webdriver for you.

This PR changes the integration tests to use Firefox instead of PhantomJS.

Depends on Rails 5.2 (https://github.com/openSUSE/software-o-o/pull/266), due to: rails/rails#29688
(fix not working here on Rails 5.1.6)

Also, the tests that need access to the status code stay as integration tests, as
Selenium Webdriver does not support access to the status code:
https://github.com/SeleniumHQ/selenium-google-code-issue-archive/issues/404