### PR TITLE
Resolves #649: Removed 'features.opensuse.org' link from footer as it linked to a di…

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,7 +8,6 @@
           <li><a href="https://build.opensuse.org/"><%= _("Build service") %></a></li>
           <li><a href="https://bugzilla.opensuse.org/">Bugzilla</a></li>
           <li><a href="https://github.com/openSUSE">Github</a></li>
-          <li><a href="https://features.opensuse.org/">openFATE</a></li>
         </ul>
       </div>
       <div class="col-6 col-md-3">


### PR DESCRIPTION
@alexandergraul Simple enough!
Just to confirm - there is no link to 'https://fate.opensuse.org' in the footer.
There is a link to 'https://features.opensuse.org' however that directs to a page with a "discontinued" warning - so that's what I removed.


---

Fixes #649 

- [x] I've included before / after screenshots or did not change the UI
