### PR TITLE
Fix Debian Release.key URL

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -80,7 +80,7 @@ pacman -S <%= repo_name %>/<%= @package %></pre>
                      when 'CentOS', 'RHEL', 'SL'
                        "cd /etc/yum.repos.d/\nwget #{v[:repo]}#{@project}.repo\nyum install #{@package}"
                      when 'Debian', 'Univention'
-                       "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' > /etc/apt/sources.list.d/#{@project}.list\nwget -nv #{v[:repo]} Release.key -O Release.key\napt-key add - < Release.key\napt-get update\napt-get install #{@package}"
+                       "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' > /etc/apt/sources.list.d/#{@project}.list\nwget -nv #{v[:repo]}Release.key -O Release.key\napt-key add - < Release.key\napt-get update\napt-get install #{@package}"
                      when 'Mageia', 'Mandriva'
                        version = k.split("_").last
                        if version == "Cauldron" or Integer(version) >= 6


### PR DESCRIPTION
A space found its way into the URL between the dynamic part and
"Release.key" which breaks the generated URL for Debian users.

Fixes https://github.com/openSUSE/software-o-o/issues/650.
