### PR TITLE
Enable Prometheus exporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'mini_magick'
 gem 'minitest'
 gem 'xmlhash', '>= 1.2.2'
 
+gem 'prometheus_exporter'
+
 # needed to collect translatable strings
 # not needed at production
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       ast (~> 2.4.0)
     pkg-config (1.3.1)
     powerpack (0.1.1)
+    prometheus_exporter (0.3.0)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -241,6 +242,7 @@ DEPENDENCIES
   minitest
   nokogiri
   open_uri_redirections
+  prometheus_exporter
   puma
   rails (~> 5.2)
   rails-i18n

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ bundle exec rails test:system
 
 See more [here.](https://developer.mozilla.org/en-US/Firefox/Headless_mode)
 
+### Instrumentation on development
+By default in non-production environments, the prometheus instrumentation is disabled. You can enable it by passing `INSTRUMENTATION=true` environment variable when starting the application:
+
+```
+INSTRUMENTATION=true bundle exec rails s
+```
+
+When doing this, you need to start the prometheus_exporter process separately (otherwise you will observe a lot of warnings in the log as the instrumentation code will try to connect to the collector process). You can do so with this command:
+
+```
+bundle exec prometheus_exporter
+```
+
 ## Running the application in production
 
 The application will take the following environment variables:
@@ -78,6 +91,8 @@ Puma will honor other variables too:
 * `PORT`
 * `RACK_ENV`
 * `SOFTWARE_O_O_RBTRACE`
+
+In production, prometheus instrumentation is enabled and `prometheus_exporter` process must be started.
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ When doing this, you need to start the prometheus_exporter process separately (o
 bundle exec prometheus_exporter
 ```
 
+After this the prometheus metrics will be exported under `http://localhost:9394/metrics`.
+
 ## Running the application in production
 
 The application will take the following environment variables:

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,12 +1,11 @@
-if Rails.env.production?
-  require 'prometheus_exporter/middleware'
-
+# Instrumentation only when explicitly enabled or when in production
+if ENV['INSTRUMENTATION'] == 'true' || ENV['RACK_ENV'] == 'production'
   # This reports stats per request like HTTP status and timings
+  require 'prometheus_exporter/middleware'
   Rails.application.middleware.unshift PrometheusExporter::Middleware
-
-  require 'prometheus_exporter/instrumentation'
 
   # this reports basic process stats like RSS and GC info, type master
   # means it is instrumenting the master process
+  require 'prometheus_exporter/instrumentation'
   PrometheusExporter::Instrumentation::Process.start(type: "master")
 end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,10 +1,12 @@
-require 'prometheus_exporter/middleware'
+if Rails.env.production?
+  require 'prometheus_exporter/middleware'
 
-# This reports stats per request like HTTP status and timings
-Rails.application.middleware.unshift PrometheusExporter::Middleware
+  # This reports stats per request like HTTP status and timings
+  Rails.application.middleware.unshift PrometheusExporter::Middleware
 
-require 'prometheus_exporter/instrumentation'
+  require 'prometheus_exporter/instrumentation'
 
-# this reports basic process stats like RSS and GC info, type master
-# means it is instrumenting the master process
-PrometheusExporter::Instrumentation::Process.start(type: "master")
+  # this reports basic process stats like RSS and GC info, type master
+  # means it is instrumenting the master process
+  PrometheusExporter::Instrumentation::Process.start(type: "master")
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,10 @@
+require 'prometheus_exporter/middleware'
+
+# This reports stats per request like HTTP status and timings
+Rails.application.middleware.unshift PrometheusExporter::Middleware
+
+require 'prometheus_exporter/instrumentation'
+
+# this reports basic process stats like RSS and GC info, type master
+# means it is instrumenting the master process
+PrometheusExporter::Instrumentation::Process.start(type: "master")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,10 +18,11 @@ on_worker_boot do
   end
 end
 
-after_worker_fork do
-  require 'prometheus_exporter'  
-  require 'prometheus_exporter/instrumentation' # todo needed?
-#  client = PrometheusExporter::Client.new(host: '172.17.0.3')
-  PrometheusExporter::Instrumentation::Process.start(type:"web")
+if Rails.env.production?
+  after_worker_fork do
+    require 'prometheus_exporter'
+    require 'prometheus_exporter/instrumentation' # todo needed?
+    PrometheusExporter::Instrumentation::Process.start(type:"web")
+  end
 end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,3 +17,11 @@ on_worker_boot do
     ObjectSpace.trace_object_allocations_start
   end
 end
+
+after_worker_fork do
+  require 'prometheus_exporter'  
+  require 'prometheus_exporter/instrumentation' # todo needed?
+#  client = PrometheusExporter::Client.new(host: '172.17.0.3')
+  PrometheusExporter::Instrumentation::Process.start(type:"web")
+end
+

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,11 +18,10 @@ on_worker_boot do
   end
 end
 
-if Rails.env.production?
+# Instrumentation only when explicitly enabled or when in production
+if ENV['INSTRUMENTATION'] == 'true' || ENV['RACK_ENV'] == 'production'
   after_worker_fork do
-    require 'prometheus_exporter'
-    require 'prometheus_exporter/instrumentation' # todo needed?
+    require 'prometheus_exporter/instrumentation'
     PrometheusExporter::Instrumentation::Process.start(type:"web")
   end
 end
-


### PR DESCRIPTION
Addresses #230 .

Instrumentation is enabled:
* in `production` environment
* OR when `INSTRUMENTATION=true` is passed when running rails server.

In most cases, instrumentation is not needed/wanted during development - it depends on `prometheus_exporter` process that needs to be manually started. If the process is not started, the app complains periodically in the log and I believe this would create unnecessary confusion.

# TODO
- [x] Only initialize the instrumentation in either production on non-test environment.
- [x] Exporter needs to be started separately (e.g. `bundle exec prometheus_exporter`). Figure out, how to start it on our deployment (separate systemd service on which the main SOO service depends).
- [ ] Adjust the `_service` and new systemd service file in the OBS project (SR pending https://build.opensuse.org/request/show/621915).