### PR TITLE
TravisCI: Update ruby 2.4 version and add 2.5, 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache: bundler
 addons:
   firefox: latest
 rvm:
-  - 2.4.3
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 script:
   - 'bundle exec rubocop -D'
   - 'bundle exec rails test'


### PR DESCRIPTION
Our application should run on the latest 2.4 minor version and also on
2.5 and the recently released 2.6. Travis can run all of them easily for
us ;)




---

~~Fixes #~~

- [x] I've included before / after screenshots or did not change the UI
