### PR TITLE
Enable puma worker killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'minitest'
 gem 'xmlhash', '>= 1.2.2'
 
 gem 'prometheus_exporter'
+gem 'puma_worker_killer'
 
 # needed to collect translatable strings
 # not needed at production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     ffi (1.9.23)
     geckodriver-helper (0.0.5)
       archive-zip (~> 0.7)
+    get_process_mem (0.2.2)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -134,6 +135,9 @@ GEM
     prometheus_exporter (0.3.0)
     public_suffix (3.0.2)
     puma (3.11.4)
+    puma_worker_killer (0.1.0)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -244,6 +248,7 @@ DEPENDENCIES
   open_uri_redirections
   prometheus_exporter
   puma
+  puma_worker_killer
   rails (~> 5.2)
   rails-i18n
   rbtrace
@@ -255,4 +260,4 @@ DEPENDENCIES
   xmlhash (>= 1.2.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
Address #225 while we finish refactoring the app for not leaking in the first place.

Note: the package service needs to be re-run before deploying, as a new dependency is introduced.

If the gem gives problems, we will fallback to plan B with the script in https://github.com/openSUSE/software-o-o/issues/225#issuecomment-418529247