### PR TITLE
Pass leap version to documentation partial

### DIFF
--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -115,7 +115,7 @@
 <section class="my-3">
   <div class="container" role="main">
   <% if @distro_type == "leap" %>
-    <%= render partial: 'documentation', locals: { distro: "Leap" } %>
+    <%= render partial: 'documentation', locals: { distro: "Leap", version: @version } %>
   <% else %>
     <%= render partial: 'documentation', locals: { distro: "Tumbleweed" } %>
   <% end %>


### PR DESCRIPTION
The documentation partial uses the leap version to create the path to
the release notes.

Fixes https://github.com/openSUSE/software-o-o/issues/581.

Before:
![Screenshot from 2019-05-22 11-45-39](https://user-images.githubusercontent.com/19352524/58165056-41ed2300-7c87-11e9-8f01-955f9f579a0f.png)

After:
![Screenshot from 2019-05-22 11-43-14](https://user-images.githubusercontent.com/19352524/58165062-47e30400-7c87-11e9-85bc-b2b9265a470f.png)


- [x] I've included before / after screenshots or did not change the UI
