### PR TITLE
[DO NOT MERGE] add appstream link

### DIFF
--- a/app/assets/images/appstream-button1.svg
+++ b/app/assets/images/appstream-button1.svg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="0.91 r13725"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 175 50.000001"
+   height="50"
+   width="175"
+   sodipodi:docname="appstream-button1.svg"
+   inkscape:export-filename="appstream.png"
+   inkscape:export-xdpi="180"
+   inkscape:export-ydpi="180">
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:window-height="1016"
+     inkscape:window-width="1920"
+     inkscape:snap-center="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox="true"
+     units="px"
+     showgrid="false"
+     inkscape:current-layer="text4773"
+     inkscape:document-units="px"
+     inkscape:cy="43.643286"
+     inkscape:cx="42.385096"
+     inkscape:zoom="4"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       id="grid4136"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4719">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4721" />
+      <stop
+         id="stop4727"
+         offset="0.90476274"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4723" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4632">
+      <stop
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0"
+         id="stop4634" />
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1"
+         offset="1"
+         id="stop4636" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4606">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop4608" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:0;"
+         offset="1"
+         id="stop4610" />
+    </linearGradient>
+    <style
+       type="text/css"
+       id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      .ColorScheme-Background {
+        color:#eff0f1;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      .ColorScheme-ViewText {
+        color:#31363b;
+      }
+      .ColorScheme-ViewBackground {
+        color:#fcfcfc;
+      }
+      .ColorScheme-ViewHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ViewFocus{
+        color:#3daee9;
+      }
+      .ColorScheme-ButtonText {
+        color:#31363b;
+      }
+      .ColorScheme-ButtonBackground {
+        color:#eff0f1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#3daee9;
+      }
+      </style>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4606"
+       id="linearGradient4612"
+       x1="25"
+       y1="1035.8622"
+       x2="29"
+       y2="1035.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4632"
+       id="linearGradient4638"
+       x1="95"
+       y1="1012.3622"
+       x2="95"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4688"
+       x="-0.014526316"
+       width="1.0290526"
+       y="-0.068999998"
+       height="1.138">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.15"
+         id="feGaussianBlur4690" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4719"
+       id="radialGradient4725"
+       cx="30"
+       cy="1028.3622"
+       fx="30"
+       fy="1028.3622"
+       r="20"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0499991,0,0,1.0499991,-1.4999739,-1053.7794)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1002.3622)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter4688);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 30,6 C 25.142187,6.00956 20.453905,7.7868415 16.810547,11 L 8,11 c -1.6620096,0 -3,1.33799 -3,3 l 0,24 c 0,1.66201 1.3379904,3 3,3 l 8.796875,0 c 3.646893,3.216265 8.3406,4.993764 13.203125,5 4.857813,-0.0096 9.546095,-1.786842 13.189453,-5 L 167,41 c 1.66201,0 3,-1.33799 3,-3 l 0,-24 c 0,-1.66201 -1.33799,-3 -3,-3 L 43.203125,11 C 39.556232,7.783735 34.862525,6.0062362 30,6 Z"
+       transform="translate(0,1002.3622)"
+       id="rect4138-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssscccsssscc" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4638);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 55.000017,1012.3622 111.999963,0 c 1.66201,0 3.00002,1.338 3.00002,3 l 0,23.9999 c 0,1.6621 -1.33801,3.0001 -3.00002,3.0001 l -111.999963,0 C 53.338008,1042.3622 52,1041.0242 52,1039.3621 l 0,-23.9999 c 0,-1.662 1.338008,-3 3.000017,-3 z"
+       id="rect4138"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#2ecc71;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 8,10 c -1.6620096,0 -3,1.33799 -3,3 l 0,24 c 0,1.66201 1.3379904,3 3,3 l 47.949219,0 A 29.999983,29.999983 0 0 0 60,25 29.999983,29.999983 0 0 0 55.9375,10 L 8,10 Z"
+       transform="translate(0,1002.3622)"
+       id="path4196-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4725);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 16.433594,10 A 20.999983,20.999983 0 0 0 9,26 20.999983,20.999983 0 0 0 14.380859,40 l 31.242188,0 A 20.999983,20.999983 0 0 0 51,26 20.999983,20.999983 0 0 0 43.595703,10 l -27.162109,0 z"
+       transform="translate(0,1002.3622)"
+       id="path4196-8"
+       inkscape:connector-curvature="0" />
+    <circle
+       r="20"
+       cy="1027.3622"
+       cx="30"
+       id="path4196"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#27ae60;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <g
+       id="g4614"
+       transform="translate(-3,0)">
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7f8c8d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect4262"
+         width="22"
+         height="4"
+         x="22"
+         y="1034.3622" />
+      <g
+         transform="translate(-20,0)"
+         id="g4470">
+        <path
+           id="rect4264"
+           d="m 44,1017.3622 18,0 2,17 -22,0 2,-17"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#eff0f1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           id="path4284"
+           d="m 46.1656,1032.0884 c -0.0143,0.1963 -0.131202,0.3855 -0.325424,0.5254 -0.194846,0.1405 -0.451029,0.2196 -0.711702,0.2196 -0.260674,0 -0.503564,-0.079 -0.674808,-0.2196 -0.170697,-0.1399 -0.255811,-0.3291 -0.237112,-0.5254 0.01862,-0.1955 0.138612,-0.3821 0.333174,-0.5192 0.193947,-0.1367 0.446615,-0.2133 0.702898,-0.2133 0.256283,0 0.49608,0.077 0.667059,0.2133 0.171521,0.1371 0.260151,0.3237 0.245915,0.5192 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4284-4"
+           d="m 47.124324,1018.9244 c -0.01029,0.1413 -0.107666,0.2774 -0.271008,0.3781 -0.163786,0.1009 -0.380115,0.1577 -0.601048,0.1577 -0.220934,0 -0.427713,-0.057 -0.574536,-0.1577 -0.146425,-0.1007 -0.220925,-0.2368 -0.207462,-0.3781 0.01341,-0.1409 0.113033,-0.2754 0.276646,-0.3743 0.163173,-0.099 0.376994,-0.1539 0.594765,-0.1539 0.217772,0 0.4223,0.055 0.568898,0.1539 0.146992,0.099 0.224001,0.2334 0.213745,0.3743 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4284-4-9"
+           d="m 46.881355,1022.2605 c -0.01125,0.1545 -0.113507,0.3032 -0.284624,0.4132 -0.171604,0.1103 -0.397996,0.1724 -0.628991,0.1724 -0.230995,0 -0.446948,-0.062 -0.600011,-0.1724 -0.15263,-0.11 -0.229897,-0.2587 -0.215188,-0.4132 0.01465,-0.1538 0.119361,-0.3008 0.290767,-0.4087 0.170925,-0.1077 0.39457,-0.1681 0.622111,-0.1681 0.227541,0 0.441041,0.06 0.593868,0.1681 0.153257,0.1079 0.23327,0.2549 0.222068,0.4087 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4284-8"
+           d="m 61.783446,1032.0884 c 0.0187,0.1963 -0.06641,0.3855 -0.237112,0.5254 -0.171244,0.1405 -0.414134,0.2196 -0.674808,0.2196 -0.260673,0 -0.516856,-0.079 -0.711702,-0.2196 -0.194222,-0.1399 -0.311125,-0.3291 -0.325424,-0.5254 -0.01424,-0.1955 0.07439,-0.3821 0.245915,-0.5192 0.170979,-0.1367 0.410776,-0.2133 0.667059,-0.2133 0.256283,0 0.508951,0.077 0.702898,0.2133 0.194562,0.1371 0.314558,0.3237 0.333174,0.5192 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4284-4-6"
+           d="m 60.52973,1018.9244 c 0.01346,0.1413 -0.06104,0.2774 -0.207462,0.3781 -0.146823,0.1009 -0.353602,0.1577 -0.574536,0.1577 -0.220933,0 -0.437262,-0.057 -0.601048,-0.1577 -0.163342,-0.1007 -0.260713,-0.2368 -0.271008,-0.3781 -0.01026,-0.1409 0.06675,-0.2754 0.213745,-0.3743 0.146598,-0.099 0.351126,-0.1539 0.568898,-0.1539 0.217771,0 0.431592,0.055 0.594765,0.1539 0.163613,0.099 0.263235,0.2334 0.276646,0.3743 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4284-4-9-3"
+           d="m 60.847459,1022.2605 c 0.01471,0.1545 -0.06256,0.3032 -0.215188,0.4132 -0.153063,0.1103 -0.369016,0.1724 -0.600011,0.1724 -0.230995,0 -0.457387,-0.062 -0.628991,-0.1724 -0.171117,-0.11 -0.273376,-0.2587 -0.284624,-0.4132 -0.0112,-0.1538 0.06881,-0.3008 0.222068,-0.4087 0.152827,-0.1077 0.366327,-0.1681 0.593868,-0.1681 0.227541,0 0.451186,0.06 0.622111,0.1681 0.171406,0.1079 0.276117,0.2549 0.290767,0.4087 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path4345"
+           d="m 53.00045,1021.6837 c -1.934098,0 -3.814521,0.5162 -5.254398,1.4523 -1.475281,0.9592 -2.395345,2.2985 -2.533031,3.7442 -0.142733,1.4987 0.565822,2.9886 2.00332,4.1216 1.476454,1.1638 3.568385,1.8316 5.784109,1.8316 2.215724,0 4.307655,-0.6678 5.784109,-1.8316 1.437498,-1.133 2.146053,-2.6229 2.00332,-4.1216 -0.137686,-1.4457 -1.05775,-2.785 -2.533031,-3.7442 -1.439877,-0.9361 -3.3203,-1.4523 -5.254398,-1.4523 0,0 0,0 0,0 m 0,1.1624 c 1.501468,0 2.956809,0.4062 4.061832,1.1397 1.125968,0.7475 1.812409,1.7842 1.893261,2.8944 0.08311,1.1411 -0.479774,2.2659 -1.583796,3.1149 -1.126558,0.8663 -2.705457,1.3608 -4.371297,1.3608 -1.66584,0 -3.244739,-0.4945 -4.371297,-1.3608 -1.104022,-0.849 -1.666904,-1.9738 -1.583796,-3.1149 0.08085,-1.1102 0.767293,-2.1469 1.893261,-2.8944 1.105023,-0.7335 2.560364,-1.1397 4.061832,-1.1397 0,0 0,0 0,0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bdc3c7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         y="1034.3622"
+         x="36"
+         height="3"
+         width="1"
+         id="rect4564"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         y="1034.3622"
+         x="34"
+         height="3"
+         width="1"
+         id="rect4564-2"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         y="1034.3622"
+         x="32"
+         height="3"
+         width="1"
+         id="rect4564-2-8"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         y="1034.3622"
+         x="30"
+         height="3"
+         width="1"
+         id="rect4564-2-7"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <circle
+         r="1"
+         cy="1036.3622"
+         cx="42"
+         id="path4602"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#11d116;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         y="1034.3622"
+         x="25"
+         height="3"
+         width="4"
+         id="rect4604"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4612);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4198"
+       d="m 29.075195,1007.3622 0,17.1719 -3.510742,-3.5108 -1.414062,1.4141 5.924804,5.9248 5.924805,-5.9248 -1.414063,-1.4141 -3.510742,3.5108 0,-17.1719 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#246d43;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <g
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84000015px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text4773">
+      <path
+         d="m 102.96375,1029.2572 q 0,-1.2512 -0.61875,-1.925 -0.61875,-0.6737 -1.65,-0.6737 -0.5775,0 -0.9075,0.041 -0.31625,0.041 -0.50875,0.096 l 0,4.51 q 0.23375,0.1925 0.67375,0.3712 0.44,0.1788 0.9625,0.1788 0.55,0 0.935,-0.1925 0.39875,-0.2063 0.64625,-0.55 0.2475,-0.3575 0.3575,-0.825 0.11,-0.4813 0.11,-1.0313 z m 1.33375,0 q 0,0.8113 -0.22,1.4988 -0.20625,0.6875 -0.61875,1.1825 -0.4125,0.495 -1.0175,0.77 -0.59125,0.275 -1.36125,0.275 -0.61875,0 -1.1,-0.165 -0.4675,-0.165 -0.70125,-0.3163 l 0,2.86 -1.27875,0 0,-9.4737 q 0.45375,-0.11 1.1275,-0.2338 0.6875,-0.1375 1.58125,-0.1375 0.825,0 1.485,0.2613 0.66,0.2612 1.1275,0.7425 0.4675,0.4812 0.715,1.1825 0.26125,0.6875 0.26125,1.5537 z"
+         id="path4939"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 111.0741,1029.2572 q 0,-1.2512 -0.61875,-1.925 -0.61875,-0.6737 -1.65,-0.6737 -0.5775,0 -0.9075,0.041 -0.31625,0.041 -0.50875,0.096 l 0,4.51 q 0.23375,0.1925 0.67375,0.3712 0.44,0.1788 0.9625,0.1788 0.55,0 0.935,-0.1925 0.39875,-0.2063 0.64625,-0.55 0.2475,-0.3575 0.3575,-0.825 0.11,-0.4813 0.11,-1.0313 z m 1.33375,0 q 0,0.8113 -0.22,1.4988 -0.20625,0.6875 -0.61875,1.1825 -0.4125,0.495 -1.0175,0.77 -0.59125,0.275 -1.36125,0.275 -0.61875,0 -1.1,-0.165 -0.4675,-0.165 -0.70125,-0.3163 l 0,2.86 -1.27875,0 0,-9.4737 q 0.45375,-0.11 1.1275,-0.2338 0.6875,-0.1375 1.58125,-0.1375 0.825,0 1.485,0.2613 0.66,0.2612 1.1275,0.7425 0.4675,0.4812 0.715,1.1825 0.26125,0.6875 0.26125,1.5537 z"
+         id="path4941"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 124.54,1025.6685 2.70875,0 0,1.0725 -2.70875,0 0,3.3 q 0,0.5362 0.0825,0.8937 0.0825,0.3438 0.2475,0.55 0.165,0.1925 0.4125,0.275 0.2475,0.082 0.5775,0.082 0.5775,0 0.92125,-0.1237 0.3575,-0.1375 0.495,-0.1925 l 0.2475,1.0587 q -0.1925,0.096 -0.67375,0.2338 -0.48125,0.1512 -1.1,0.1512 -0.72875,0 -1.21,-0.1787 -0.4675,-0.1925 -0.75625,-0.5638 -0.28875,-0.3712 -0.4125,-0.9075 -0.11,-0.55 -0.11,-1.265 l 0,-6.38 1.27875,-0.22 0,2.2138 z"
+         id="path4945"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 131.51598,1025.5172 q 0.165,0 0.37125,0.027 0.22,0.014 0.42625,0.055 0.20625,0.027 0.37125,0.069 0.17875,0.027 0.26125,0.055 l -0.22,1.1137 q -0.15125,-0.055 -0.50875,-0.1237 -0.34375,-0.082 -0.89375,-0.082 -0.3575,0 -0.715,0.082 -0.34375,0.069 -0.45375,0.096 l 0,6.0088 -1.27875,0 0,-6.8475 q 0.45375,-0.165 1.1275,-0.3025 0.67375,-0.1513 1.5125,-0.1513 z"
+         id="path4947"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 133.79461,1029.2572 q 0,-0.9487 0.275,-1.65 0.275,-0.715 0.72875,-1.1825 0.45375,-0.4675 1.045,-0.7012 0.59125,-0.2338 1.21,-0.2338 1.44375,0 2.21375,0.9075 0.77,0.8938 0.77,2.7363 0,0.082 0,0.22 0,0.1237 -0.0138,0.2337 l -4.895,0 q 0.0825,1.1138 0.64625,1.6913 0.56375,0.5775 1.76,0.5775 0.67375,0 1.1275,-0.11 0.4675,-0.1238 0.70125,-0.2338 l 0.17875,1.0725 q -0.23375,0.1238 -0.825,0.2613 -0.5775,0.1375 -1.32,0.1375 -0.935,0 -1.6225,-0.275 -0.67375,-0.2888 -1.11375,-0.7838 -0.44,-0.495 -0.66,-1.1687 -0.20625,-0.6875 -0.20625,-1.4988 z m 4.90875,-0.7012 q 0.0137,-0.8663 -0.44,-1.4163 -0.44,-0.5637 -1.22375,-0.5637 -0.44,0 -0.78375,0.1787 -0.33,0.165 -0.56375,0.44 -0.23375,0.275 -0.37125,0.6325 -0.12375,0.3575 -0.165,0.7288 l 3.5475,0 z"
+         id="path4949"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.29402,1031.8972 q 0.45375,0 0.7975,-0.014 0.3575,-0.027 0.59125,-0.082 l 0,-2.1313 q -0.1375,-0.069 -0.45375,-0.11 -0.3025,-0.055 -0.7425,-0.055 -0.28875,0 -0.61875,0.041 -0.31625,0.041 -0.59125,0.1787 -0.26125,0.1238 -0.44,0.3575 -0.17875,0.22 -0.17875,0.5913 0,0.6875 0.44,0.9625 0.44,0.2612 1.19625,0.2612 z m -0.11,-6.4075 q 0.77,0 1.2925,0.2063 0.53625,0.1925 0.8525,0.5637 0.33,0.3575 0.4675,0.8663 0.1375,0.495 0.1375,1.1 l 0,4.4687 q -0.165,0.027 -0.4675,0.082 -0.28875,0.041 -0.66,0.082 -0.37125,0.041 -0.81125,0.069 -0.42625,0.041 -0.8525,0.041 -0.605,0 -1.11375,-0.1237 -0.50875,-0.1238 -0.88,-0.385 -0.37125,-0.275 -0.5775,-0.715 -0.20625,-0.44 -0.20625,-1.0588 0,-0.5912 0.23375,-1.0175 0.2475,-0.4262 0.66,-0.6875 0.4125,-0.2612 0.9625,-0.385 0.55,-0.1237 1.155,-0.1237 0.1925,0 0.39875,0.027 0.20625,0.014 0.385,0.055 0.1925,0.027 0.33,0.055 0.1375,0.027 0.1925,0.041 l 0,-0.3575 q 0,-0.3162 -0.0687,-0.6187 -0.0688,-0.3163 -0.2475,-0.55 -0.17875,-0.2475 -0.495,-0.385 -0.3025,-0.1513 -0.7975,-0.1513 -0.6325,0 -1.11375,0.096 -0.4675,0.082 -0.70125,0.1787 l -0.15125,-1.0587 q 0.2475,-0.11 0.825,-0.2063 0.5775,-0.11 1.25125,-0.11 z"
+         id="path4951"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 149.04444,1025.8747 q 0.44,-0.11 1.155,-0.2337 0.72875,-0.1238 1.6775,-0.1238 0.6875,0 1.155,0.1925 0.4675,0.1788 0.78375,0.5363 0.0962,-0.069 0.3025,-0.1925 0.20625,-0.1238 0.50875,-0.2338 0.3025,-0.1237 0.67375,-0.2062 0.37125,-0.096 0.7975,-0.096 0.825,0 1.3475,0.2475 0.5225,0.2338 0.81125,0.6738 0.3025,0.44 0.39875,1.045 0.11,0.605 0.11,1.32 l 0,4.015 -1.27875,0 0,-3.74 q 0,-0.6325 -0.0687,-1.0863 -0.055,-0.4537 -0.23375,-0.7562 -0.165,-0.3025 -0.4675,-0.44 -0.28875,-0.1513 -0.75625,-0.1513 -0.64625,0 -1.0725,0.1788 -0.4125,0.165 -0.56375,0.3025 0.11,0.3575 0.165,0.7837 0.055,0.4263 0.055,0.8938 l 0,4.015 -1.27875,0 0,-3.74 q 0,-0.6325 -0.0687,-1.0863 -0.0688,-0.4537 -0.2475,-0.7562 -0.165,-0.3025 -0.4675,-0.44 -0.28875,-0.1513 -0.7425,-0.1513 -0.1925,0 -0.4125,0.014 -0.22,0.014 -0.42625,0.041 -0.1925,0.014 -0.3575,0.041 -0.165,0.027 -0.22,0.041 l 0,6.0363 -1.27875,0 0,-6.9438 z"
+         id="path4953"
+         inkscape:connector-curvature="0" />
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4187"
+         transform="matrix(0.42396483,0,0,0.42396483,83.41376,584.1454)">
+        <path
+           d="m 79.706797,1056.6732 q 6.08,0 6.08,-4.16 0,-1.28 -0.56,-2.16 -0.52,-0.92 -1.44,-1.56 -0.92,-0.68 -2.12,-1.16 -1.16,-0.48 -2.48,-0.96 -1.52,-0.52 -2.88,-1.16 -1.36,-0.68 -2.36,-1.56 -1,-0.92 -1.6,-2.16 -0.56,-1.24 -0.56,-3 0,-3.64 2.48,-5.68 2.48,-2.04 6.84,-2.04 2.52,0 4.56,0.56 2.08,0.52 3.04,1.16 l -1.24,3.16 q -0.84,-0.52 -2.52,-1 -1.64,-0.52 -3.84,-0.52 -1.12,0 -2.08,0.24 -0.96,0.24 -1.68,0.72 -0.72,0.48 -1.16,1.24 -0.4,0.72 -0.4,1.72 0,1.12 0.44,1.88 0.44,0.76 1.24,1.36 0.8,0.56 1.84,1.04 1.08,0.48 2.36,0.96 1.8,0.72 3.28,1.44 1.52,0.72 2.6,1.72 1.12,1 1.72,2.4 0.6,1.36 0.6,3.32 0,3.64 -2.68,5.6 -2.64,1.96 -7.48,1.96 -1.64,0 -3.04,-0.24 -1.36,-0.2 -2.44,-0.48 -1.08,-0.32 -1.88,-0.64 -0.76,-0.36 -1.2,-0.6 l 1.16,-3.2 q 0.92,0.52 2.8,1.16 1.88,0.64 4.6,0.64 z"
+           id="path4192"
+           inkscape:connector-curvature="0"
+           style="fill:#4d4d4d;fill-opacity:1" />
+      </g>
+    </g>
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#2ecc71;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path4883"
+       cx="74"
+       cy="1024.3622"
+       r="1" />
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#2ecc71;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path4885"
+       cx="74"
+       cy="1030.3622"
+       r="1" />
+    <path
+       style="fill:#2ecc71;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 76,1033.3622 5,-12 2,0 -5,12 z"
+       id="path4887"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#246d43;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 89,1021.3622 -5,12 2,0 0.83398,-2 6.33204,0 0.83398,2 2,0 -5,-12 -2,0 z m 1,2.4004 2.33398,5.5996 -4.66796,0 L 90,1023.7626 Z"
+       id="path4887-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#2ecc71;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 80,1033.3622 5,-12 2,0 -5,12 z"
+       id="path4887-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -31,6 +31,7 @@ class PackageController < OBSController
         @name = pkg_appdata.first[:name]
         @appcategories = pkg_appdata.first[:categories]
         @homepage = pkg_appdata.first[:homepage]
