### PR TITLE
Hide image size if retrieval failed

### DIFF
--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -43,7 +43,8 @@ module DistributionHelper
     return medium['short'] if medium['short'].present?
 
     case image_size(medium)
-    when 0..700_000_000
+    when 0 then ""
+    when 1..700_000_000
       _("For CD and USB stick")
     when 700_000_001..5_000_000_000
       _("For DVD and USB stick")

--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -58,7 +58,8 @@
             <%= type["name"] %>
             </a>
             <div class="p-2">
-              <h5 class="mb-2 text-muted"><%= number_to_human_size(image_size(type)) %></h5>
+              <% human_size = number_to_human_size(image_size(type)) %>
+              <h5 class="mb-2 text-muted"><%= human_size unless human_size.starts_with? "0" %></h5>
               <h6 class="mb-2 text-muted"><%= short_description(type) %></h6>
               <p class="text-muted"><%= _(type["desc"]) %></p>
 


### PR DESCRIPTION
Users don't need to see a size of 0. Although it is probably obvious to
most that the size is incorrect, there is no benefit from showing it
when we can just hide it.

Before:
![before](https://user-images.githubusercontent.com/19352524/61799990-766a9000-ae2c-11e9-8080-e92058e1841d.png)

After:
![after](https://user-images.githubusercontent.com/19352524/61799999-7cf90780-ae2c-11e9-988f-9572a1b45678.png)

---

Fixes #631

- [x] I've included before / after screenshots or did not change the UI
