### PR TITLE
Fix flickering search test

### DIFF
--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -29,7 +29,7 @@ class Seeker < ActiveXML::Node
         xpath_items << "contains-ic(@name, " + substring_words + ")"
       end
       words.select {|word| word.match(/^".+"$/) }.map {|word| word.gsub("\"", "") }.each do |word|
-        xpath_items << "@name = '#{word.gsub(/['"()]/, "")}' "
+        xpath_items << "@name = '#{word.gsub(/['"()]/, "")}'"
       end
       xpath_items << "path/project='#{baseproject}'" unless baseproject.blank?
       xpath_items << "not(contains-ic(@project, '#{exclude_filter}'))" if (!exclude_filter.blank? && project.blank?)

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'search/default_searches'  if @search_term %>
+
 <% if @packages.blank? %>
   <div class="py-5">
     <div class="container">

--- a/app/views/search/_default_searches.html.erb
+++ b/app/views/search/_default_searches.html.erb
@@ -1,0 +1,7 @@
+<% if DEFAULT_SEARCHES[@search_term] %>
+  <div id="search-result-error" >
+    <div id="msg" class="alert alert-info"/>
+    <%=DEFAULT_SEARCHES[@search_term].html_safe %>
+  </div>
+  </div>
+<% end %>

--- a/app/views/search/_find_results.html.erb
+++ b/app/views/search/_find_results.html.erb
@@ -1,13 +1,7 @@
 <div id="search-result" class="py-3">
   <div class="container">
 
-    <% if DEFAULT_SEARCHES[@search_term] %>
-      <div id="search-result-error" >
-        <div id="msg" class="alert alert-info"/>
-          <%=DEFAULT_SEARCHES[@search_term].html_safe %>
-        </div>
-      </div>
-    <% end %>
+    <%= render :partial => 'search/default_searches'  if @search_term %>
 
     <%= render :partial => 'search/category_header'  if @category %>
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,7 +100,7 @@ class ActiveSupport::TestCase
 
     stub_remote_file("https://download.opensuse.org/tumbleweed/repo/oss/repodata/#{APPDATA_CHECKSUM}-appdata.xml.gz", "appdata.xml.gz")
     stub_remote_file("https://download.opensuse.org/tumbleweed/repo/non-oss/repodata/#{APPDATA_NON_OSS_CHECKSUM}-appdata.xml.gz", "appdata-non-oss.xml.gz")
-    stub_remote_file("https://api.opensuse.org/search/published/binary/id?match=@name%20=%20'pidgin'%20", "pidgin.xml")
+    stub_remote_file("https://api.opensuse.org/search/published/binary/id?match=@name%20=%20'pidgin'", "pidgin.xml")
     stub_remote_file("https://api.opensuse.org/published/openSUSE:13.1/standard/i586/pidgin-2.10.7-4.1.3.i586.rpm?view=fileinfo", "pidgin-fileinfo.xml")
     stub_content("https://api.opensuse.org/source/openSUSE:13.1/_attribute/OBS:QualityCategory", "<attributes/>")
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,7 +77,6 @@ class ActiveSupport::TestCase
     # rubocop:enable Metrics/BlockLength
 
     xpath = "@project = '#{baseproject}'  and contains-ic(@name, '#{term}') and path/project='#{baseproject}'"
-    stub_content("api.opensuse.org/search/published/binary/id?match=#{URI.escape(xpath)}", builder.to_xml)
     stub_content("https://api.opensuse.org/search/published/binary/id?match=#{URI.escape(xpath)}", builder.to_xml)
   end
 


### PR DESCRIPTION
The cause was multiple:

* Missing stubs
* Superfluous spaces
* Redirects depending on the number of results

I was now able to reproduce test failures only by timeouts, which are expected when running the testsuite and webdriver in permanent loops.

Should fix #341