### PR TITLE
Use travis-ci.com badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ script:
   - 'bundle exec rubocop -D'
   - 'bundle exec rails test'
   - 'bundle exec rails test:system'
+
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # software.opensuse.org
 
-[![Build Status](https://travis-ci.org/openSUSE/software-o-o.svg?branch=master)](https://travis-ci.org/openSUSE/software-o-o) [![Gitter chat](https://badges.gitter.im/openSUSE/software-o-o.png)](https://gitter.im/openSUSE/software-o-o)
+[![Build Status](https://travis-ci.com/openSUSE/software-o-o.svg?branch=master)](https://travis-ci.com/openSUSE/software-o-o)[![Gitter chat](https://badges.gitter.im/openSUSE/software-o-o.png)](https://gitter.im/openSUSE/software-o-o)
 
 Ruby on Rails application powering
 [https://software.opensuse.org](https://software.opensuse.org)


### PR DESCRIPTION
The project was migrated to travis-ci.com so a new badge is needed.




---

Fixes #456 

- [x] I've included before / after screenshots or did not change the UI
