### PR TITLE
Add checksum links to AArch64 Tumbleweed

### DIFF
--- a/app/views/distributions/tumbleweed.html.erb
+++ b/app/views/distributions/tumbleweed.html.erb
@@ -151,7 +151,7 @@
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-<!-- Currently sha256 file is missing <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a> -->
+              <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
           <div class="card">
@@ -165,7 +165,7 @@
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso" class="card-link"><%= _('Direct Link') %></a>
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4" class="card-link"><%= _('Metalink') %></a>
               <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist" class="card-link"><%= _('Pick Mirror') %></a>
-<!-- Currently sha256 file is missing <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a> -->
+              <a href="https://download.opensuse.org/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256" class="card-link"><%= _('Checksum') %></a>
             </div>
           </div><!-- /.card -->
         </div><!-- /.card-deck -->


### PR DESCRIPTION
sha256 check sums are back for aarch64. 
See: https://bugzilla.opensuse.org/show_bug.cgi?id=1098215