### PR TITLE
Update footer copyright years to '2011 - 2019'

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -45,7 +45,7 @@
     </div>
     <div class="footer-copyright-language-row">
       <div class="footer-copyright">
-        &copy; 2011&ndash;2017 <%= _("openSUSE contributors") %>
+        &copy; 2011&ndash;2019 <%= _("openSUSE contributors") %>
       </div>
       <div>
         <a class = "footer-Contribute-ReportBugs" href="https://github.com/openSUSE/software-o-o" target="_blank" >


### PR DESCRIPTION
The copyright year was not updated since 2017, now it is correct again :)

![pre_update](https://user-images.githubusercontent.com/19352524/51029116-bc00f300-1595-11e9-9488-8eede27681a3.png)

![post_update](https://user-images.githubusercontent.com/19352524/51029119-be634d00-1595-11e9-8fc5-e63fbfa422a2.png)


---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
