### PR TITLE
Use a single Leap action to render all releases

### DIFF
--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -1,8 +1,8 @@
 # Helper for distribution controller
 module DistributionHelper
   def leap_image_tag(opts = {})
-    return image_tag('distributions/testing-white.svg', opts) if action_name == 'testing'
-    image_tag('distributions/leap-white.svg', opts)
+    image_name = @version == @testing_version ? 'testing' : 'leap'
+    image_tag("distributions/#{image_name}-white.svg", opts)
   end
 
   def markdownify(text)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,10 @@ SoftwareOO::Application.routes.draw do
       get 'tumbleweed'
       get 'tumbleweed/ports', to: 'distributions#tumbleweed_ports'
       get 'tumbleweed/unsupported', to: 'distributions#tumbleweed_unsupported'
-      get 'leap'
+      get 'leap(/:version)', to: 'distributions#leap', as: 'leap'
       get 'leap/ports', to: 'distributions#leap_ports'
-      get 'testing'
-      get 'legacy'
+      get 'testing', to: 'distributions#leap', version: 'testing'
+      get 'legacy', to: 'distributions#leap', version: 'legacy'
     end
   end
 

--- a/test/integration/distributions_test.rb
+++ b/test/integration/distributions_test.rb
@@ -37,4 +37,55 @@ class DistributionsTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  def test_versioned_leap_testing
+    VCR.use_cassette('default') do
+      travel_to Time.parse('2018-05-25 11:00:00 UTC') do
+        get '/distributions/leap/15_0'
+        assert_match %r{assets\/distributions\/testing(.*)\.svg}, body
+      end
+    end
+  end
+
+  def test_versioned_leap_stable
+    VCR.use_cassette('default') do
+      travel_to Time.parse('2018-05-25 13:00:00 UTC') do
+        Rails.cache.delete('software-o-o/releases')
+        get '/distributions/leap/15_0'
+        assert_match %r{assets\/distributions\/leap(.*)\.svg}, body
+      end
+    end
+  end
+
+  def test_versioned_leap_legacy
+    VCR.use_cassette('default') do
+      travel_to Time.parse('2018-05-25 13:00:00 UTC') do
+        Rails.cache.delete('software-o-o/releases')
+        get '/distributions/leap/42_3'
+        assert_match %r{assets\/distributions\/leap(.*)\.svg}, body
+      end
+    end
+  end
+
+  def test_legacy_route
+    VCR.use_cassette('default') do
+      travel_to Time.parse('2018-05-25 13:00:00 UTC') do
+        Rails.cache.delete('software-o-o/releases')
+        get '/distributions/leap/legacy'
+        assert_match %r{assets\/distributions\/leap(.*)\.svg}, body
+        assert_includes body, 'openSUSE Leap 42.3'
+      end
+    end
+  end
+
+  def test_testing_route
+    VCR.use_cassette('default') do
+      travel_to Time.parse('2019-05-01 13:00:00 UTC') do
+        Rails.cache.delete('software-o-o/releases')
+        get '/distributions/testing'
+        assert_match %r{assets\/distributions\/testing(.*)\.svg}, body
+        assert_includes body, 'openSUSE Leap 15.1'
+      end
+    end
+  end
 end


### PR DESCRIPTION
All three releases ("testing", "stable" and "legacy") share a lot of
logic. Instead of having three actions that basically do the same, only
one action is needed that behaves differently based on how it was
accessed (i.e. by which route). Additionally, this allows an easy
addition of versioned leap routes. From now on, /leap/15_1 will render
the appropriate page (while in beta, it uses the "testing" style, then
the regular ("stable") style).

Tests for /distributions/testing, /distributions/legacy and versioned
routes are added to ensure the action works correctly.

---

Fixes https://github.com/openSUSE/software-o-o/issues/542.

- [x] I've included before / after screenshots or did not change the UI