### PR TITLE
don't force cache misses

### DIFF
--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -8,9 +8,7 @@ class OBSController < ApplicationController
   before_action :set_releases_parameters
 
   def set_distributions
-    @distributions = Rails.cache.fetch('distributions',
-                                       expires_in: 120.minutes,
-                                       force: true) do
+    @distributions = Rails.cache.fetch('distributions', expires_in: 120.minutes) do
       load_distributions
     end
   rescue OBSError

--- a/test/integration/obs_controller_test.rb
+++ b/test/integration/obs_controller_test.rb
@@ -16,6 +16,8 @@ class OBSControllerTest < ActionDispatch::IntegrationTest
     end
 
     ApiConnect.stub :get, mock do
+      # Otherwise the controller would get the distributions from cache
+      Rails.cache.clear
       get '/explore'
       assert_includes body, 'Connection to OBS is unavailable.'
       assert_equal 200, status


### PR DESCRIPTION
0c79506d9 included a leftover of local testing: disabling the rails
caching for load_distributions which caused poor performance.

Fixes #356.