### PR TITLE
Fix set search options

### DIFF
--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -50,7 +50,7 @@ class OBSController < ApplicationController
 
   def set_search_options
     @search_term = params[:q] || ""
-    @baseproject =  if !cookies[:baseproject].nil? && @distributions.select { |d| d[:project] == cookies[:baseproject] }
+    @baseproject =  if cookies[:baseproject] && @distributions.select { |d| d[:project] == cookies[:baseproject] }
                       cookies[:baseproject]
                     else
                       "openSUSE:Factory"

--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -50,7 +50,7 @@ class OBSController < ApplicationController
 
   def set_search_options
     @search_term = params[:q] || ""
-    @baseproject =  if cookies[:baseproject] && @distributions.select { |d| d[:project] == cookies[:baseproject] }
+    @baseproject =  if cookies[:baseproject] && @distributions.any? { |d| d[:project] == cookies[:baseproject] }
                       cookies[:baseproject]
                     else
                       "openSUSE:Factory"


### PR DESCRIPTION
Array#select always returns an array. Because of that the second part
of the condition would always evaluate to true.
Using `any?` solves the issue. Since `any?` returns with the first match this also reduces the number of iterations (if there is a match).
