### PR TITLE
Expert download link in package show

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -10,7 +10,7 @@
    <h2 class="my-4"><%= _("Select Your Operating System") %></h2>
    <div class="row py-3">
       <% @flavors.each do |flavor| %>
-      <button class="col btn btn-link btn-pointer align-items-center p-0" id="<%= flavor %>_button" data-toggle="collapse" data-target="#<%= flavor %>" aria-expanded="false" aria-controls="<%= flavor %>">
+      <button class="col btn btn-link btn-pointer align-items-center p-0" id="<%= flavor %>_button" data-toggle="collapse" data-target="#<%= flavor %>" aria-controls="<%= flavor %>" aria-expanded="<%= @flavors.size == 1 %>">
          <img src="<%= image_path('download/' + flavor.downcase + '.png') %>" alt="<%= flavor %>" />
          <h6><%= flavor %></h6>
       </button>
@@ -20,7 +20,7 @@
    <div id="accordion">
       <% @flavors.each do |flavor| %>
       <div class="card border-0">
-         <div id="<%= flavor %>" class="collapse" aria-labelledby="heading<%= flavor %>" data-parent="#accordion">
+         <div id="<%= flavor %>" class="collapse<%= ' show' if @flavors.size == 1 %>" aria-labelledby="heading<%= flavor %>" data-parent="#accordion">
             <div class="card-body p-3">
                <div class="row w-100">
                   <% @data.select {|k,v| v.has_key?(:ymp) && v[:flavor] == flavor}.sort.reverse.each do |k,v|%>

--- a/app/views/package/_download_rows.html.erb
+++ b/app/views/package/_download_rows.html.erb
@@ -49,18 +49,10 @@
           <a class="btn btn-sm btn-primary" href="<%= url %>"><span class="typcn typcn-flash-outline"></span> <%= _("1 Click Install") %></a>
         <% end %>
 
-        <div class="btn-group">
-          <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="typcn typcn-download-outline"></span> <%= _("Download") %>
-          </button>
-          <div class="dropdown-menu dropdown-menu-right">
-              <% archs.each do |arch| %>
-                <% items.select{|item| human_arch( item.arch ) == arch}.each do |bin| %>
-                  <%= link_to _(human_arch( bin.arch )), "http://download.opensuse.org/repositories/" + bin.filepath, :class => 'dropdown-item'  %>
-                <% end -%>
-              <% end -%>
-          </div>
-        </div>
+        <%= link_to download_package_path(project: result.first, package: @pkgname), class: 'btn btn-sm btn-secondary' do %>
+          <span class="typcn typcn-download-outline"></span>
+          <%= _('Expert Download') %>
+        <% end %>
 
       </div><!-- /.col- -->
     </div><!-- /.card-body -->

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -53,6 +53,11 @@
               <span class="typcn typcn-flash-outline"></span>
               <%= _("Direct Install") %>
             </a>
+
+            <%= link_to download_package_path(project: @default_package.project, package: @pkgname), class: 'btn btn-lg btn-secondary' do %>
+              <span class="typcn typcn-download-outline"></span>
+              <%= _('Expert Download') %>
+            <% end %>
           <% end -%>
         </div><!-- /#package-description -->
       </div><!-- /.row -->


### PR DESCRIPTION
Link to the download page, which shows all installation options (such as the manually install one) and not only the binaries. Closes #372

We plan to create a new page for the expert download, but we think we need some discussion for that before (we will open an issue), but this is already much better than before (you don't need to go though OBS anymore :tada: )

Also, save the users one click to select the distribution on the download page if there is only one option. :bowtie: 

Co-authored-by: @alexandergraul 

![image](https://user-images.githubusercontent.com/16052290/64911616-243e4080-d6f2-11e9-87c0-ab0e19b8ffa1.png)
![image](https://user-images.githubusercontent.com/16052290/64911620-39b36a80-d6f2-11e9-8e7f-c8c6457b0631.png)

