### PR TITLE
Make /search the default index page, and disable search box in download page

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -31,11 +31,11 @@ end
 
     <div class="collapse navbar-collapse" id="global-navbar-content">
         <ul class="navbar-nav mr-auto">
-            <li class="nav-item <%= 'active' if defined?(activenav) && (activenav == 'download') %>">
-                <a class="nav-link" href="/"><%= _("Download") %></a>
-            </li>
             <li class="nav-item <%= 'active' unless defined?(activenav) && (activenav == 'download') %>">
                 <a class="nav-link" href="/search"><%= _("Software") %></a>
+            </li>
+            <li class="nav-item <%= 'active' if defined?(activenav) && (activenav == 'download') %>">
+                <a class="nav-link" href="/distributions"><%= _("Download") %></a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://doc.opensuse.org/"><%= _("Documentation") %></a>

--- a/app/views/layouts/download.html.erb
+++ b/app/views/layouts/download.html.erb
@@ -77,18 +77,6 @@
       <%= render(:partial => "layouts/flash", :object => flash) %>
     <% end %>
 
-
-    <% unless @hide_search_box %>
-      <%# Caching is really crucial in the front page (at release date, at least) %>
-    <% if controller.controller_name == "main" && controller.action_name == "release" %>
-        <% cache :locale => @lang, :baseproject => (@baseproject || default_baseproject) do %>
-          <%= render :partial => 'search/find_form' %>
-        <% end %>
-      <% else %>
-        <%= render :partial => 'search/find_form' %>
-      <% end %>
-    <% end %>
-
     <%= yield %>
 
     <%= render :partial => "layouts/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 SoftwareOO::Application.routes.draw do
 
-  root to: 'distributions#index'
+  root to: 'search#index'
 
   resources :distributions, only: [:index] do
     collection do


### PR DESCRIPTION
Right now we have two pages:

* Download (home page) link, pointing to /distributions

![screenshot from 2018-05-07 22-33-43](https://user-images.githubusercontent.com/15332/39723754-17785ed4-5247-11e8-9c87-c30e46259129.png)

* Search link, pointing to /search

![screenshot from 2018-05-07 22-33-57](https://user-images.githubusercontent.com/15332/39723753-1759f624-5247-11e8-9b1d-2816c2426842.png)

This does not make sense, as the search bar is *in both*. However, we don't want to just remove it and need an extra click to access the search functionality.

The proposal is to remove the search from /distributions, but make /search the default index page. Most people accessing /distributions come from https://opensuse.org directly to a subpage of /distributions like https://software.opensuse.org/distributions/leap , so /distributions already overlaps with opensuse.org.

With this proposal, users accessing https://software.opensuse.org would see the search bar:
(@guoyunhe proposes adding some featured apps later).

![screenshot from 2018-05-07 22-33-28](https://user-images.githubusercontent.com/15332/39723755-179c3f52-5247-11e8-9fec-8a8242b0f809.png)

Clicking [Download](https://software.opensuse.org/distributions) would go to the distribution list.

![screenshot from 2018-05-07 22-33-11](https://user-images.githubusercontent.com/15332/39723756-17bc017a-5247-11e8-9425-3a2773bfc2d2.png)

Links from opensuse.org, would be unchanged.