### PR TITLE
Revert "Add bundler cache with cache version = 1"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-          cache-version: 1
-
       - name: Install dependencies
         run: bundle install
       - name: Lint


### PR DESCRIPTION
Reverts openSUSE/software-o-o#1022. Sadly, the cache is still corrupting rubocop.