### PR TITLE
Move aarch64 (TW) to Installation tab again

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -53,6 +53,33 @@
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.sha256
+  - name: aarch64
+    types:
+    - name: <%= _("DVD Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 4.7GB
+      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256
+    - name: <%= _("Network Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
+      image_size: 340MB
+      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256
+
 - name: Kubic
   arches:
   - name: x86_64
@@ -140,33 +167,6 @@
   leap-switch: true
   info: <%= _("Ports of openSUSE Tumbleweed to architectures other than the PC are maintained by separate community teams. Scope and pace of the rolling release might be different due to limited resources for those architectures.") %>
   arches:
-  - name: aarch64
-    types:
-    - name: <%= _("DVD Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      image_size: 4.7GB
-      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256
-    - name: <%= _("Network Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 340MB
-      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256
-
   - name: ppc64le
     types:
     - name: <%= _("DVD Image") %>


### PR DESCRIPTION
This change was lost when moving to the new, declarative way for /distributions.

![pre-aarch64](https://user-images.githubusercontent.com/19352524/52879426-648b0f80-315f-11e9-8ff0-d90a3a688e39.png)
![post-aarch64](https://user-images.githubusercontent.com/19352524/52879421-60f78880-315f-11e9-81bf-21df9a1d7cd6.png)

---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
