### PR TITLE
Fix ruby version matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7.x, 2.6.x, 2.5.x]
+        ruby-version: [2.7, 2.6, 2.5]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
.x is listed here[0] but does not actually work[1]

0: https://docs.github.com/en/actions/guides/building-and-testing-ruby#testing-with-multiple-versions-of-ruby
1: https://github.com/ruby/setup-ruby#supported-version-syntax




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
