### PR TITLE
package.erb: Update Arch Linux instructions to support signature verification

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -44,12 +44,18 @@
                   <% repo_name = @project.gsub(":", "_") + "_" + k %>
                   <h5><%= _("For <strong>Arch Linux</strong>, edit /etc/pacman.conf and add the following (note that the order of repositories in pacman.conf is important, since pacman always downloads the first found package):") %></h5>
                   <pre><%= "[#{repo_name}]" %>
-SigLevel = Never
 Server = <%= v[:repo].gsub(/(\w):(\w)/, '\1:/\2') %>$arch
 </pre>
                   <h5><%= _("Then run the following as <strong>root</strong>") %></h5>
-                  <pre>pacman -Syu
-pacman -S <%= repo_name %>/<%= @package %></pre>
+                  <pre>
+key=$(curl -fsSL <%= "#{v[:repo]}$(uname -m)/#{repo_name}.key" %>)
+fingerprint=$(gpg --quiet --with-colons --import-options show-only --import --fingerprint &lt;&lt;&lt; "${key}" | awk -F: '$1 == "fpr" { print $10 }')
+
+pacman-key --init
+pacman-key --add - &lt;&lt;&lt; "${key}"
+pacman-key --lsign-key "${fingerprint}"
+
+pacman -Sy <%= repo_name %>/<%= @package %></pre>
                   <% elsif v[:flavor] == "Ubuntu" or v[:flavor] == "Debian" %>
                   <h5><%= (_("For <strong>%s</strong> run the following:") % k.gsub('_', '&nbsp;').html_safe).html_safe %></h5>
                   <h6><%= (_("Keep in mind that the owner of the key may distribute updates, packages and repositories that your system will trust (<a href=\"%s\">more information</a>).") % secure_apt_url).html_safe %></h6>


### PR DESCRIPTION
OBS has supported both signed metadata and packages for Arch Linux for a
while now. This commit updates the setup instructions to enable
signature verfication.

The steps for Arch Linux are a bit more complicated than other distros.
The GPG public key must first be imported into the pacman GPG keyring
and then be locally signed to trust the key.

---

Fixes #931

- [X] I've included before / after screenshots or did not change the UI

Before: [image](https://user-images.githubusercontent.com/646253/103254337-e8fd6a80-4952-11eb-9d98-a797ce431b89.png)
After: [image](https://user-images.githubusercontent.com/646253/103254355-fa467700-4952-11eb-8917-e6310bf7d245.png)

I did not change any localized strings and tested the commands in a fresh `podman run --rm -it archlinux` container.

---

Assuming this update is reasonable, it might make sense to merge/deploy at the same time as https://github.com/openSUSE/open-build-service/pull/10570 because the OBS issue caused signatures to not be created for zstd-compressed packages.