### PR TITLE
Corrrect Leap 15 DVD size

### DIFF
--- a/app/views/distributions/leap-15.0.html.erb
+++ b/app/views/distributions/leap-15.0.html.erb
@@ -36,7 +36,7 @@
             <div class="card-body">
               <h4 class="card-title">
                 <span class="typcn typcn-download-outline"></span>
-                <%= _("DVD Image") %> (4.7GB)
+                <%= _("DVD Image") %> (3.6GB)
               </h4>
               <h6 class="card-subtitle mb-2 text-muted"><%= _("For DVD and USB stick") %></h6>
               <p class="card-text text-muted"><%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %></p>


### PR DESCRIPTION
Leap 15 DVD size is 3.6GB (detected by Firefox download).