+        @appid = pkg_appdata.first[:id]
       end
 
       @screenshot = url_for :controller => :package, :action => :screenshot, :package => @pkgname, protocol: request.protocol

--- a/app/models/appdata.rb
+++ b/app/models/appdata.rb
@@ -25,6 +25,7 @@ class Appdata
       appdata[:pkgname] = app.xpath('pkgname').text
       appdata[:categories] = app.xpath('categories/category').map {|c| c.text}.reject {|c| c.match(/^X-/)}.uniq
       appdata[:homepage] = app.xpath('url').text
+      appdata[:id] = app.xpath('id').text
       appdata[:screenshots] = app.xpath('screenshots/screenshot/image').map {|s| s.text}
       data[:apps] << appdata
     end

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -37,7 +37,9 @@
             <p class="text-muted"><%= _("No description.") %></p>
           <% end -%>
 
-          <% unless @default_package.blank? %>
+          <% if @default_package.blank? %>
+            <%= _("There is no official package available for %s") % @default_project_name %>
+          <% else %>
             <%
               url = url_for :controller => 'download', :action => 'ymp_without_arch_and_version', :query => @pkgname,
               :project => @default_package.project, :repository => @default_package.repository, :package => @pkgname, :base => @default_package.baseproject, :protocol => 'https'
