### PR TITLE
Fix sles package search

### DIFF
--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -38,9 +38,15 @@ class PackageController < OBSController
       filter_packages
 
       @packages.each do |package|
-        # Backports chains up to the toolchain module for newer GCC.
-        # So break the link immediately.
-        package.baseproject = package.project if /^openSUSE:Backports:SLE-12/.match?(package.project)
+        # Backports chains up to the toolchain module for newer GCC,
+        # SLE 15 SPs and Leap 15.3 chains up to SUSE:SLE-15:GA
+        # => Baseproject is wrong and needs to be overriden
+        if @distributions.find { |dist| dist[:project] == package.project }
+          package.baseproject = package.project
+        else
+          repo = @distributions.find { |dist| dist[:reponame] == package.repository }
+          package.baseproject = repo[:project] if repo
+        end
       end
 
       @official_projects = @distributions.map { |d| d[:project] }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,6 +12,13 @@ class SearchController < OBSController
       @search_project = @baseproject
     end
 
+    if ['SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP1:GA', 'openSUSE:Leap:15.3'].include?(@baseproject)
+      # These projects chain up to SUSE-SLE-15:GA. If the baseproject is not
+      # overridden, no package can be found by OBS.
+      base = 'SUSE:SLE-15:GA'
+      @search_project = nil
+    end
+
     begin
       query_opts = { baseproject: base,
                      project: @search_project,


### PR DESCRIPTION
SLES 15 SPs and openSUSE Leap 15.3 don't have their own `baseproject`. As a workaround, the search is redirected and the response is compared against the distributions, without using the `baseproject`. Without this PR, the search does not work and the packages are grouped under `SUSE:SLE-15:GA`.

Before:
![Screenshot from 2021-05-19 22-06-52](https://user-images.githubusercontent.com/19352524/118877453-c282a080-b8ee-11eb-8a03-72508283d69d.png)

![Screenshot from 2021-05-19 22-07-15](https://user-images.githubusercontent.com/19352524/118877432-bbf42900-b8ee-11eb-9ef7-e26df42da6a4.png)

After:

![Screenshot from 2021-05-19 22-03-56](https://user-images.githubusercontent.com/19352524/118877505-d0d0bc80-b8ee-11eb-93c0-a73ef85f888d.png)
![Screenshot from 2021-05-19 22-04-15](https://user-images.githubusercontent.com/19352524/118877512-d29a8000-b8ee-11eb-9e54-651b3be8c1b9.png)

---

Fixes #741

- [x] I've included before / after screenshots or did not change the UI
