### PR TITLE
package.erb: produce GPG-safe keyring names

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -55,7 +55,7 @@ pacman -S <%= repo_name %>/<%= @package %></pre>
                   <pre><%=
                      # don't use apt-add-repository wrapper for Ubuntu for now, because it adds source repo which we don't provide
                      #        "apt-add-repository deb #{v[:repo]} /\napt-get update\napt-get install #{@package}"
-                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\ncurl -fsSL #{v[:repo]}Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/#{@project}.gpg > /dev/null\nsudo apt update\nsudo apt install #{@package}"
+                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\ncurl -fsSL #{v[:repo]}Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/#{@project.gsub(':', '_')}.gpg > /dev/null\nsudo apt update\nsudo apt install #{@package}"
                      %></pre>
                   <% else %>
                   <h5><%= (_("For <strong>%s</strong> run the following as <strong>root</strong>:") % k.gsub('_', '&nbsp;').html_safe).html_safe %></h5>


### PR DESCRIPTION
On Debian/Ubuntu since 3248a08c28cfcbf2, the instructions will save the repository key to a file in the APT trusted keyrings directory with the same name as the project. Unfortunately, if there is a colon in the project name (such as home:someuser), future invocations of apt-key fail silently or with the following error:

```
gpg: invalid key resource URL '/tmp/apt-key-gpghome.xyz/home:someuser.asc.gpg'
gpg: keyblock resource '(null)': General error
```

Transform the filename to remove colons in order to avoid GPG interpreting these filenames as URLs.

---

Fixes #842 

- [ ] I've included before / after screenshots or did not change the UI