### PR TITLE
Update copyright year in footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="footer-copyright-language-row">
       <div class="footer-copyright">
-        &copy; 2011&ndash;2019 <%= _("openSUSE contributors") %>
+        &copy; 2011&ndash;2020 <%= _("openSUSE contributors") %>
       </div>
       <div>
         <a class = "footer-Contribute-ReportBugs" href="https://github.com/openSUSE/software-o-o" target="_blank" >


### PR DESCRIPTION
I'm somewhat amused that this was left alone this long. ;) Might there be a better way to prevent this in the future, by having the current year inserted into the template? I'd think so, but I'm not familiar with RoR.

Before (from the production site):

![screen_20201023113351_openSUSE software - Mozilla Firefox](https://user-images.githubusercontent.com/648663/96988989-5f31bb00-1525-11eb-8572-37267ba24c58.png)

After (local repo, no further setup so pardon the big error):

![screen_20201023114424_Error - Mozilla Firefox](https://user-images.githubusercontent.com/648663/96989049-6fe23100-1525-11eb-9af8-342d128eaf6a.png)

---

Fixes #880

- [x] I've included before / after screenshots or did not change the UI
