### PR TITLE
Keep the menu always in sight

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark <%= @colour ? "bg-#{@colour}" : "bg-dark" %>">
+<nav id="global-navbar" class="navbar navbar-expand-md navbar-toggleable navbar-dark <%= @colour ? "bg-#{@colour}" : "bg-dark" %> sticky-top">
 
   <a class="navbar-brand" href="https://www.opensuse.org/">
     <%= image_tag "chameleon/logo/logo-white.svg", width: 48, height: 30, class: "d-inline-block align-top", alt: "openSUSE Logo" %>


### PR DESCRIPTION
Having to scroll long ways just to reach the main menu items is pointless. So let's keep the menu always on top of the visible content.

- [x] I've included before / after screenshots or did not change the UI

Before:
![image](https://user-images.githubusercontent.com/74432/81088505-4e4fa780-8efb-11ea-832d-f5c3c6b4b3b6.png)

After:
![image](https://user-images.githubusercontent.com/74432/81088550-5f98b400-8efb-11ea-9e81-67e17d7f215d.png)

