### PR TITLE
Include NonFree:Update projects

### DIFF
--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -19,8 +19,10 @@ class PackageController < OBSController
       # only show rpms
       @packages.select! { |p| p.type != 'ymp' && p.quality != 'Private' }
       @default_project_name = @distributions.find { |d| d[:project] == @baseproject }[:name]
-      @default_package = @packages.find { |s| s.project == "#{@baseproject}:Update" } ||
-                         @packages.find { |s| [@baseproject, "#{@baseproject}:NonFree"].include? s.project }
+      default_update_projects = ["#{@baseproject}:Update", "#{@baseproject}:NonFree:Update"]
+      default_release_projects = [@baseproject, "#{@baseproject}:NonFree"]
+      @default_package = @packages.find { |p| default_update_projects.include?(p.project) } ||
+                         @packages.find { |p| default_release_projects.include?(p.project) }
 
       pkg_appdata = @appdata[:apps].find { |app| app[:pkgname].casecmp(@pkgname).zero? }
       if pkg_appdata

--- a/app/views/package/_download_rows.html.erb
+++ b/app/views/package/_download_rows.html.erb
@@ -1,7 +1,7 @@
 <% packages.flatten.sort_by(&:project).group_by(&:project).each do |result| %>
   <% if  result.first == distro[:project] || result.first == "#{distro[:project]}:NonFree"
     name = _("<b>official release</b>")
-  elsif result.first == "#{distro[:project]}:Update"
+  elsif result.first == "#{distro[:project]}:Update" || result.first == "#{distro[:project]}:NonFree:Update"
     name = _("<b>official update</b>")
   else
     name = shorten result.first, 40

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -80,7 +80,7 @@
         <!-- official packages -->
         <%
         official, pkgs = pkgs.partition{|s| s.project == distro[:project] || s.project == "#{distro[:project]}:NonFree" }
-        update, pkgs = pkgs.partition{|s| s.project == "#{distro[:project]}:Update"}
+        update, pkgs = pkgs.partition{|s| s.project == "#{distro[:project]}:Update" || s.project == "#{distro[:project]}:NonFree:Update"}
         stable, pkgs = pkgs.partition{|s| s.quality == "Stable"} %>
 
         <%= render( :partial => 'package/download_rows', :locals => {:packages => official, :distro => distro, :oneclick => true, :type => 'official'} ) if update.blank? %>


### PR DESCRIPTION
We previously looked at `@baseproject`, `@baseproject:Update` and
`@baseproject:NonFree` to show the current version and link to OBS.
Only `@baseproject:NonFree:Update` was missing.

There is no reason not to include `@baseproject:NonFree:Update` if both
`@baseproject:Update` and `@baseproject:NonFree` are included.

Before (https://software.opensuse.org/package/opera):
![before-nonfree-update](https://user-images.githubusercontent.com/19352524/70390050-82b04d80-19c7-11ea-8d4a-9ab75fabed03.png)

After:
![after-nonfree-update](https://user-images.githubusercontent.com/19352524/70390053-880d9800-19c7-11ea-97a0-d7973106ff68.png)



---

Fixes https://github.com/openSUSE/software-o-o/issues/702.

- [x] I've included before / after screenshots or did not change the UI
