### PR TITLE
Downgrade nio4r to 2.5.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'faraday'
 gem 'faraday_middleware'
 gem 'multi_xml'
 
+# nio4r bug: https://github.com/socketry/nio4r/issues/275
+gem 'nio4r', '<= 2.5.4'
+
 # needed to collect translatable strings
 # not needed at production
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     minitest (5.14.4)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nio4r (2.5.7)
+    nio4r (2.5.4)
     nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -275,6 +275,7 @@ DEPENDENCIES
   mini_magick
   minitest
   multi_xml
+  nio4r (<= 2.5.4)
   nokogiri
   open_uri_redirections
   prometheus_exporter


### PR DESCRIPTION
As mentioned in https://github.com/socketry/nio4r/issues/275, the newer nio4r has bugged dependency (libev). It is easier to simply downgrade this and wait for the fix.

Even Tumbleweed repo is holding nio4r at 2.5.4-1.7.