### PR TITLE
Use a regular class for Appdata

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -171,13 +171,13 @@ class ApplicationController < ActionController::Base
 
   def tumbleweed_appdata
     Rails.cache.fetch('appdata/tumbleweed', expires_in: 12.hours) do
-      Appdata.get('factory')
+      Appdata.new('tumbleweed').data
     end
   end
 
   def leap_appdata(version)
     Rails.cache.fetch("appdata/leap#{version}", expires_in: 12.hours) do
-      Appdata.get("leap/#{version}")
+      Appdata.new("leap/#{version}").data
     end
   end
 

--- a/test/models/appdata_test.rb
+++ b/test/models/appdata_test.rb
@@ -3,9 +3,9 @@
 require File.expand_path('../test_helper', __dir__)
 
 class AppdataTest < ActiveSupport::TestCase
-  test 'Factory Appdata can be parsed' do
+  test 'Tumbleweed Appdata can be parsed' do
     VCR.use_cassette('default') do
-      appdata = Appdata.get('factory')
+      appdata = Appdata.new('tumbleweed').data
       pkg_list = appdata[:apps].map { |p| p[:pkgname] }.uniq
 
       assert_equal 736, pkg_list.size
@@ -17,7 +17,7 @@ class AppdataTest < ActiveSupport::TestCase
 
   test 'Leap 15.2 Appdata can be parsed' do
     VCR.use_cassette('default') do
-      appdata = Appdata.get('leap/15.2')
+      appdata = Appdata.new('leap/15.2').data
       pkg_list = appdata[:apps].map { |p| p[:pkgname] }.uniq
 
       assert_equal 733, pkg_list.size
@@ -31,7 +31,7 @@ class AppdataTest < ActiveSupport::TestCase
     VCR.use_cassette('default') do
       stub_request(:get, %r{https://download.opensuse.org/tumbleweed/repo/(non-)?oss/repodata/(.*)-appdata.xml.gz})
         .to_return(status: 404, body: '', headers: {})
-      appdata = Appdata.get('factory')
+      appdata = Appdata.new('tumbleweed').data
       assert_empty appdata[:apps]
     end
   end


### PR DESCRIPTION
Previously we needed to pass variables around that now live as instance variables. The class API changed slightly, but all users were updated accordingly. 

---

- [x] I've included before / after screenshots or did not change the UI
