### PR TITLE
Tumbleweed: remove 'Ports' tab and move ppc64le and aarch64 to 'Installation' tab

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -6,7 +6,7 @@
     - name: <%= _("DVD Image") %>
       short: <%= _("For DVD and USB stick") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      image_size: 4.1GB
+      image_size: 4.3GB
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso
       links:
       - name: <%= _("Metalink") %>
@@ -18,7 +18,7 @@
     - name: <%= _("Network Image") %>
       short: <%= _("For CD and USB stick") %>
       desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 126MB
+      image_size: 130MB
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso
       links:
       - name: <%= _("Metalink") %>
@@ -44,7 +44,7 @@
     - name: <%= _("Network Image") %>
       short: <%= _("For CD and USB stick") %>
       desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 108MB
+      image_size: 112MB
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso
       links:
       - name: <%= _("Metalink") %>
@@ -53,6 +53,58 @@
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.sha256
+  - name: aarch64
+    types:
+    - name: <%= _("DVD Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 3.6GB
+      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256
+    - name: <%= _("Network Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
+      image_size: 127MB
+      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256
+  - name: ppc64le
+    types:
+    - name: <%= _("DVD Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 3.6GB
+      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.sha256
+    - name: <%= _("Network Image") %>
+      short: <%= _("For CD and USB stick") %>
+      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
+      image_size: 123MB
+      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.meta
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.sha256
 
 - name: Kubic
   arches:
@@ -150,86 +202,3 @@
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.meta4
       - name: <%= _("Checksum") %>
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.sha256
-- name: <%= _("Ports") %>
-  choosing-media: true
-  leap-switch: true
-  info: <%= _("Ports of openSUSE Tumbleweed to architectures other than the PC are maintained by separate community teams. Scope and pace of the rolling release might be different due to limited resources for those architectures.") %>
-  arches:
-  - name: aarch64
-    types:
-    - name: <%= _("DVD Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      image_size: 4.7GB
-      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256
-    - name: <%= _("Network Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 340MB
-      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256
-  - name: ppc64le
-    types:
-    - name: <%= _("DVD Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      image_size: 4.7GB
-      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.sha256
-    - name: <%= _("Network Image") %>
-      short: <%= _("For CD and USB stick") %>
-      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 85MB
-      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.meta
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.sha256
-  - name: ppc64
-    types:
-    - name: <%= _("DVD Image") %>
-      short: <%= _("For DVD and USB stick") %>
-      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      image_size: 4.7GB
-      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso.sha256
-    - name: <%= _("Network Image") %>
-      short: <%= _("For CD and USB stick") %>
-      desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
-      image_size: 85MB
-      primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso
-      links:
-      - name: <%= _("Metalink") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso.sha256


### PR DESCRIPTION
and update ISO sizes with current values.

* Screenshot before this commit: https://paste.opensuse.org/view//95308051
* Screenshot after this commit: https://paste.opensuse.org/view//97828991
