### PR TITLE
Modify footer copyright year

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="footer-copyright-language-row">
       <div class="footer-copyright">
-        &copy; 2011&ndash;2020 <%= _("openSUSE contributors") %>
+        &copy; 2011&ndash;2021 <%= _("openSUSE contributors") %>
       </div>
       <div>
         <a class = "footer-Contribute-ReportBugs" href="https://github.com/openSUSE/software-o-o" target="_blank" >

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="footer-copyright-language-row">
       <div class="footer-copyright">
-        &copy; 2011&ndash;2021 <%= _("openSUSE contributors") %>
+        &copy; 2011&ndash;<%= Time.new.year %> <%= _("openSUSE contributors") %>
       </div>
       <div>
         <a class = "footer-Contribute-ReportBugs" href="https://github.com/openSUSE/software-o-o" target="_blank" >


### PR DESCRIPTION
Happy new year, everybody! Let's not wait almost a year before we reflect the current year in the footer, this time. ;)

Same as the last time (see #879), I've added a screen shot of the new footer without any further content installation or content. I trust that it's OK, just as it was last time.

![Screenshot_20210101_015228](https://user-images.githubusercontent.com/648663/103431687-7f8c8e80-4bd4-11eb-9b02-e165134f0874.png)

---


- [:heavy_check_mark:] I've included before / after screenshots or did not change the UI

Fixes #958 