### PR TITLE
Revert "Patch rubocop for older Bundlers"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,7 @@ group :test do
   gem 'capybara'
   gem 'faker'
   gem 'geckodriver-helper'
-  # TODO: move back to rubygems on next rubocop release (> 0.67.2)
-  gem 'rubocop', git: 'https://github.com/alexandergraul/rubocop', branch: 'fix-for-old-bundler-version'
+  gem 'rubocop'
   gem 'selenium-webdriver'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/alexandergraul/rubocop
-  revision: 09e0a9033c7b23397e60eeff8cb97e8549ce18ec 
-  branch: fix-for-old-bundler-version
-  specs:
-    rubocop (0.66.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      psych (>= 3.1.0)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -174,6 +160,14 @@ GEM
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
     regexp_parser (1.4.0)
+    rubocop (0.67.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      psych (>= 3.1.0)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
@@ -251,7 +245,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rails-i18n
   redcarpet (~> 3.4.0)
-  rubocop!
+  rubocop
   sass-rails
   selenium-webdriver
   uglifier
@@ -261,4 +255,4 @@ DEPENDENCIES
   xmlhash (>= 1.2.2)
 
 BUNDLED WITH
-   1.17.2
+   1.17.1


### PR DESCRIPTION
Reverts openSUSE/software-o-o#544

It is easier to just use upstream rubocop and disable it during %check when building the rpm for now.
