### PR TITLE
Update docker environment to Leap 15 + ruby2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:42.1
+FROM opensuse/leap:15.0
 ARG IMAGE_USERID
 
 # Update distro
@@ -8,7 +8,7 @@ RUN zypper -q --non-interactive update
 RUN zypper -q --non-interactive install timezone vim aaa_base glibc-locale sudo nodejs
 
 # Install ruby
-RUN zypper -q --non-interactive install ruby2.1 ruby2.1-devel ruby2.1-rubygem-mysql2
+RUN zypper -q --non-interactive install ruby2.5 ruby2.5-devel
 
 # Setup gem & sudo
 RUN echo 'install: --no-format-executable' >> /etc/gemrc; \
@@ -25,7 +25,6 @@ RUN useradd -m vagrant  -u $IMAGE_USERID -p vagrant
 
 USER vagrant
 WORKDIR /vagrant
+
 # Setup bundler
 RUN bundle config build.nokogiri --use-system-libraries
-
-CMD ["bundle", "exec", "rails", "server"] 

--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,5 @@ group :test do
 end
 
 # Debugging gems
-gem 'rbtrace', require: false
+# rbtrace does not install successfully in Docker and needs to be manually enabled
+# gem 'rbtrace', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.3)
-    capybara (3.8.0)
+    capybara (3.8.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -113,21 +113,19 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mimemagic (0.3.2)
-    mini_magick (4.9.0)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    msgpack (1.2.4)
     multi_json (1.13.1)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     open_uri_redirections (0.2.1)
-    optimist (3.0.0)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -175,10 +173,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rbtrace (0.4.11)
-      ffi (>= 1.0.6)
-      msgpack (>= 0.4.3)
-      optimist (>= 3.0.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -251,7 +245,6 @@ DEPENDENCIES
   puma_worker_killer
   rails (~> 5.2)
   rails-i18n
-  rbtrace
   rubocop (~> 0.49.0)
   sass-rails
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -134,37 +134,37 @@ Windows.
 
 1.  Install [Vagrant](https://www.vagrantup.com/downloads.html) and [docker](https://docs.docker.com/engine/getstarted/step_one/). Both tools support Linux, MacOS and Windows.
 
-2.  Clone this code repository:
+1.  Clone this code repository:
 
     ```
     git clone --recurse-submodules git@github.com:openSUSE/software-o-o.git
     ```
 
-3.  Build your Vagrant box:
+1.  Build your Vagrant box:
 
     ```
     vagrant up
     ```
 
-4.  Attach to your new development box
+1.  Attach to your new development box:
 
     ```
     docker attach software_web
     ```
 
-5.  Setup the database
+1. Install gems:
 
     ```
-    rake db:setup db:seed
+    bundle install
     ```
 
-6.  Start the app
+1.  Start the app:
 
     ```
     rails server
     ```
 
-7.  Enjoy your software.opensuse.org clone at http://127.0.0.1:3000/
+1.  Enjoy your software.opensuse.org clone at http://127.0.0.1:3000/
 
 If you exit the shell inside the vagrant box your development environment
 is stopped. Want to continue? Run `vagrant up` and `docker attach software_web`


### PR DESCRIPTION
Use latest leap for docker and update documentation.
Installing `rbtrace` in the docker environment does not succeed and is disabled in the Gemfile. I suspect not many actually use it and those who really want it can easily re-enable it.

Fixes #238 