### PR TITLE
Improve automatic image size

### DIFF
--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -18,6 +18,14 @@ module DistributionHelper
     markdown.render(text).html_safe
   end
 
+  def image_size(medium)
+    url = "https://download.opensuse.org#{medium['primary_link']}"
+    cache_key = ActiveSupport::Cache.expand_cache_key('image_size', url)
+    Rails.cache.fetch(cache_key, expires_in: 12.hours) do
+      retrieve_image_size(url)
+    end
+  end
+
   def retrieve_image_size(url)
     conn = Faraday.new(url: url) do |f|
       f.use FaradayMiddleware::FollowRedirects, limit: 5
@@ -31,17 +39,10 @@ module DistributionHelper
     0
   end
 
-  def cached_image_size(name, url)
-    cache_key = ActiveSupport::Cache.expand_cache_key('image_size', name)
-    Rails.cache.fetch(cache_key, expires_in: 12.hours) do
-      retrieve_image_size(url)
-    end
-  end
+  def short_description(medium)
+    return medium['short'] if medium['short'].present?
 
-  def short_description(short_desc, image_size)
-    return short_desc if short_desc.present?
-
-    case image_size
+    case image_size(medium)
     when 0..700_000_000
       _("For CD and USB stick")
     when 700_000_001..5_000_000_000

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -20,12 +20,15 @@ module DistributionHelper
 
   def retrieve_image_size(url)
     conn = Faraday.new(url: url) do |f|
-      f.use FaradayMiddleware::FollowRedirects
-      f.request  :url_encoded
-      f.adapter  Faraday.default_adapter
+      f.use FaradayMiddleware::FollowRedirects, limit: 5
+      f.request :url_encoded
+      f.adapter Faraday.default_adapter
     end
     # Turn into integer just in case we have dead links (they will report 0B)
     conn.head.headers['content-length'].to_i
+  rescue Faraday::Error::ClientError => e
+    Rails.logger.error("Exception in distribution_helper#retrieve_image_size: #{e}")
+    0
   end
 
   def short_description(short_desc, image_size)

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -31,6 +31,13 @@ module DistributionHelper
     0
   end
 
+  def cached_image_size(name, url)
+    cache_key = ActiveSupport::Cache.expand_cache_key('image_size', name)
+    Rails.cache.fetch(cache_key, expires_in: 12.hours) do
+      retrieve_image_size(url)
+    end
+  end
+
   def short_description(short_desc, image_size)
     return short_desc if short_desc.present?
 

--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -58,7 +58,7 @@
             <%= type["name"] %>
             </a>
             <div class="p-2">
-              <% image_size = retrieve_image_size( "https://download.opensuse.org#{type["primary_link"]}" ) %>
+              <% image_size = cached_image_size(type["name"], "https://download.opensuse.org#{type["primary_link"]}") %>
               <h5 class="mb-2 text-muted"><%= number_to_human_size(image_size) %></h5>
               <h6 class="mb-2 text-muted"><%= short_description(type["short"], image_size) %></h6>
               <p class="text-muted"><%= _(type["desc"]) %></p>

--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -58,9 +58,8 @@
             <%= type["name"] %>
             </a>
             <div class="p-2">
-              <% image_size = cached_image_size(type["name"], "https://download.opensuse.org#{type["primary_link"]}") %>
-              <h5 class="mb-2 text-muted"><%= number_to_human_size(image_size) %></h5>
-              <h6 class="mb-2 text-muted"><%= short_description(type["short"], image_size) %></h6>
+              <h5 class="mb-2 text-muted"><%= number_to_human_size(image_size(type)) %></h5>
+              <h6 class="mb-2 text-muted"><%= short_description(type) %></h6>
               <p class="text-muted"><%= _(type["desc"]) %></p>
 
               <% type["links"].try(:each) do |link| %>

--- a/test/helper/distribution_helper_test.rb
+++ b/test/helper/distribution_helper_test.rb
@@ -3,12 +3,25 @@
 require 'test_helper'
 
 class DistributionHelperTest < ActionView::TestCase
-  test 'short should display correct messages' do
-    assert_equal 'test', short_description('test', 0)
-    assert_equal _("For CD and USB stick"), short_description(nil, 0)
-    assert_equal _("For CD and USB stick"), short_description(nil, 700_000_000)
-    assert_equal _("For DVD and USB stick"), short_description(nil, 700_000_001)
-    assert_equal _("For DVD and USB stick"), short_description(nil, 5_000_000_000)
-    assert_equal _("For USB stick"), short_description(nil, 5_000_000_001)
+  test 'short description given medium without predefined description' do
+    # VCR has trouble with :head request
+    WebMock.stub_request(:head, 'https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso')
+           .to_return(headers: { 'content_length' => 4_689_231_872 })
+    WebMock.stub_request(:head, 'https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso')
+           .to_return(headers: { 'content_length' => 135_266_304 })
+
+    dvd_image = { "name" => "DVD Image",
+                  "primary_link" => "/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso" }
+    network_image = { "name" => "Network Image",
+                      "primary_link" => "/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso" }
+
+    assert_equal 'For DVD and USB stick', short_description(dvd_image)
+    assert_equal 'For CD and USB stick', short_description(network_image)
+  end
+
+  test 'short description given medium with predefined description' do
+    medium = { "name" => "KVM and XEN", "short" => "For use in KVM or XEN HVM hypervisors" }
+
+    assert_equal medium['short'], short_description(medium)
   end
 end


### PR DESCRIPTION
After deploying today, /distributions/tumbleweed could not be loaded because the http requests to retrieve the image sizes were redirected too often. This resulted in uncaught exceptions which in turn stopped the page from rendering.

A limit of 5 redirects seems to fix the issue. In case it there is still an issue, the exception is logged but a size of 0 is returned. The page can render and will show the obviously incorrect 0. In the future this can be handled a bit differently, e.g. by showing a message that the size information is unavailable.

Additionally, the image size is now cached by Rails.