### PR TITLE
Automatically switch Leap logo based on testing/release

### DIFF
--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -1,0 +1,7 @@
+# Helper for distribution controller
+module DistributionHelper
+  def leap_image_tag(opts = {})
+    return image_tag('distributions/testing.svg', opts) if action_name == 'testing'
+    image_tag('distributions/leap.svg', opts)
+  end
+end

--- a/app/views/distributions/leap-15.0.html.erb
+++ b/app/views/distributions/leap-15.0.html.erb
@@ -1,7 +1,7 @@
 <header class="download-home-header jumbotron jumbotron-fluid text-center">
   <div class="container">
     <div class="page-heading">
-      <%= image_tag 'distributions/testing.svg', alt: "Testing Logo", class: "animated jackInTheBox", width: "256", height: "256" %>
+      <%= leap_image_tag alt: "Leap 15 Logo", class: "animated jackInTheBox", width: "256", height: "256" %>
       <h1 class="display-3">
         openSUSE Leap <%= @version %> <sup><%= @testing_state %></sup>
       </h1>

--- a/test/integration/distributions_test.rb
+++ b/test/integration/distributions_test.rb
@@ -6,13 +6,13 @@ class DistributionsTest < ActionDispatch::IntegrationTest
       get '/distributions/leap'
       assert_includes body, 'openSUSE Leap 42.3'
       assert_includes body, 'Choosing Which Media to Download'
-      assert_includes body, 'assets/distributions/leap.svg'
+      assert_match %r{assets\/distributions\/leap(.*)\.svg}, body
       assert_equal 200, status
 
       get '/distributions/testing'
       assert_includes body, 'openSUSE Leap 15.0'
       assert_includes body, 'Help test the next version of openSUSE Leap!'
-      assert_includes body, 'assets/distributions/testing.svg'
+      assert_match %r{assets\/distributions\/testing(.*)\.svg}, body
 
       assert_equal 200, status
     end
@@ -23,7 +23,8 @@ class DistributionsTest < ActionDispatch::IntegrationTest
       get '/distributions/leap'
       assert_includes body, 'openSUSE Leap 15.0'
       assert_includes body, 'Choosing Which Media to Download'
-      assert_includes body, 'assets/distributions/leap.svg'
+      assert_match %r{assets\/distributions\/leap(.*)\.svg}, body
+
       assert_equal 200, status
 
       get '/distributions/testing'

--- a/test/integration/distributions_test.rb
+++ b/test/integration/distributions_test.rb
@@ -6,11 +6,13 @@ class DistributionsTest < ActionDispatch::IntegrationTest
       get '/distributions/leap'
       assert_includes body, 'openSUSE Leap 42.3'
       assert_includes body, 'Choosing Which Media to Download'
+      assert_includes body, 'assets/distributions/leap.svg'
       assert_equal 200, status
 
       get '/distributions/testing'
       assert_includes body, 'openSUSE Leap 15.0'
       assert_includes body, 'Help test the next version of openSUSE Leap!'
+      assert_includes body, 'assets/distributions/testing.svg'
 
       assert_equal 200, status
     end
@@ -21,6 +23,7 @@ class DistributionsTest < ActionDispatch::IntegrationTest
       get '/distributions/leap'
       assert_includes body, 'openSUSE Leap 15.0'
       assert_includes body, 'Choosing Which Media to Download'
+      assert_includes body, 'assets/distributions/leap.svg'
       assert_equal 200, status
 
       get '/distributions/testing'


### PR DESCRIPTION
If the current page is "testing", use the testing logo.

Alternative approach to https://github.com/openSUSE/software-o-o/pull/307