@@ -57,8 +59,12 @@
     </div><!-- /.container -->
   </header>
 
-
-  <div class="container">
+  <% unless @default_package.blank? %>
+    <div class="container">
+    <button class="btn" type="button" data-toggle="collapse" data-target="#other-distributions-listing"><%= _("Show %s for other distributions") % @pkgname %></button>
+    </div>
+  <% end %>
+  <div class="container <% unless @default_package.blank? %>collapse<% end %>" id="other-distributions-listing">
     <h3 class="mt-5 mb-4"><%= _("Distributions") %></h3>
 
     <% @distributions.each do |distro| -%>

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -53,6 +53,11 @@
               <span class="typcn typcn-flash-outline"></span>
               <%= _("Direct Install") %>
             </a>
+            <% if @appid %>
+            <div>
+              <a id="appstream-button" class="btn" href="appstream://<%= @appid %>"><img class="typcn" src="<%= image_path('appstream-button1.svg') %>" width="177" height="51" alt="AppStream" /></a>
+            </div>
+            <% end %>
           <% end -%>
         </div><!-- /#package-description -->
       </div><!-- /.row -->


### PR DESCRIPTION
Add appstream link which integrates with gnome-software and KDE discover:
https://hackweek.suse.com/projects/unassigned-opensuse-app-store

Problem is that the appstream data comes from Factory and the ids may change. So atm appstream installation of 0ad does  not work with Leap 15.0.