### PR TITLE
Align navbar order with other openSUSE websites

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,11 +10,11 @@
 
   <div class="collapse navbar-collapse" id="global-navbar-content">
     <ul class="navbar-nav mr-auto">
-      <li class="nav-item <%= 'active' unless defined?(activenav) && (activenav == 'download') %>">
-        <a class="nav-link" href="/explore"><%= _("Software") %></a>
-      </li>
       <li class="nav-item <%= 'active' if defined?(activenav) && (activenav == 'download') %>">
         <a class="nav-link" href="/distributions"><%= _("Download") %></a>
+      </li>
+      <li class="nav-item <%= 'active' if !defined?(activenav) || (activenav == 'software') %>">
+        <a class="nav-link" href="/explore"><%= _("Software") %></a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://doc.opensuse.org/"><%= _("Documentation") %></a>


### PR DESCRIPTION
Swap "Download" and "Software" to align with the order of other openSUSE
websites like https://en.opensuse.org or https://kubic.opensuse.org.

Resolves: https://github.com/openSUSE/software-o-o/issues/311

Before:

![before](https://user-images.githubusercontent.com/19352524/46870130-14f1ab80-ce2e-11e8-8ea5-7db072547749.png)

After:

![after](https://user-images.githubusercontent.com/19352524/46870142-19b65f80-ce2e-11e8-90e9-c4c799343845.png)

Kubic page:

![kubic](https://user-images.githubusercontent.com/19352524/46870152-1cb15000-ce2e-11e8-97ca-c2cf2e82e559.png)
