### PR TITLE
Fix binary coercion for single binaries

### DIFF
--- a/lib/obs.rb
+++ b/lib/obs.rb
@@ -28,9 +28,15 @@ module OBS
   # Binary.quality => [String]
   class Binary < Hashie::Mash
     include Hashie::Extensions::Mash::SymbolizeKeys
+
     def self.coerce(binary)
-      binary = Array(binary)
-      binary.map { |bin| Binary.new(bin) }
+      if binary.instance_of?(Hashie::Array)
+        binary.map do |bin|
+          Binary.new(bin)
+        end
+      else
+        [Binary.new(binary.to_h)]
+      end
     end
   end
 


### PR DESCRIPTION
When a `binary' is not a `Hashie::Array', it needs to turned into a
Hash. Otherwise Hashie::Mash's automatic conversion is confused.

Fixes https://github.com/openSUSE/software-o-o/issues/961
Fixes https://github.com/openSUSE/software-o-o/issues/988
Fixes https://github.com/openSUSE/software-o-o/issues/1010




---

- [x] I've included before / after screenshots or did not change the UI
