### PR TITLE
Fix text, from Gnome to GNOME

### DIFF
--- a/app/data/15.0.yml.erb
+++ b/app/data/15.0.yml.erb
@@ -86,7 +86,7 @@
   arches:
   - name: x86_64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current.iso
       links:
       - name: <%= _("Metalink") %>

--- a/app/data/15.1.yml.erb
+++ b/app/data/15.1.yml.erb
@@ -86,7 +86,7 @@
   arches:
   - name: x86_64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Current.iso
       links:
       - name: <%= _("Metalink") %>

--- a/app/data/15.2.yml.erb
+++ b/app/data/15.2.yml.erb
@@ -76,7 +76,7 @@
   arches:
   - name: x86_64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso
       links:
       - name: <%= _("Metalink") %>
@@ -105,7 +105,7 @@
         url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso.sha256
   - name: aarch64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /ports/aarch64/distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-aarch64-Media.iso
       links:
       - name: <%= _("Metalink") %>

--- a/app/data/15.3.yml.erb
+++ b/app/data/15.3.yml.erb
@@ -142,7 +142,7 @@
   arches:
   - name: x86_64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-x86_64-Media.iso
       links:
       - name: <%= _("Metalink") %>
@@ -171,7 +171,7 @@
         url: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-Rescue-CD-x86_64-Media.iso.sha256
   - name: aarch64
     types:
-    - name: Gnome
+    - name: GNOME
       primary_link: /distribution/leap/<%= @version %>/live/openSUSE-Leap-<%= @version %>-GNOME-Live-aarch64-Media.iso
       links:
       - name: <%= _("Metalink") %>


### PR DESCRIPTION


---

Fixes #

- [x] I've included before / after screenshots or did not change the UI

In Tumbleweed section, it's already GNOME.

![screenshot-software opensuse org-2020 12 17-09_40_04](https://user-images.githubusercontent.com/6271071/102436874-13465280-404c-11eb-9d91-c331c3c1bcb7.png)

This pull request fix GNOME text on Leap section.

Before:

![screenshot-software opensuse org-2020 12 17-09_40_45](https://user-images.githubusercontent.com/6271071/102436957-3e30a680-404c-11eb-9072-7959a4c7d92a.png)

After:

![screenshot-software opensuse org-2020 12 17-09_49_56](https://user-images.githubusercontent.com/6271071/102437565-4d642400-404d-11eb-857f-fd4efdd79945.png)
