### PR TITLE
Revert "Use http instead of https for download.o.o links"

### DIFF
--- a/app/views/distributions/_distribution.html.erb
+++ b/app/views/distributions/_distribution.html.erb
@@ -53,7 +53,7 @@
         <div class="row">
           <% arch["types"].try(:each) do |type| %>
           <div class="col text-center">
-            <a href="<%= "http://download.opensuse.org#{type["primary_link"]}" %>" class="btn btn-lg btn-block btn-<%= @colour %>">
+            <a href="<%= "https://download.opensuse.org#{type["primary_link"]}" %>" class="btn btn-lg btn-block btn-<%= @colour %>">
             <span class="typcn typcn-download-outline"></span>
             <%= type["name"] %>
             </a>
@@ -64,7 +64,7 @@
               <p class="text-muted"><%= _(type["desc"]) %></p>
 
               <% type["links"].try(:each) do |link| %>
-              <a href="<%= "http://download.opensuse.org#{link["url"]}" %>" class="btn btn-link"><%= _(link["name"]) %></a>
+              <a href="<%= "https://download.opensuse.org#{link["url"]}" %>" class="btn btn-link"><%= _(link["name"]) %></a>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
download links need to be https:// otherwise current Chrome releases
block .iso and other "insecure" files from downloading.

See https://blog.chromium.org/2020/02/protecting-users-from-insecure.html
for details.

This reverts commit 470f55fd55169acf86d61b4119a79e7ec13d72cc.




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
