### PR TITLE
zypper addrepo: switch to the supported syntax

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -70,9 +70,9 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
                      case v[:flavor]
                      when 'openSUSE', 'SLE'
                        if @package.nil?
-                         "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install -t pattern #{@pattern}"
+                         "zypper addrepo #{v[:repo]} #{@project}\nzypper refresh\nzypper install -t pattern #{@pattern}"
                        else
-                         "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install #{@package}"
+                         "zypper addrepo #{v[:repo]} {@project}\nzypper refresh\nzypper install #{@package}"
                        end
                      when 'Fedora'
                        version = k.split("_").last


### PR DESCRIPTION
The `.repo` files are gone.  The only supported syntax is [`addrepo $URI $ALIAS`](https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-sw-cl.html#sec-zypper).  We shall use the project name to ALIAS for lack of a better choice; since this is just an instruction, the administrator running this command can use their own ALIAS.




---

Fixes [bsc#1185917](https://bugzilla.suse.com/show_bug.cgi?id=1185917)

- [ ] I've included before / after screenshots or did not change the UI
