### PR TITLE
Fix fonts assets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,7 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  */
-//= require chameleon
+@import "chameleon/chameleon";
 @import "app";
 @import "style";
 


### PR DESCRIPTION
Needs to be merged after https://github.com/openSUSE/opensuse_theme_chameleon-rails/pull/1. This change will force processing on `font_url` directives in `opensuse_theme_chameleon-rails`, which will result in using correct URLs with MD5 hashes.