### PR TITLE
Remove -Current from links

### DIFF
--- a/app/data/15.1.yml.erb
+++ b/app/data/15.1.yml.erb
@@ -8,30 +8,30 @@
       short: <%= _("For DVD and USB stick") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
       image_size: 3.6GB
-      primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64-Current.iso
+      primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64-Current.iso.sha256
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.sha256
       - name: <%= _("Torrent File") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64-Current.iso.torrent
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.torrent
     - name: <%= _("Network Image") %>
       short: <%= _("For CD and USB stick") %>
       desc: <%= _("Downloads the installation system and all packages from online repositories. Suitable for installation or upgrade.") %>
       image_size: 120MB
-      primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso
+      primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso.sha256
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.sha256
       - name: <%= _("Torrent File") %>
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso.torrent
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.torrent
 - name: <%= _("JeOS") %>
   arches:
   - name: x86_64


### PR DESCRIPTION
Also remove 15.1 testing downloads until the release as the links would
be broken anyways.




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
