### PR TITLE
Fix Leap 15.2 JeOS and Live links

### DIFF
--- a/app/data/15.2.yml.erb
+++ b/app/data/15.2.yml.erb
@@ -30,85 +30,85 @@
     types:
     - name: KVM and XEN
       short: <%= _("For use in KVM or XEN HVM hypervisors") %>
-      primary_link: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-kvm-and-xen-Current.qcow2
+      primary_link: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-kvm-and-xen-Current.qcow2.meta4
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-kvm-and-xen.qcow2.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-kvm-and-xen-Current.qcow2?mirrorlist
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-kvm-and-xen.qcow2?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-kvm-and-xen-Current.qcow2.sha256
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-kvm-and-xen.qcow2.sha256
     - name: XEN
       short: <%= _("For use in XEN PV hypervisors") %>
-      primary_link: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-XEN-Current.qcow2
+      primary_link: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-XEN.qcow2
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-XEN-Current.qcow2.meta4
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-XEN.qcow2.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-XEN-Current.qcow2?mirrorlist
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-XEN.qcow2?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-XEN-Current.qcow2.sha256
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-XEN.qcow2.sha256
     - name: MS HyperV
       short: <%= _("For running virtual machines on MS HyperV") %>
-      primary_link: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-MS-HyperV-Current.vhdx.xz
+      primary_link: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-MS-HyperV-Current.vhdx.xz.meta4
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-MS-HyperV.vhdx.xz.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-MS-HyperV-Current.vhdx.xz?mirrorlist
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-MS-HyperV.vhdx.xz?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-MS-HyperV-Current.vhdx.zx.sha256
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-MS-HyperV.vhdx.zx.sha256
     - name: VMware
       short: <%= _("For running virtual machines in VMware") %>
-      primary_link: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-VMware-Current.vmdk.xz
+      primary_link: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-VMware.vmdk.xz
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-VMware-Current.vmdk.xz.meta4
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-VMware.vmdk.xz.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-VMware-Current.vmdk.xz?mirrorlist
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-VMware.vmdk.xz?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-VMware-Current.vmdk.xz.sha256
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-VMware.vmdk.xz.sha256
     - name: OpenStack-Cloud
       short: <%= _("For running virtual machines in OpenStack") %>
-      primary_link: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-OpenStack-Cloud-Current.qcow2
+      primary_link: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-OpenStack-Cloud-Current.qcow2.meta4
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-OpenStack-Cloud.qcow2.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-OpenStack-Cloud-Current.qcow2?mirrorlist
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-OpenStack-Cloud.qcow2?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/jeos/openSUSE-Leap-<%= @version %>-JeOS.x86_64-<%= @version %>.0-OpenStack-Cloud-Current.qcow2.sha256
+        url: /distribution/leap/<%= @version %>/appliances/openSUSE-Leap-<%= @version %>-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256
 - name: <%= _("Live") %>
   arches:
   - name: x86_64
     types:
     - name: Gnome
-      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current-Current.iso
+      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current-Current.iso.meta4
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current-Current.iso?mirrorlist
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current-Current.iso.sha256
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso.sha256
     - name: KDE
-      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Current-Current.iso
+      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Current-Current.iso.meta4
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Current-Current.iso?mirrorlist
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Current-Current.iso.sha256
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-KDE-Live-x86_64-Media.iso.sha256
     - name: Rescue LiveCD
-      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Current-Current.iso
+      primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Current-Current.iso.meta4
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Current-Current.iso?mirrorlist
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Current-Current.iso.sha256
+        url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso.sha256
 - name: <%= _("Ports") %>
   info: <%= _("Ports of openSUSE Leap to architectures other than the PC are maintained by separate community teams, with limited resources.") %>
   arches:
@@ -116,43 +116,43 @@
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      primary_link: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media-Current.iso
+      primary_link: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media-Current.iso.meta4
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media-Current.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media-Current.iso.sha256
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-aarch64-Media.iso.sha256
     - name: <%= _("Network Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      primary_link: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media-Current.iso
+      primary_link: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media-Current.iso.meta4
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media-Current.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media-Current.iso.sha256
+        url: /ports/aarch64/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Media.iso.sha256
   - name: ppc64le
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      primary_link: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media-Current.iso
+      primary_link: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media-Current.iso.meta4
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media-Current.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media-Current.iso.sha256
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-DVD-ppc64le-Media.iso.sha256
     - name: <%= _("Network Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
-      primary_link: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media-Current.iso
+      primary_link: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media.iso
       links:
       - name: <%= _("Metalink") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media-Current.iso.meta4
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media.iso.meta4
       - name: <%= _("Pick Mirror") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media-Current.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media.iso?mirrorlist
       - name: <%= _("Checksum") %>
-        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media-Current.iso.sha256
+        url: /ports/ppc/distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Media.iso.sha256


### PR DESCRIPTION
The OBS publisher setup is different, so the links had to be adjusted.