### PR TITLE
Downgrade back the bundler in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,4 +275,4 @@ DEPENDENCIES
   xmlhash (>= 1.2.2)
 
 BUNDLED WITH
-   2.1.4
+   1.17.2


### PR DESCRIPTION
* openSUSE Leap 15.2 doesn't have bundler 2+




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
