### PR TITLE
Specify s390x with IBM Z and LinuxONE for software.opensuse.org

### DIFF
--- a/app/data/15.3.yml.erb
+++ b/app/data/15.3.yml.erb
@@ -72,7 +72,7 @@
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Current.iso.sha256
-  - name: s390x
+  - name: s390x (IBM Z and LinuxONE)
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>


### PR DESCRIPTION

https://software.opensuse.org/distributions/testing contains all available hardware architectures. s390x should be more specified that users can understand, that the download option for s390x should be available for IBM Z and LinuxONE.