### PR TITLE
Add bundler cache with cache version = 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          cache-version: 1
+
       - name: Install dependencies
         run: bundle install
       - name: Lint


### PR DESCRIPTION
Counting up those versions is a way to invalidate the cache. I hope it's
more stable now, the longest part of the action is setting up
dependencies. A cache would really help, but not if it corrupts rubocop
again.




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
