### PR TITLE
Fix pattern matching generating rubocop errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,3 @@ DEPENDENCIES
   web-console
   webmock
   xmlhash (>= 1.2.2)
-
-BUNDLED WITH
-   1.17.2

--- a/test/integration/package_controller_test.rb
+++ b/test/integration/package_controller_test.rb
@@ -13,7 +13,7 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
   def test_thumbnail_unknown_package_returns_default_asset
     FileUtils.rm_f UNKNOWN_PACKAGE_THUMBNAIL
     VCR.use_cassette('default') do
-      get '/package/thumbnail/SupperFancyBrowser.png'
+      get '/package/thumbnail/SuperFancyBrowser.png'
       assert_response :redirect
       assert_match %r{/assets/default-screenshots/package(.*).png}, @response.redirect_url
     end


### PR DESCRIPTION
Fixed pattern matching issues in /lib/api_connect.rb and /lib/obs.rb generating errors in rubocop tests and I have implemented guard clause style to search controller to fix rubocop error

---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
