### PR TITLE
Fix failing package controller test

### DIFF
--- a/app/controllers/package_controller.rb
+++ b/app/controllers/package_controller.rb
@@ -2,7 +2,7 @@
 
 class PackageController < OBSController
   before_action :set_search_options, only: %i[show categories]
-  before_action :prepare_appdata, :set_categories, only: %i[show explore category thumbnail screenshot]
+  before_action :prepare_appdata, :set_categories
 
   skip_before_action :set_language, only: %i[thumbnail screenshot]
 

--- a/test/integration/package_controller_test.rb
+++ b/test/integration/package_controller_test.rb
@@ -13,7 +13,7 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
   def test_thumbnail_unknown_package_returns_default_asset
     FileUtils.rm_f UNKNOWN_PACKAGE_THUMBNAIL
     VCR.use_cassette('default') do
-      get '/package/thumbnail/SupperFancyBrowser.png'
+      get '/package/thumbnail/SupperFancyBrowser.png?baseproject=ALL'
       assert_response :redirect
       assert_match %r{/assets/default-screenshots/package(.*).png}, @response.redirect_url
     end
@@ -24,7 +24,7 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
     FileUtils.cp PKG_4PANE_THUMBNAIL_RESIZED, PKG_4PANE_THUMBNAIL
 
     VCR.use_cassette('default') do
-      get '/package/thumbnail/4pane.png'
+      get '/package/thumbnail/4pane.png?baseproject=ALL'
       assert_redirected_to '/images/thumbnails/4pane.png'
     end
   ensure
@@ -34,7 +34,7 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
   def test_thumbnail_not_downloaded_downloads_it
     FileUtils.rm_f PKG_4PANE_THUMBNAIL
     VCR.use_cassette('default') do
-      get '/package/thumbnail/4pane.png'
+      get '/package/thumbnail/4pane.png?baseproject=ALL'
       assert_redirected_to '/images/thumbnails/4pane.png'
       assert File.exist?(PKG_4PANE_THUMBNAIL)
     end
@@ -47,7 +47,7 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
       stub_request(:any, 'http://www.4Pane.co.uk/4Pane624x351.png')
         .to_return(body: '', status: 404)
       FileUtils.rm_f PKG_4PANE_THUMBNAIL
-      get '/package/thumbnail/4pane.png'
+      get '/package/thumbnail/4pane.png?baseproject=ALL'
       assert_response :redirect
       assert_match %r{/assets/default-screenshots/package(.*).png}, @response.redirect_url
       assert !File.exist?(PKG_4PANE_THUMBNAIL)
@@ -56,14 +56,14 @@ class PackageControllerTest < ActionDispatch::IntegrationTest
 
   def test_known_screenshot_redirects_to_original
     VCR.use_cassette('default') do
-      get '/package/screenshot/4pane.png'
+      get '/package/screenshot/4pane.png?baseproject=ALL'
       assert_redirected_to 'http://www.4Pane.co.uk/4Pane624x351.png'
     end
   end
 
   def test_unknown_screenshot_is404
     VCR.use_cassette('default') do
-      get '/package/screenshot/paralapapiricoipi.png'
+      get '/package/screenshot/paralapapiricoipi.png?baseproject=ALL'
       assert_equal 404, status
     end
   end

--- a/test/system/package_information_test.rb
+++ b/test/system/package_information_test.rb
@@ -6,7 +6,7 @@ class PackageInformationTest < ActionDispatch::SystemTestCase
   def test_package_information
     VCR.use_cassette('default') do
       # Check that package information is displayed
-      visit '/package/pidgin'
+      visit '/package/pidgin?baseproject=ALL'
       page.assert_text 'Multiprotocol Instant Messaging Client'
       page.assert_text 'Pidgin is a messaging application which lets you log in to accounts'
     end


### PR DESCRIPTION
This test uses appdata from the default baseproject (latest Leap). Leap 15.3's appdata does not include information on 4pane. As a workaround, the test specifies "ALL" as the baseproject, which looks for appdata from all releases, including Tumbleweed.




---

Fixes https://github.com/openSUSE/software-o-o/issues/829

- [x] I've included before / after screenshots or did not change the UI
