### PR TITLE
manifest.js is required by updated sprockets-rails

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,5 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .scss
+//= link application.css
+


### PR DESCRIPTION
Recent update of sprocket-rails broke both runtime and tests
An extra manifest file is needed to get it operational




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
