### PR TITLE
Update geckodriver-helper to 0.27.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,10 @@ end
 group :test do
   gem 'capybara'
   gem 'faker'
-  gem 'geckodriver-helper'
+  # bragboy's fork works with Firefox 80
+  # ', git:...' can be removed once https://github.com/DevicoSolutions/geckodriver-helper/pull/17
+  # is merged and a new gem version is released
+  gem 'geckodriver-helper', git: 'https://github.com/bragboy/geckodriver-helper'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/bragboy/geckodriver-helper
+  revision: 929e5da958de9f82705e2dce71a7dbba873a461f
+  specs:
+    geckodriver-helper (0.27.0)
+      archive-zip (~> 0.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,8 +85,6 @@ GEM
       faraday (~> 1.0)
     fast_gettext (2.0.3)
     ffi (1.10.0)
-    geckodriver-helper (0.24.0)
-      archive-zip (~> 0.7)
     get_process_mem (0.2.4)
       ffi (~> 1.0)
     gettext (3.3.5)
@@ -93,7 +98,7 @@ GEM
     hashie (4.1.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
+    io-like (0.3.1)
     jaro_winkler (1.5.4)
     locale (2.1.3)
     loofah (2.5.0)
@@ -251,7 +256,7 @@ DEPENDENCIES
   faraday
   faraday_middleware
   fast_gettext (>= 0.7.0)
-  geckodriver-helper
+  geckodriver-helper!
   gettext (>= 1.9.3)
   gettext_i18n_rails (>= 0.4.3)
   hashie


### PR DESCRIPTION
This update is required for running system tests with Firefox 80. Since the version on rubygems.org or the official upstream repo is not updated yet, the version for an open upstream PR is used instead.