### PR TITLE
Live images i586 vs i686

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -182,7 +182,7 @@
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.meta4
       - name: <%= _("Checksum") %>
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.sha256
-  - name: i586
+  - name: i686
     types:
     - name: <%= _("GNOME LiveCD") %>
       short: <%= _("For DVD and USB stick") %>

--- a/app/views/images/images.xml.erb
+++ b/app/views/images/images.xml.erb
@@ -53,7 +53,7 @@ tw_snapshot = get_version('/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Curren
                  <decision name="<%= _("Desktop") %>">
                      <option name="GNOME">
                          <decision name="<%= _("Architecture") %>">
-                             <option name="<%= _("i586") %>">
+                             <option name="<%= _("i686") %>">
                                  <%= image_element("/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Snapshot#{tw_snapshot}-Media.iso", _("Tumbleweed %s GNOME Live (i686)") % tw_snapshot) %>
                              </option>
                              <option name="<%= _("x86_64") %>" preselected="true">
@@ -63,7 +63,7 @@ tw_snapshot = get_version('/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Curren
                      </option>
                      <option name="KDE" preselected="true">
                          <decision name="<%= _("Architecture") %>">
-                             <option name="<%= _("i586") %>">
+                             <option name="<%= _("i686") %>">
                                  <%= image_element("/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Snapshot#{tw_snapshot}-Media.iso", _("Tumbleweed %s KDE Live (i686)") % tw_snapshot) %>
                              </option>
                              <option name="<%= _("x86_64") %>" preselected="true">
@@ -73,7 +73,7 @@ tw_snapshot = get_version('/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Curren
                      </option>
                      <option name="<%= _("Rescue") %>">
                          <decision name="<%= _("Architecture") %>">
-                             <option name="<%= _("i586") %>">
+                             <option name="<%= _("i686") %>">
                                  <%= image_element("/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Snapshot#{tw_snapshot}-Media.iso", _("Tumbleweed %s Rescue CD (i686)") % tw_snapshot) %>
                              </option>
                              <option name="<%= _("x86_64") %>" preselected="true">


### PR DESCRIPTION
On https://software.opensuse.org/distributions/tumbleweed#Live-ports the second headline says "i586" while all links below point to i686 ISOs. Hopefully this commit fixes it.




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
