### PR TITLE
Deprecate leap42.3 ruby2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache: bundler
 addons:
   firefox: latest
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 script:
   - 'bundle exec rake rubocop'
   - 'bundle exec rails test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 2.5.7
   - 2.6.5
   - 2.7.0
+before_install:
+    - gem install bundler
 script:
   - 'bundle exec rake rubocop'
   - 'bundle exec rails test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 RUN gem install bundler
 
 # Install requirements for our rubygems 
-RUN zypper -q --non-interactive install sqlite3-devel gcc make libxml2-devel libxslt-devel
+RUN zypper -q --non-interactive install sqlite3-devel gcc gcc-c++ make libxml2-devel libxslt-devel
 
 # Add our user
 RUN useradd -m vagrant  -u $IMAGE_USERID -p vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2'
 # For appdata redirections (https -> http)
 gem 'open_uri_redirections'
 # Use SCSS for stylesheets
-gem 'sass-rails'
+gem 'sassc-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   xmlhash (>= 1.2.2)
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,9 +157,6 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
     regexp_parser (1.6.0)
     reverse_markdown (1.3.0)
@@ -176,17 +173,14 @@ GEM
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
-    sass (3.7.2)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -210,7 +204,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     text (1.3.1)
-    thor (1.0.1)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
     tzinfo (1.2.6)
@@ -265,7 +259,7 @@ DEPENDENCIES
   redcarpet (~> 3.4.0)
   rubocop
   rubocop-performance
-  sass-rails
+  sassc-rails
   selenium-webdriver
   solargraph
   uglifier

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ We hope you'll get involved! Read our [Contributors' Guide](https://github.com/o
 
 ## Installing dependencies in a (open)SUSE system
 
-We recommend the usage of Ruby 2.4 or higher for the development.
+We recommend the usage of Ruby 2.5 or higher for the development.
 
 If you are an openSUSE Tumbleweed user, it comes with the latest Ruby releases as default so you can configure your environment doing:
 
 ```console
 zypper ref
-zypper in ruby ruby-devel 'rubygem(bundler)' nodejs gcc make libxml2-devel libxslt-devel
+zypper in ruby ruby-devel 'rubygem(bundler)' nodejs gcc gcc-c++ make libxml2-devel libxslt-devel
 ```
 
-On openSUSE Leap 42.3 you will need to install the Ruby 2.4 environment doing:
+On openSUSE Leap 15.1 you will need to install the Ruby 2.5 environment doing:
 
 ```console
 zypper ref
-zypper in ruby2.4 ruby2.4-devel ruby2.4-rubygem-bundler nodejs6 gcc make libxml2-devel libxslt-devel
+zypper in ruby2.5 ruby2.5-devel ruby2.5-rubygem-bundler nodejs gcc gcc-c++ make libxml2-devel libxslt-devel
 ```
 
 You can find more information about Ruby development and packaging on openSUSE distributions [here](https://en.opensuse.org/Ruby).


### PR DESCRIPTION
Now that the production VM runs Leap 15.1 we don't need to support an unsupported OS anymore.
This allows us to use libsass, which is needed by sassc-rails.
