### PR TITLE
Remove Google+ link

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -27,7 +27,6 @@
           <li><a href="https://forums.opensuse.org/"><%= _("Forums") %></a></li>
           <li><a href="https://connect.opensuse.org/">Connect</a></li>
           <li><a href="https://www.facebook.com/groups/opensuseproject/"><%= _("Facebook group") %></a></li>
-          <li><a href="https://plus.google.com/communities/115444043324891769569"><%= _("Google+ group") %></a></li>
           <li><a href="https://en.opensuse.org/openSUSE:Mailing_lists_subscription"><%= _("Mail lists") %></a></li>
           <li><a href="https://en.opensuse.org/openSUSE:IRC_list"><%= _("IRC channels") %></a></li>
         </ul>
@@ -36,7 +35,6 @@
         <h6><%= _("Social Media") %></h6>
         <ul class="list-unstyled">
           <li><a href="https://www.facebook.com/en.openSUSE">Facebook</a></li>
-          <li><a href="https://plus.google.com/+openSUSE">Google+</a></li>
           <li><a href="https://twitter.com/opensuse">Twitter</a></li>
           <li><a href="https://www.youtube.com/user/opensusetv">YouTube</a></li>
           <li><a href="https://t.me/opensusenews">Telegram</a></li>


### PR DESCRIPTION
Google+ is going to be shutdown https://support.google.com/plus/answer/9195133
