### PR TITLE
Correcting Kubic download links

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -114,28 +114,28 @@
       short: <%= _("For DVD and USB stick") %>
       desc: <%= _("Container as a Service Platform based on Kubernetes atop openSUSE MicroOS.") %>
       image_size: 1.6GB
-      primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso
+      primary_link: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-x86_64-Current.iso.sha256
+        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.sha256
   - name: aarch64
     types:
     - name: <%= _("DVD Image") %>
       short: <%= _("For DVD and USB stick") %>
       desc: <%= _("Container as a Service Platform based on Kubernetes atop openSUSE MicroOS.") %>
       image_size: 1.1GB
-      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-aarch64-Current.iso
+      primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-aarch64-Current.iso?mirrorlist
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Kubic-DVD-aarch64-Current.iso.sha256
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.sha256
 - name: <%= _("Live") %>
   choosing-media: true
   info: >-


### PR DESCRIPTION
There's no more "Tumbleweed" in file names.
See https://download.opensuse.org/tumbleweed/iso/ and http://download.opensuse.org/ports/aarch64/tumbleweed/iso/ respectively.