### PR TITLE
Don't try to Time.parse a "Time" object

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,7 +82,7 @@ class ApplicationController < ActionController::Base
       now = Time.now
       versions.each do |version|
         version['releases'].reject! do |release|
-          release['date'] = Time.parse(release['date'])
+          release['date'] = Time.parse(release['date']) unless release['date']
           release['date'] > now
         end
         # Get the latest release


### PR DESCRIPTION
With Ruby2.7, Time can't be converted into a String implicitly. The way we use `Time.parse`, we don't need to convert the Time object into a String just to convert it into a Time object again (using `Time.parse`).

---
Fixes https://github.com/openSUSE/software-o-o/issues/815.

- [x] I've included before / after screenshots or did not change the UI
