### PR TITLE
Prevent exceptions when accessing @appdata

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -164,6 +164,8 @@ class ApplicationController < ActionController::Base
                  leap_appdata(@testing_version)
                when "openSUSE:Leap:#{@legacy_release}"
                  leap_appdata(@legacy_release)
+               else
+                 { apps: [], categories: Set.new }
                end
   end
 


### PR DESCRIPTION
For many distributions we don't load `@appdata`. `@appdata` is still accessed, expecting that it always exists and contains `:apps` and
`:categories`. With this change, those accesses don't throw exceptions.

---

Fixes https://github.com/openSUSE/software-o-o/issues/885.

- [x] I've included before / after screenshots or did not change the UI
