### PR TITLE
Rename filter! to select! to support older Rubies

### DIFF
--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -81,9 +81,9 @@ class OBSController < ApplicationController
 
     # filter out ports for different arch
     if @baseproject.end_with?("ARM")
-      @packages.filter! { |p| p.project.include?("ARM") || p.repository.include?("ARM") }
+      @packages.select! { |p| p.project.include?("ARM") || p.repository.include?("ARM") }
     elsif @baseproject.end_with?("PowerPC")
-      @packages.filter! { |p| p.project.include?("PowerPC") || p.repository.include?("PowerPC") }
+      @packages.select! { |p| p.project.include?("PowerPC") || p.repository.include?("PowerPC") }
     else # x86
       @packages.reject! do |p|
         p.repository.end_with?("_ARM", "_PowerPC", "_zSystems") || p.repository == 'ports' ||


### PR DESCRIPTION
Current production ruby version is 2.4, filter! was only added to Ruby
in 2.6 (https://bugs.ruby-lang.org/issues/13784).

---
- [x] I've included before / after screenshots or did not change the UI
