### PR TITLE
Remove ActiveXML leftover models

### DIFF
--- a/app/models/attribute.rb
+++ b/app/models/attribute.rb
@@ -1,2 +1,0 @@
-class Attribute < ActiveXML::Node
-end

--- a/app/models/pattern.rb
+++ b/app/models/pattern.rb
@@ -1,3 +1,0 @@
-class Pattern < ActiveXML::Node
-  # namespace "http://novell.com/package/metadata/suse/pattern"
-end

--- a/app/models/published.rb
+++ b/app/models/published.rb
@@ -1,2 +1,0 @@
-class Published < ActiveXML::Node
-end


### PR DESCRIPTION
These models were part of ActiveXML and keeping them around stops the
application from starting in production.




---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
