### PR TITLE
Use geckodriver-bin rather than geckodriver-helper Issue#977

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,10 +54,7 @@ end
 group :test do
   gem 'capybara'
   gem 'faker'
-  # bragboy's fork works with Firefox 80
-  # ', git:...' can be removed once https://github.com/DevicoSolutions/geckodriver-helper/pull/17
-  # is merged and a new gem version is released
-  gem 'geckodriver-helper', git: 'https://github.com/bragboy/geckodriver-helper'
+  gem 'geckodriver-bin', '~> 0.28.0'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/bragboy/geckodriver-helper
-  revision: 929e5da958de9f82705e2dce71a7dbba873a461f
-  specs:
-    geckodriver-helper (0.27.0)
-      archive-zip (~> 0.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -88,6 +81,8 @@ GEM
       faraday (~> 1.0)
     fast_gettext (2.0.3)
     ffi (1.13.1)
+    geckodriver-bin (0.28.0)
+      archive-zip (~> 0.7)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     gettext (3.3.7)
@@ -265,7 +260,7 @@ DEPENDENCIES
   faraday
   faraday_middleware
   fast_gettext (>= 0.7.0)
-  geckodriver-helper!
+  geckodriver-bin (~> 0.28.0)
   gettext (>= 1.9.3)
   gettext_i18n_rails (>= 0.4.3)
   hashie


### PR DESCRIPTION
* geckodriver-bin is claimed to be maintained fork of geckodriver-helper in order not to need a local gem patch in .spec




---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
