### PR TITLE
Bump Ruby Versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-sudo: required
-dist: trusty
 language: ruby
 cache: bundler
 addons:
   firefox: latest
 rvm:
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 before_install:
-    - gem install bundler
+    - gem install bundler:1.17.2
 script:
   - 'bundle exec rake rubocop'
   - 'bundle exec rails test'


### PR DESCRIPTION
Catching up to Ruby versions released on 2020-03-31

---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
