### PR TITLE
Mark show packages button

### DIFF
--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -81,8 +81,10 @@
             s.project.match( /#{distro[:project]}\:NonFree/ ) || s.project.match( /openSUSE\:Maintenance\:/ ) } %>
 
         <p>
-          <button class="btn btn-sm btn-warning" type="button" data-toggle="collapse" data-target="#<%= slug %>-experimental-packages"><%= _("Show experimental packages") %></button>
-          <button class="btn btn-sm btn-danger" type="button" data-toggle="collapse" data-target="#<%= slug %>-community-packages"><%= _("Show community packages") %></button>
+        <% devel_disabled = 'disabled' if devel.empty? %>
+        <button class="btn btn-sm btn-warning" <%= devel_disabled %> type="button" data-toggle="collapse" data-target="#<%= slug %>-experimental-packages"><%= _("Show experimental packages") %></button>
+        <% home_disabled = 'disabled' if home.empty? %>
+        <button class="btn btn-sm btn-danger" <%= home_disabled %> type="button" data-toggle="collapse" data-target="#<%= slug %>-community-packages"><%= _("Show community packages") %></button>
         </p>
         <!-- experimental packages -->
         <div id="<%= slug %>-experimental-packages" class="collapse">


### PR DESCRIPTION
On the package search page users are presented two buttons (per
distribution) that can be collapsed to show a list of packages.
Since these buttons were not indicating whether there would be any
packages in the list, users would always have to click through all
buttons.

This patch adds the disabled class to buttons that won't show any
results when clicked.


![image](https://user-images.githubusercontent.com/968949/41205650-9c6096f0-6cf7-11e8-97c1-ab34df0c88da.png)
