### PR TITLE
Sync release timestamp for 15.2 with landing page

### DIFF
--- a/config/releases.yml
+++ b/config/releases.yml
@@ -7,7 +7,7 @@
     state: 'Beta'
   - date: '2020-05-28 12:00:00 UTC'
     state: 'RC'
-  - date: '2020-07-02 10:00:00 UTC'
+  - date: '2020-07-02 11:45:00 UTC'
     state: 'Stable'
 - version: 15.1
   order: 4


### PR DESCRIPTION
* do it 15 minutes ahead of the time so we do not have any broken
  links




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
