### PR TITLE
Remove XEN flavor from Tumbleweed JeOS page

### DIFF
--- a/app/data/tumbleweed.yml.erb
+++ b/app/data/tumbleweed.yml.erb
@@ -120,8 +120,7 @@
   - name: x86_64
     types:
     - name: KVM and XEN
-      short: <%= _("For use in KVM or XEN HVM hypervisors") %>
-      image_size: 250MB
+      short: <%= _("For use in KVM or XEN hypervisors") %>
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: <%= _("Metalink") %>
@@ -130,20 +129,8 @@
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2?mirrorlist
       - name: <%= _("Checksum") %>
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2.sha256
-    - name: XEN
-      short: <%= _("For use in XEN PV hypervisors") %>
-      image_size: 250MB
-      primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-XEN.qcow2
-      links:
-      - name: <%= _("Metalink") %>
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-XEN.qcow2.meta4
-      - name: <%= _("Pick Mirror") %>
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-XEN.qcow2?mirrorlist
-      - name: <%= _("Checksum") %>
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-XEN.qcow2.sha256
     - name: MS HyperV
       short: <%= _("For running virtual machines on MS HyperV") %>
-      image_size: 900MB
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: <%= _("Metalink") %>
@@ -154,7 +141,6 @@
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz.sha256
     - name: VMware
       short: <%= _("For running virtual machines in VMware") %>
-      image_size: 800MB
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz
       links:
       - name: <%= _("Metalink") %>
@@ -165,7 +151,6 @@
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz.sha256
     - name: OpenStack-Cloud
       short: <%= _("For running virtual machines in OpenStack") %>
-      image_size: 250MB
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: <%= _("Metalink") %>


### PR DESCRIPTION
kvm-and-xen is a complete replacement, so XEN got dropped.

![Screenshot_20200416_135433](https://user-images.githubusercontent.com/1622084/79453316-d112d000-7fe9-11ea-9d80-19f0c9c6f2a8.png)
