### PR TITLE
Change wording for Tumbleweed live media warning

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -141,7 +141,7 @@
   info: >-
     <%= _("Please be aware of the following limitations of the live images:") %>
 
-      * <%= _("They cannot be used to install or upgrade Tumbleweed. Please use the [Tumbleweed media](%{tw}) instead") % { tw: '/distributions/tumbleweed'} %>
+      * <%= _("They should not be used to install or upgrade Tumbleweed. Please use the [Tumbleweed media](%{tw}) instead") % { tw: '/distributions/tumbleweed'} %>
       * <%= _("They have a limited package and driver selection, so cannot be considered an accurate reflection as to whether Tumbleweed will work on your hardware or not") %>
   arches:
   - name: x86_64


### PR DESCRIPTION
Fixes #
Change wording from `cannot` to `should not`.
Tumbleweed live ISOs *can* be used to install Tumbleweed, but are not recommended over using the normal ISO as they potentially have the same issues as the net install does currently and are not as well tested.

- [X] I've included before / after screenshots or did not change the UI
