### PR TITLE
Fix package show when there is not description

### DIFF
--- a/app/helpers/package_helper.rb
+++ b/app/helpers/package_helper.rb
@@ -23,6 +23,8 @@ module PackageHelper
   end
 
   def prepare_desc txt
+    return if txt.blank?
+
     txt = txt.gsub(/[\n][\n]+/, "\n\n")
     txt = create_links txt
     txt = txt.sub(/Authors[:]?[\w\W]+/, "")


### PR DESCRIPTION
In `prepare_desc` we were calling `gsub` for the description, which can be `nil`. This case breaks the code.

Fixes https://github.com/openSUSE/software-o-o/issues/549