### PR TITLE
Responsive search form layout

### DIFF
--- a/app/views/search/_find_form.html.erb
+++ b/app/views/search/_find_form.html.erb
@@ -1,21 +1,26 @@
 <div class="search-box py-5">
   <div class="container">
     <%= form_tag( {:controller => 'search', :action => :index}, :method => :get ) do %>
-      <div class="d-flex justify-content-center">
-        <%= text_field_tag 'q', @search_term, :size => 30, :type => "search", :id => "search-form", :class => 'form-control mr-2', :placeholder => _('Search packages...'), :autocomplete => "off", :autofocus => true %>
-
-        <button id="search-button" type="submit" class="btn btn-primary mr-2 hidden-sm-down">
-          <span class="typcn typcn-lg typcn-zoom-outline"></span>
-          <span class="hidden-xs-down"><%= _("Search") %></span>
-        </button>
-
-        <button id="settings-button" type="button" class="btn btn-link" data-toggle="modal" data-target="#search-settings">
+      <div class="row">
+        <div class="col-12 col-sm-6 col-lg-8">
+          <div class="form-group">
+            <%= text_field_tag 'q', @search_term, :id => "search-form", :class => 'form-control', :placeholder => _('Search packages...'), :autocomplete => "off", :autofocus => true %>
+          </div>
+        </div>
+        <div class="col-6 col-sm-3 col-lg-2">
+          <button id="search-button" type="submit" class="btn btn-primary btn-block">
+            <span class="typcn typcn-lg typcn-zoom-outline"></span>
+            <%= _("Search") %>
+          </button>
+        </div>
+        <div class="col-6 col-sm-3 col-lg-2">
+          <button id="settings-button" type="button" class="btn btn-secondary btn-block" data-toggle="modal" data-target="#search-config-modal">
             <span class="typcn typcn-lg typcn-spanner-outline"></span>
-            <span class="hidden-xs-down"><%= _("Settings") %></span>
-        </button>
+            <%= _("Settings") %>
+          </button>
+        </div>
       </div>
     <% end -%>
   </div>
 </div>
-
 <%= render :partial => 'search/settings' %>


### PR DESCRIPTION
Before:

![2018-05-16 14 39 15](https://user-images.githubusercontent.com/5836790/40114864-1e241814-5917-11e8-9dac-cee5b01d25c9.png)

After:

![2018-05-16 14 36 27](https://user-images.githubusercontent.com/5836790/40114828-fb44aab6-5916-11e8-94fb-10b45c01279a.png)
