### PR TITLE
Prevent searches empty/without package name from overloading OBS (#404)

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,8 +3,6 @@ class SearchController < OBSController
   before_action :prepare_appdata
 
   def index
-    render 'find' and return if @search_term.blank?
-
     base = @baseproject == "ALL" ? "" : @baseproject
 
     # if we have a baseproject, and don't show unsupported packages, shortcut: '
@@ -21,6 +19,9 @@ class SearchController < OBSController
         @packages = Seeker.prepare_result("#{@search_term}", base, @search_project, @exclude_filter, @exclude_debug)
       end
       raise e if @packages.nil?
+    rescue Seeker::InvalidSearchTerm => e
+      flash[:error] = e.message
+      render 'find' and return
     end
 
     filter_packages

--- a/app/models/seeker.rb
+++ b/app/models/seeker.rb
@@ -20,7 +20,8 @@ class Seeker < ActiveXML::Node
       words = query.split(" ").reject { |part| part.match(/^[0-9_\.-]+$/) }
       versrel = query.split(" ").select { |part| part.match(/^[0-9_\.-]+$/) }
       logger.debug "splitted words and versrel: #{words.inspect} #{versrel.inspect}"
-      raise InvalidSearchTerm.new "Please provide a valid search term" if words.blank? && project.blank?
+      raise InvalidSearchTerm.new "Please provide a valid search term" if words.blank? && versrel.blank?
+      raise InvalidSearchTerm.new "The package name is required when searching for a version" if words.blank? && !versrel.blank?
 
       xpath_items = Array.new
       xpath_items << "@project = '#{project}' " unless project.blank?

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -37,4 +37,36 @@ class SearchResultsTest < ActionDispatch::SystemTestCase
 
     page.assert_text 'No packages found matching your search.'
   end
+
+  def test_only_version_query
+    visit '/'
+    # There is no need to click on settings. If cookies are fresh, they will auto popup
+    # if this ever changes, uncomment the next line
+    # page.click_on 'Settings'
+    within '#search-settings' do
+      find('option[value="openSUSE:Leap:42.3"]').click
+      page.click_on 'OK'
+    end
+
+    page.fill_in 'q', with: '1'
+    page.find(:css, 'button#search-button').click
+
+    page.assert_text 'The package name is required when searching for a version'
+  end
+
+  def test_empty_query
+    visit '/'
+    # There is no need to click on settings. If cookies are fresh, they will auto popup
+    # if this ever changes, uncomment the next line
+    # page.click_on 'Settings'
+    within '#search-settings' do
+      find('option[value="openSUSE:Leap:42.3"]').click
+      page.click_on 'OK'
+    end
+
+    page.fill_in 'q', with: ''
+    page.find(:css, 'button#search-button').click
+
+    page.assert_text 'Please provide a valid search term'
+  end
 end


### PR DESCRIPTION
Searches for version without name create huge loads in OBS.

This PR prevents them, and also the empty/no name case in a more unified way.

I still think OBS should return _400 Bad Request_, but these are not mutually exclusive.