### PR TITLE
Dearmor APT key before putting it into trusted.gpg.d

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -55,7 +55,7 @@ pacman -S <%= repo_name %>/<%= @package %></pre>
                   <pre><%=
                      # don't use apt-add-repository wrapper for Ubuntu for now, because it adds source repo which we don't provide
                      #        "apt-add-repository deb #{v[:repo]} /\napt-get update\napt-get install #{@package}"
-                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\nsudo wget -nv #{v[:repo]}Release.key -O \"/etc/apt/trusted.gpg.d/#{@project}.asc\"\nsudo apt update\nsudo apt install #{@package}"
+                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\ncurl -fsSL #{v[:repo]}Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/#{@project}.gpg > /dev/null\nsudo apt update\nsudo apt install #{@package}"
                      %></pre>
                   <% else %>
                   <h5><%= (_("For <strong>%s</strong> run the following as <strong>root</strong>:") % k.gsub('_', '&nbsp;').html_safe).html_safe %></h5>


### PR DESCRIPTION
Just implementing [my own suggestion](https://github.com/openSUSE/software-o-o/pull/786#issuecomment-644089036):

> However, some APT versions don't recognize ASCII-armoured keys, which lead to [complaints like this](https://github.com/Eloston/ungoogled-chromium/issues/1071). Might I suggest adding a `gpg --dearmor` step?
>
>```sh
> curl -fsSL 'https://download.opensuse.org/repositories/home:ungoogled_chromium/Ubuntu_Focal/Release.key' \
>  | gpg --dearmor \
>  | sudo tee /etc/apt/trusted.gpg.d/ungoogled-chromium.gpg \
>  > /dev/null
>```