### PR TITLE
use relative URLs for screenshots and thumbnails

### DIFF
--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -32,8 +32,8 @@ class PackageController < OBSController
         @appid = pkg_appdata[:id]
       end
 
-      @screenshot = url_for controller: :package, action: :screenshot, package: @pkgname, protocol: request.protocol
-      @thumbnail = url_for controller: :package, action: :thumbnail, package: @pkgname, protocol: request.protocol
+      @screenshot = url_for controller: :package, action: :screenshot, package: @pkgname, only_path: true
+      @thumbnail = url_for controller: :package, action: :thumbnail, package: @pkgname, only_path: true
 
       filter_packages
 


### PR DESCRIPTION
Mixed-security content (http images in https pages) can be avoided by using relative URLs to access them.

This pull request just replaces the `protocol: request.protocol` parameter of `url_for` by `only_path: true` to create such relative references.

---

Fixes #769

- [x] I've included before / after screenshots or did not change the UI (did not change the UI)
