### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,14 @@ With the rubocop version we are pinned to, there should be no warnings, and the 
 
 If you are not going to fix all issues of a certain type on all files, but just on a subset, you can as well disable the ignore in '.rubocop_todo.yml' locally, fix the issues in a few files, and commit those, without committing '.rubocop_todo.yml', so that it keeps ignoring the files that still have the issue.
 
-If you fixes rubocop issues like the ones above, you can submit it with a Github pull request.
+If you fix rubocop issues like the ones above, you can submit it with a GitHub pull request.
 
 Other changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of this application will generally not be accepted (we share the same [rationales as the Rails project](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
 
 #### **Do you intend to add a new feature or change an existing one?**
 
 * Please open an [issue](https://github.com/openSUSE/software-o-o/issues/new) to discuss your change before writing any code.
-* If the changes are visual, consider attaching screenshots showing the before/after change in the Github pull request description.
+* If the changes are visual, consider attaching screenshots showing the before/after change in the GitHub pull request description.
 
 #### **Do you want to talk to us?**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,13 @@ Other changes that are cosmetic in nature and do not add anything substantial to
 
 #### **Do you intend to add a new feature or change an existing one?**
 
-* Make sure you discussed this with the relevant people and got some feedback, before you start writing code.
-
+* Please open an [issue](https://github.com/openSUSE/software-o-o/issues/new) to discuss your change before writing any code.
 * If the changes are visual, consider attaching screenshots showing the before/after change in the Github pull request description.
 
-* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+#### **Do you want to talk to us?**
+
+* We hang out in our [gitter chatroom](https://gitter.im/openSUSE/software-o-o). This is an **informal** chat, please
+  keep discussions about bugs and features on GitHub.
 
 Thanks! :green_heart: :green_heart: :green_heart:
 


### PR DESCRIPTION
### Clarify ways of communication

GitHub issues are our de-facto feature request tracker (for smaller
features at least, we don't really close them) anyway, so that is our
main way of communication. Feature requests can be discussed there.

Gitter is used for informal chatting.

Fixes #368.