### PR TITLE
Improve package routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,7 +130,7 @@ class ApplicationController < ActionController::Base
   end
 
   def valid_package_name?(name)
-    name =~ /^[[:alnum:]][-+\w\.:\@]*$/
+    name =~ /^[[:alnum:]][-+~\w\.:\@]*$/
   end
 
   def valid_pattern_name?(name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,15 +21,15 @@ SoftwareOO::Application.routes.draw do
   get 'images.xml', to: 'images#images'
 
   controller :package do
-    get 'package/:package' => :show, :constraints => { :package => /[-+\w\.:\@]+/ }
-    get 'package/thumbnail/:package.png' => :thumbnail, :constraints => { :package => /[-+\w\.:\@]+/ }
-    get 'package/screenshot/:package.png' => :screenshot, :constraints => { :package => /[-+\w\.:\@]+/ }
+    get 'package/:package', action: :show, constraints: { package: /[-+\w\.:\@]+/ }
+    get 'package/thumbnail/:package.png', action: :thumbnail, constraints: { package: /[-+\w\.:\@]+/ }
+    get 'package/screenshot/:package.png', action: :screenshot, constraints: { package: /[-+\w\.:\@]+/ }
 
-    get 'explore' => :explore
-    get 'packages' => :explore
-    get 'appstore' => :explore
-    get 'packages/:category' => :category, :constraints => { :category => /[\w\-\.: ]+/ }
-    get 'appstore/:category' => :category, :constraints => { :category => /[\w\-\.: ]+/ }
+    get 'explore', action: :explore
+    get 'packages', action: :explore
+    get 'appstore', action: :explore
+    get 'packages/:category', action: :category, constraints: { category: /[\w\-\.: ]+/ }
+    get 'appstore/:category', action: :category, constraints: { category: /[\w\-\.: ]+/ }
   end
 
   namespace 'download' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,9 +21,9 @@ SoftwareOO::Application.routes.draw do
   get 'images.xml', to: 'images#images'
 
   controller :package do
-    get 'package/:package', action: :show, constraints: { package: /[-+\w\.:\@]+/ }
-    get 'package/thumbnail/:package.png', action: :thumbnail, constraints: { package: /[-+\w\.:\@]+/ }
-    get 'package/screenshot/:package.png', action: :screenshot, constraints: { package: /[-+\w\.:\@]+/ }
+    get 'package/:package', action: :show, constraints: { package: /[-+~\w\.:\@]+/ }
+    get 'package/thumbnail/:package.png', action: :thumbnail, constraints: { package: /[-+~\w\.:\@]+/ }
+    get 'package/screenshot/:package.png', action: :screenshot, constraints: { package: /[-+~\w\.:\@]+/ }
 
     get 'explore', action: :explore
     get 'packages', action: :explore


### PR DESCRIPTION
This PR adds "~" as an accepted characters for package names and uses ruby 1.9 hash syntax instead of hash rockets.

---

Fixes #697

- [x] I've included before / after screenshots or did not change the UI
