### PR TITLE
Additional Arch Description

### DIFF
--- a/app/data/15.3.yml.erb
+++ b/app/data/15.3.yml.erb
@@ -3,6 +3,7 @@
   leap-switch: true
   arches:
   - name: x86_64
+    desc: Intel or AMD 64-bit servers, desktops, laptops and boards
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
@@ -29,6 +30,7 @@
       - name: <%= _("Torrent File") %>
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-x86_64-Current.iso.torrent
   - name: aarch64
+    desc: UEFI Arm 64-bit servers, desktops, laptops and boards
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
@@ -51,6 +53,7 @@
       - name: <%= _("Checksum") %>
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-aarch64-Current.iso.sha256
   - name: ppc64le
+    desc: PowerPC servers, not big-endian
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>
@@ -72,7 +75,8 @@
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Current.iso?mirrorlist
       - name: <%= _("Checksum") %>
         url: /distribution/leap/<%= @version %>/iso/openSUSE-Leap-<%= @version %>-NET-ppc64le-Current.iso.sha256
-  - name: s390x (IBM Z and LinuxONE)
+  - name: s390x
+    desc: IBM Z and LinuxONE
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>

--- a/app/data/15.3.yml.erb
+++ b/app/data/15.3.yml.erb
@@ -3,7 +3,7 @@
   leap-switch: true
   arches:
   - name: x86_64
-    desc: Intel or AMD 64-bit servers, desktops, laptops and boards
+    desc: Intel or AMD 64-bit desktops, laptops, and servers
     types:
     - name: <%= _("DVD Image") %>
       desc: <%= _("Contains a large collection of software for desktop or server use. Suitable for installation or upgrade.") %>

--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -49,7 +49,7 @@
           </div>
         <% end %>
         <% tab["arches"].try(:each) do |arch| %>
-        <h3 class="my-3 text-center"><%= arch["name"] %> <% if arch["desc"] %>(<%= arch["desc"] %>)<% end %></h3>
+        <h3 class="my-3 text-center"><%= arch["name"] %><% if arch["desc"] %> (<%= arch["desc"] %>)<% end %></h3>
         <div class="row">
           <% arch["types"].try(:each) do |type| %>
           <div class="col text-center">

--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -49,7 +49,7 @@
           </div>
         <% end %>
         <% tab["arches"].try(:each) do |arch| %>
-        <h3 class="my-3 text-center"><%= arch["name"] %></h3>
+        <h3 class="my-3 text-center"><%= arch["name"] %> <% if arch["desc"] %>(<%= arch["desc"] %>)<% end %></h3>
         <div class="row">
           <% arch["types"].try(:each) do |type| %>
           <div class="col text-center">


### PR DESCRIPTION
Adds additional description after the architecture as per concerns of @bmwiedemann who was worried that using single tab for all arches might be confusing for some users.

I've moved descriptions under a separate attr, as otherwise they were also projected in these little labels in individual tabs and that didn't look nice.


- [ x] I've included before / after screenshots or did not change the UI

![arches](https://user-images.githubusercontent.com/510119/102381009-fc125100-3fc8-11eb-8801-3b1e6ced3578.png)

