### PR TITLE
Hide search box on /download pages

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DownloadController < ApplicationController
-  before_action :set_colors
+  before_action :set_colors, :hide_search_box
 
   # display documentation
   def doc; end
@@ -244,5 +244,9 @@ class DownloadController < ApplicationController
 
   def valid_color? color
     color =~ /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/
+  end
+
+  def hide_search_box
+    @hide_search_box = true
   end
 end


### PR DESCRIPTION
Searching is not required on these pages. They are only for displaying
download instructions and the documentation thereof. Users can search on
the homepage, /search and others.




---
Before:
![before-hide-searchbox](https://user-images.githubusercontent.com/19352524/66125522-71258080-e5e7-11e9-9b53-ce23279f8761.png)

After:
![after-hide-searchbox](https://user-images.githubusercontent.com/19352524/66125521-71258080-e5e7-11e9-9a58-d37218f349b0.png)


- [x] I've included before / after screenshots or did not change the UI
