### PR TITLE
Fix instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ keys for `secrets.yml`).
 git clone https://github.com/openSUSE/software-o-o.git
 cd software-o-o
 
+bundle config set --local path 'vendor/bundle'
 bundle package
 bundle exec rails s
 ```


### PR DESCRIPTION
The bundler is named `ruby2.7-rubygem-bundler` in Tumbleweed.

`bundle config set --local path 'vendor/bundle'` is required to download gems locally instead of messing up the system library.