### PR TITLE
Remove SUSE Studio link from footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -9,7 +9,6 @@
                   <li><a href="https://bugzilla.opensuse.org/">Bugzilla</a></li>
                   <li><a href="https://github.com/openSUSE">Github</a></li>
                   <li><a href="https://features.opensuse.org/">openFATE</a></li>
-                  <li><a href="https://susestudio.com/">SUSE Studio</a></li>
               </ul>
           </div>
           <div class="col-6 col-md-3">


### PR DESCRIPTION
SUSE Studio does not exist anymore and the link is dead.