### PR TITLE
Add Leap 15.1 ppc64le links

### DIFF
--- a/app/data/15.1.yml.erb
+++ b/app/data/15.1.yml.erb
@@ -157,3 +157,29 @@
         url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.sha256
+  - name: ppc64le
+    types:
+    - name: <%= _("DVD Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 3.6GB
+      primary_link: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.sha256
+    - name: <%= _("Network Image") %>
+      short: <%= _("For DVD and USB stick") %>
+      desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
+      image_size: 120MB
+      primary_link: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso
+      links:
+      - name: <%= _("Metalink") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.meta4
+      - name: <%= _("Pick Mirror") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso?mirrorlist
+      - name: <%= _("Checksum") %>
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.sha256


### PR DESCRIPTION
Add Leap 15.1 ppc64le links
now that stable links are availables on
http://download.opensuse.org/ports/ppc/distribution/leap/15.1/iso

* I do not know how to test the UI changes, I am expecting my ppc64le in same tab as aarch64.
