### PR TITLE
Fix more Rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -273,14 +273,6 @@ Style/EmptyLiteral:
     - 'lib/activexml/node.rb'
     - 'lib/activexml/transport.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: compact, expanded
-Style/EmptyMethod:
-  Exclude:
-    - 'app/controllers/download_controller.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,16 +23,6 @@ Lint/EmptyWhen:
     - 'app/controllers/application_controller.rb'
     - 'lib/activexml/matcher.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleAlignWith, SupportedStylesAlignWith, AutoCorrect.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Lint/EndAlignment:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/models/screenshot.rb'
-    - 'lib/activexml/node.rb'
-
 # Offense count: 1
 Lint/HandleExceptions:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -273,15 +273,6 @@ Style/EmptyLiteral:
     - 'lib/activexml/node.rb'
     - 'lib/activexml/transport.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'app/controllers/download_controller.rb'
-    - 'lib/activexml/transport.rb'
-
 # Offense count: 8
 # Configuration parameters: MinBodyLength.
 Style/GuardClause:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     when Timeout::Error
     else
       logger.error exception.backtrace.join("\n")
-      end
+    end
     render :template => 'error', :formats => [:html], :layout => layout, :status => 400
   end
 

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -39,7 +39,7 @@ class DownloadController < ApplicationController
       end
     end
     set_flavours
-    @page_title = _("Download appliance from %s") % [@project]
+    @page_title = format(_("Download appliance from %s"), @project)
     render_page :appliance
   end
 
@@ -81,7 +81,7 @@ class DownloadController < ApplicationController
       end
     end
     set_flavours
-    @page_title = _("Install package %s / %s") % [@project, @package]
+    @page_title = format(_("Install package %s / %s"), @project, @package)
     render_page :package
   end
 
@@ -123,7 +123,7 @@ class DownloadController < ApplicationController
       end
     end
     set_flavours
-    @page_title = _("Install pattern %s / %s") % [@project, @pattern]
+    @page_title = format(_("Install pattern %s / %s"), @project, @pattern)
     render_page :package
   end
 

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -2,8 +2,7 @@ class DownloadController < ApplicationController
   before_action :set_colors
 
   # display documentation
-  def doc
-  end
+  def doc; end
 
   def appliance
     required_parameters :project

--- a/app/models/screenshot.rb
+++ b/app/models/screenshot.rb
@@ -118,7 +118,7 @@ class Screenshot
              "openstack-package.png"
            else
              "package.png"
-    end
+           end
     "default-screenshots/#{file}"
   end
 end

--- a/lib/activexml/node.rb
+++ b/lib/activexml/node.rb
@@ -131,7 +131,7 @@ module ActiveXML
           if obj
             logger.debug "returning #{args.inspect} from object_cache"
             return obj
-    end
+          end
         end
 
         objhash = nil

--- a/lib/activexml/transport.rb
+++ b/lib/activexml/transport.rb
@@ -158,13 +158,13 @@ module ActiveXML
       if data.nil?
         # logger.debug"[REST] Transport.find using GET-method"
         objdata = http_do('get', url, :timeout => 300)
-        raise RuntimeError.new("GET to %s returned no data" % url) if objdata.empty?
+        raise RuntimeError.new(format("GET to %s returned no data", url)) if objdata.empty?
       else
         # use post-method
         logger.debug "[REST] Transport.find using POST-method"
         # logger.debug"[REST] POST-data as xml: #{data.to_s}"
         objdata = http_do('post', url, :data => data.to_s, :content_type => own_mimetype)
-        raise RuntimeError.new("POST to %s returned no data" % url) if objdata.empty?
+        raise RuntimeError.new(format("POST to %s returned no data", url)) if objdata.empty?
       end
       objdata = objdata.force_encoding("UTF-8")
       return [objdata, params]


### PR DESCRIPTION
Fix the following cops:

- Fix Style/EmptyMethod offense
- Fix Style/FormatString offenses
- Fix Lint/EndAlignment offenses 