### PR TITLE
Add missing development packages

### DIFF
--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -67,7 +67,7 @@ class OBSController < ApplicationController
     # only show packages
     @packages.reject! { |p| p.type == 'ymp' }
 
-    @packages.reject! { |p| p.name.end_with?('-devel') } unless @search_devel
+    @packages.reject! { |p| /-devel/i.match?(p.name) } unless @search_devel
 
     unless @search_lang
       @packages.reject! { |p| p.name.end_with?('-lang') || p.name.include?('-translations-') || p.name.include?('-l10n-') }

--- a/lib/obs.rb
+++ b/lib/obs.rb
@@ -183,7 +183,7 @@ module OBS
     binary.relevance -= 20 if /^openSUSE:Maintenance/i.match?(binary.project)
     binary.relevance -= 10 if /-debugsource$/.match?(binary.name)
     binary.relevance -= 10 if /-debuginfo$/.match?(binary.name)
-    binary.relevance -= 3 if /-devel$/.match?(binary.name)
+    binary.relevance -= 3 if /-devel/i.match?(binary.name)
     binary.relevance -= 3 if /-doc$/.match?(binary.name)
     binary
   end


### PR DESCRIPTION
Only packages ending with `-devel` were considered development packages. Change it to consider packages which contain the `-devel` string and to be not case-sensitive to include packages such as:

```
ruby2.5-devel-extra
perl-Devel-Cover
nginx-module-devel-kit-source
```

Closes https://github.com/openSUSE/software-o-o/issues/653

A test for this would be good, but we don't currently have any tests for the search. So I think this is out of scope, maybe for next year's Hacktoberfest... :eyes: 

