### PR TITLE
Add Solargraph gem for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   # no need to load the gem via require
   # we only need the rake tasks
   gem 'gettext', '>= 1.9.3', require: false
+  gem 'solargraph'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    backport (1.1.2)
     bindex (0.5.0)
     builder (3.2.3)
     byebug (11.0.1)
@@ -100,6 +101,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    maruku (0.7.3)
     method_source (0.9.2)
     mimemagic (0.3.3)
     mini_magick (4.9.5)
@@ -160,6 +162,8 @@ GEM
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
     regexp_parser (1.6.0)
+    reverse_markdown (1.3.0)
+      nokogiri
     rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -186,6 +190,18 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    solargraph (0.38.0)
+      backport (~> 1.1)
+      bundler (>= 1.17.2)
+      jaro_winkler (~> 1.5)
+      maruku (~> 0.7, >= 0.7.3)
+      nokogiri (~> 1.9, >= 1.9.1)
+      parser (~> 2.3)
+      reverse_markdown (~> 1.0, >= 1.0.5)
+      rubocop (~> 0.52)
+      thor (~> 0.19, >= 0.19.4)
+      tilt (~> 2.0)
+      yard (~> 0.9)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -219,6 +235,7 @@ GEM
       pkg-config
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -250,6 +267,7 @@ DEPENDENCIES
   rubocop-performance
   sass-rails
   selenium-webdriver
+  solargraph
   uglifier
   vcr
   web-console


### PR DESCRIPTION
solargraph is a LSP-server for Ruby. It integrates with many different
Editors and supports--among others--Go-to-definition, completion,
automated refactoring.

More on LSP: https://langserver.org/

---

- [x] I've included before / after screenshots or did not change the UI