### PR TITLE
Add open_uri_redirections gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'nokogiri'
 gem 'rails', '~> 5.2'
 
+# For appdata redirections (https -> http)
+gem 'open_uri_redirections'
 # Use SCSS for stylesheets
 gem 'sass-rails'
 # With compass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    open_uri_redirections (0.2.1)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -239,6 +240,7 @@ DEPENDENCIES
   mini_magick
   minitest
   nokogiri
+  open_uri_redirections
   puma
   rails (~> 5.2)
   rails-i18n

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'open_uri_redirections'
 require 'zlib'
 
 class Appdata
@@ -45,7 +46,7 @@ class Appdata
                     "https://download.opensuse.org/distribution/#{dist}/repo/#{flavour}/suse/setup/descr/appdata.xml.gz"
                   end
     begin
-      Nokogiri::XML(Zlib::GzipReader.new(open(appdata_url)))
+      Nokogiri::XML(Zlib::GzipReader.new(open(appdata_url, allow_redirections: :all)))
     rescue StandardError => e
       Rails.logger.error e
       Rails.logger.error "Can't retrieve appdata from: '#{appdata_url}'"


### PR DESCRIPTION
Retrieving appdata from a download mirror may require a redirection
from https://download.opensuse.org/... to http://mirror.abc.xyz/...
This redirection (https -> http) is considered unsafe by 'open-uri'
and requires the open_uri_redirections gem.

Fixes #337.

Thanks @coolo for the pointer to https://github.com/open-uri-redirections/open_uri_redirections