### PR TITLE
Allow to run Travis in fork braches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ script:
   - 'bundle exec rubocop -D'
   - 'bundle exec rails test'
   - 'bundle exec rails test:system'
-
-branches:
-  only:
-    - master


### PR DESCRIPTION
According to de04c9dcb51315cc2ae42cfe771e2d0b8be207ee, Travis is only needed in the master branch, but I would also like to run it for my fork. This can be enabled in the user options in Travis, but it is rejected because of the branch being excluded per configuration.
