### PR TITLE
Add route constraints and remove required_parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -121,14 +121,6 @@ class ApplicationController < ActionController::Base
     render({ content_type: 'application/javascript', body: response }.merge(options))
   end
 
-  def required_parameters(*parameters)
-    parameters.each do |parameter|
-      unless params.include? parameter.to_s
-        raise MissingParameterError, "Required Parameter #{parameter} missing"
-      end
-    end
-  end
-
   def valid_package_name?(name)
     name =~ /^[[:alnum:]][-+\w\.:\@]*$/
   end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -7,7 +7,6 @@ class DownloadController < ApplicationController
   def doc; end
 
   def appliance
-    required_parameters :project
     @project = params[:project]
     # TODO: no clear way to fetch appliances. we need a /search/published/appliance
 
@@ -44,8 +43,6 @@ class DownloadController < ApplicationController
   end
 
   def package
-    redirect_to(action: :doc) && return if !params[:project] && !params[:package]
-    required_parameters :project, :package
     @project = params[:project]
     @package = params[:package]
     escaped_prj = CGI.escape(@project)
@@ -84,7 +81,6 @@ class DownloadController < ApplicationController
   end
 
   def pattern
-    required_parameters :project, :pattern
     @project = params[:project]
     @pattern = params[:pattern]
 

--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -7,7 +7,6 @@ class PackageController < OBSController
   skip_before_action :set_language, :set_distributions, :set_baseproject, only: %i[thumbnail screenshot]
 
   def show
-    required_parameters :package
     @pkgname = params[:package]
     raise MissingParameterError, 'Invalid parameter package' unless valid_package_name? @pkgname
 
@@ -62,7 +61,6 @@ class PackageController < OBSController
   end
 
   def category
-    required_parameters :category
     @category = params[:category]
     raise MissingParameterError, 'Invalid parameter category' unless valid_package_name? @category
 
@@ -82,12 +80,10 @@ class PackageController < OBSController
   end
 
   def screenshot
-    required_parameters :package
     image params[:package], :screenshot
   end
 
   def thumbnail
-    required_parameters :package
     image params[:package], :thumbnail
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,8 +33,13 @@ SoftwareOO::Application.routes.draw do
   end
 
   namespace 'download' do
-    %w(doc appliance package pattern).each do |action|
-      get action
+    get 'appliance', constraints: ->(request) { request.params[:project].present? }
+    get 'package', constraints: ->(request) { request.params[:project].present? && request.params[:package].present? }
+    get 'pattern', constraints: ->(request) { request.params[:project].present? && request.params[:pattern].present? }
+
+    # Show documentation if contraints are not met
+    %w(doc appliance package pattern).each do |path|
+      get path, action: :doc
     end
   end
   get 'ymp/:project/:repository/:package.ymp', to: 'download#ymp_without_arch_and_version',


### PR DESCRIPTION
`required_parameters` provided a way to ensure that the `params` hash contains
specific keys. `required_parameters` is not needed if routes are validated
properly using constraints. As a side effect, `required_parameters` caused
a lot of false positive "unpermitted parameters" log statements.

Instead of having the check inside the controller action, routes should only match if the parameters are provided. This was already the case for the package controller, which still called `required_parameters` even though it was not needed. For the download controller I've added the contraints.

---

Fixes #500 

- [x] I've included before / after screenshots or did not change the UI
