### PR TITLE
CI: re-enable branch restriction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Ruby CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
depfu pushes to branches that are used for PRs -> double text executions




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
