### PR TITLE
Use JavaScript 5 syntax in search-setttings.js

### DIFF
--- a/app/assets/javascripts/search-settings.js
+++ b/app/assets/javascripts/search-settings.js
@@ -5,10 +5,10 @@
  * - Clicking Cancel or x button do nothing.
  */
 $(function() {
-  let $settings_modal = $("#search-settings");
-  let $project_dropdown = $("#baseproject");
-  let $ok = $settings_modal.find(".ok-button");
-  let $cancel = $settings_modal.find(".cancel-button");
+  var $settings_modal = $("#search-settings");
+  var $project_dropdown = $("#baseproject");
+  var $ok = $settings_modal.find(".ok-button");
+  var $cancel = $settings_modal.find(".cancel-button");
 
   function set_cookie(name, value) {
     console.log("Setting cookie: " + name + " = " + value);
@@ -19,8 +19,8 @@ $(function() {
     /*
      * See https://stackoverflow.com/a/41542008 for editing query string
      */
-    let value = $project_dropdown.val();
-    let query_params = new URLSearchParams(window.location.search);
+    var value = $project_dropdown.val();
+    var query_params = new URLSearchParams(window.location.search);
 
     set_cookie("baseproject", value);
     if (query_params.has("baseproject")) query_params.set("baseproject", value);
@@ -31,7 +31,7 @@ $(function() {
 
   $ok.click(function() {
     for (setting of ["search_devel", "search_lang", "search_debug"]) {
-      let value = $settings_modal.find('[name="'+ setting +'"]').prop("checked");
+      var value = $settings_modal.find('[name="'+ setting +'"]').prop("checked");
       set_cookie(setting, value);
     }
     location.reload();


### PR DESCRIPTION
We use UglifierJS to minify our JavaScript. Uglifier only supports
JavaScript 5 syntax. `let` was introduced in JavaScript 6 (2015).

---

- [x] I've included before / after screenshots or did not change the UI