### PR TITLE
Change how baseproject is set

### DIFF
--- a/app/assets/javascripts/search-settings.js
+++ b/app/assets/javascripts/search-settings.js
@@ -5,37 +5,40 @@
  * - Clicking Cancel or x button do nothing.
  */
 $(function() {
-  var $modal = $("#search-settings");
-  var $form = $("#baseproject");
-  var $ok = $modal.find(".ok-button");
-  var $cancel = $modal.find(".cancel-button");
+  let $settings_modal = $("#search-settings");
+  let $project_dropdown = $("#baseproject");
+  let $ok = $settings_modal.find(".ok-button");
+  let $cancel = $settings_modal.find(".cancel-button");
 
-  function save_input_cookie(name) {
-    var value = $form.val();
-    console.log(name + ": " + value);
+  function set_cookie(name, value) {
+    console.log("Setting cookie: " + name + " = " + value);
     Cookies.set(name, value, { expires: 365 });
   }
-  
-  $form.on('change', function() {
-    save_input_cookie("baseproject");
-    location.reload();
+
+  $project_dropdown.on('change', function() {
+    /*
+     * See https://stackoverflow.com/a/41542008 for editing query string
+     */
+    let value = $project_dropdown.val();
+    let query_params = new URLSearchParams(window.location.search);
+
+    set_cookie("baseproject", value);
+    if (query_params.has("baseproject")) query_params.set("baseproject", value);
+
+    // causes site reload
+    window.location.search = query_params.toString();
   });
-
-  function save_checkbox_cookie(name) {
-    var value = $modal.find('[name="' + name + '"]').prop("checked");
-    console.log(name + ": " + value);
-    Cookies.set(name, value, { expires: 365 });
-  }
 
   $ok.click(function() {
-    save_checkbox_cookie("search_devel");
-    save_checkbox_cookie("search_lang");
-    save_checkbox_cookie("search_debug");
-    $modal.modal("hide");
+    for (setting of ["search_devel", "search_lang", "search_debug"]) {
+      let value = $settings_modal.find('[name="'+ setting +'"]').prop("checked");
+      set_cookie(setting, value);
+    }
     location.reload();
   });
+
   $cancel.click(function() {
-    $modal.find('form')[0].reset();
-    $modal.modal("hide");
+    $settings_modal.find('form')[0].reset();
+    $settings_modal.modal("hide");
   });
 });

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,6 @@ class ApplicationController < ActionController::Base
   before_action :validate_configuration
   before_action :set_language
   before_action :set_external_urls
-  before_action :set_releases_parameters
-  # depends on releases
-  before_action :set_baseproject
 
   helper :all # include all helpers, all the time
   require "rexml/document"
@@ -103,13 +100,6 @@ class ApplicationController < ActionController::Base
     @testing_version = current['testing_version']
     @testing_state = current['testing_state']
     @legacy_release = current['legacy_version']
-  end
-
-  def set_baseproject
-    unless @distributions.blank? || @distributions.select { |d| d[:project] == cookies[:baseproject] }.blank?
-      @baseproject = cookies[:baseproject]
-    end
-    @baseproject = "openSUSE:Leap:#{@stable_version}" if @baseproject.blank?
   end
 
   # special version of render json with JSONP capabilities (only needed for rails < 3.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ SoftwareOO::Application.configure do
   config.cache_store = :memory_store
   # Do not eager load code on boot.
   config.eager_load = false
-
+  config.assets.debug = true
   # Needed for generated thumbnails
   config.serve_static_files = true
 end

--- a/test/models/appdata_test.rb
+++ b/test/models/appdata_test.rb
@@ -8,7 +8,7 @@ class AppdataTest < ActiveSupport::TestCase
       appdata = Appdata.get('factory')
       pkg_list = appdata[:apps].map { |p| p[:pkgname] }.uniq
 
-      assert_equal 669, pkg_list.size
+      assert_equal 689, pkg_list.size
       ['0ad', '4pane', 'opera', 'steam'].each do |pkg|
         assert_includes pkg_list, pkg
       end

--- a/test/obs_test.rb
+++ b/test/obs_test.rb
@@ -40,7 +40,7 @@ class OBSTest < ActiveSupport::TestCase
         'project' => 'home:dmacvicar',
         'repository' => 'openSUSE_Tumbleweed',
         'arch' => 'x86_64',
-        'filename' => 'vcpkg-0.0+git.1524688133.90be0d9b-9.6.x86_64.rpm'
+        'filename' => 'vcpkg-0.0+git.1524688133.90be0d9b-9.22.x86_64.rpm'
       )
       fileinfo = OBS.search_published_binary_fileinfo(binary)
 

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -14,7 +14,7 @@ class SearchResultsTest < ActionDispatch::SystemTestCase
       # if this ever changes, uncomment the next line
       # page.click_on 'Settings'
       within '#baseproject' do
-        find('option[value="openSUSE:Leap:42.3"]').click
+        find('option[value="openSUSE:Leap:15.1"]').click
       end
       page.fill_in 'q', with: 'nvidia'
       page.find(:css, 'button#search-button').click
@@ -23,14 +23,14 @@ class SearchResultsTest < ActionDispatch::SystemTestCase
   end
 
   def test_non_existing_packages
-    #    VCR.use_cassette('search_paralapapiricoipi_openSUSE_Leap_42.3') do
+    #    VCR.use_cassette('search_paralapapiricoipi_openSUSE_Leap_15.1') do
     VCR.use_cassette('default') do
       visit '/explore'
       # There is no need to click on settings. If cookies are fresh, they will auto popup
       # if this ever changes, uncomment the next line
       # page.click_on 'Settings'
       within '#baseproject' do
-        find('option[value="openSUSE:Leap:42.3"]').click
+        find('option[value="openSUSE:Leap:15.1"]').click
       end
 
       page.fill_in 'q', with: 'paralapapiricoipi'
@@ -47,7 +47,7 @@ class SearchResultsTest < ActionDispatch::SystemTestCase
       # if this ever changes, uncomment the next line
       # page.click_on 'Settings'
       within '#baseproject' do
-        find('option[value="openSUSE:Leap:42.3"]').click
+        find('option[value="openSUSE:Leap:15.1"]').click
       end
 
       page.fill_in 'q', with: '1'
@@ -64,7 +64,7 @@ class SearchResultsTest < ActionDispatch::SystemTestCase
       # if this ever changes, uncomment the next line
       # page.click_on 'Settings'
       within '#baseproject' do
-        find('option[value="openSUSE:Leap:42.3"]').click
+        find('option[value="openSUSE:Leap:15.1"]').click
       end
 
       page.fill_in 'q', with: ''


### PR DESCRIPTION
The baseproject can be set either via the Cookie header or via the query
string. The latter takes precedence over the cookie value, i.e. opening
a search URL that contains a baseproject key will override the
previously set cookie. This helps with sharing of searches.

Before, this happened:
![before-baseproject-fix](https://user-images.githubusercontent.com/19352524/62840283-40d0fe00-bc98-11e9-991b-13cb3c918d7f.png)

Now we get results:

![after-baseproject-fix](https://user-images.githubusercontent.com/19352524/62840285-475f7580-bc98-11e9-8379-30091a85ce3b.png)

---

Fixes #589

- [x] I've included before / after screenshots or did not change the UI