### PR TITLE
Correct sequence of html tags in search settings

### DIFF
--- a/app/views/search/_settings.html.erb
+++ b/app/views/search/_settings.html.erb
@@ -31,13 +31,13 @@
               <%= _("Show debug packages") %>
             </label>
           </div>
-        </div>
+        </form>
 
         <div class="modal-footer">
           <button type="button" class="ok-button btn btn-primary"><%= _("OK") %></button>
           <button type="button" class="cancel-button btn btn-secondary"><%= _("Cancel") %></button>
         </div>
-      </form>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Switch the sequence of `</div>` and `</form>` tag in the search option modal dialog.

---

Fixes #895 

- [x] I've included before / after screenshots or did not change the UI (no change to the UI)
