### PR TITLE
Add Leap 15.1 aarch64 links

### DIFF
--- a/app/data/15.1.yml.erb
+++ b/app/data/15.1.yml.erb
@@ -128,3 +128,32 @@
         url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso.sha256
+- name: <%= _("Ports") %>
+  info: <%= _("Ports of openSUSE Leap to architectures other than the PC are maintained by separate community teams, with limited resources.") %>
+  arches:
+  - name: aarch64
+    types:
+    - name: <%= _("DVD Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 3.6GB
+      primary_link: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.sha256
+    - name: <%= _("Network Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 120MB
+      primary_link: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.sha256


### PR DESCRIPTION
Revert https://github.com/openSUSE/software-o-o/pull/484/commits/caa167bd0544a23ebe27caf8447151f07300e760 and update links since aarch64 has now static links.
