### PR TITLE
Fix tabs in distribution page

### DIFF
--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -21,10 +21,10 @@
   </div>
   <div class="border-bottom" role="tablist">
     <ul class="container nav nav-tabs nav-justified border-0">
-      <% @yaml_data.try(:each) do |tab| %>
+      <% @yaml_data.try(:each_with_index) do |tab, index| %>
 
       <li class="nav-item">
-        <a class="nav-link h-100<% if @yaml_data[0]["name"] == tab["name"] %> active<% end %>" data-toggle="tab" href="#<%= tab["name"] %>-ports" role="tab">
+        <a class="nav-link h-100<% if index == 0 %> active<% end %>" data-toggle="tab" href="#tab-<%= index %>" role="tab">
           <%= _(tab["name"]) %>
           <div class="text-nowrap">
             <% tab["arches"].try(:each) do |arch| %>
@@ -41,8 +41,8 @@
 <section class="mb-5">
   <div class="container">
     <div class="tab-content">
-      <% @yaml_data.try(:each) do |tab| %>
-      <div class="tab-pane <% if @yaml_data[0]["name"] == tab["name"] %>active<% end %>" id="<%= tab["name"] %>-ports" role="tabpanel">
+      <% @yaml_data.try(:each_with_index) do |tab, index| %>
+      <div class="tab-pane <% if index == 0 %>active<% end %>" id="tab-<%= index %>" role="tabpanel">
         <% if tab["info"] %>
           <div class="alert alert-<%= tab["info-colour"] || @colour %>">
             <%= markdownify( _(tab["info"]) ) %>


### PR DESCRIPTION
Do no use translations as tabs. Use `tab-<number>` instead.

Another solution is to have the English names in the version files and use the translations when needed. This makes a bit easier to modify the version files and would allow us to have nicer links. But the change is a bit more complicated and this page may be migrated to: https://get.opensuse.org

Fix (partially): https://github.com/openSUSE/software-o-o/issues/596


