### PR TITLE
do not addrepo system repos

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -68,7 +68,15 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
                   <pre><%=
                      case v[:flavor]
                      when 'openSUSE', 'SLE'
-                         "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install #{@package}"
+                       if @project != "openSUSE:Factory" && @project != "openSUSE:Tumbleweed" && !@project.start_with?("openSUSE:Leap:") && !@project.start_with?("openSUSE:Backports:") && !@project.start_with?("SUSE:SLE-15-")
+
+                         "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\n"
+                       end
+                       if @package.nil?
+                         "zypper install -t pattern #{@pattern}\n"
+                       else
+                         "zypper install #{@package}\n"
+                       end
                      when 'Fedora'
                        version = k.split("_").last
                        if version == "Rawhide" or Integer(version) >= 41


### PR DESCRIPTION
Manual download: do not tell the operator to addrepo system repos (Factory, Tumbleweed or Leap)!

---

Fixes [bsc#1185917](https://bugzilla.suse.com/show_bug.cgi?id=1185917).

- [ ] I've included before / after screenshots or did not change the UI
