### PR TITLE
Enable CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.5-browsers
+        environment:
+          RAILS_ENV: test
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: openSUSE/software-o-o-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      - save_cache:
+          key: openSUSE/software-o-o-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop -D
+      - run:
+          name: Rails test
+          command: bundle exec rails test
+      - run:
+          name: Rails system test
+          command: bundle exec rails test:system


### PR DESCRIPTION
While moving from travis-ci.org to travis-ci.com (GitHub App), we
disabled the GitHub service for travis-ci.org. The migration did not
work out yet, so for the meantime CirecleCI is used. Once travis-ci.com
works, we can drop CircleCI again.




---

~~Fixes #~~

- [x] I've included before / after screenshots or did not change the UI
