### PR TITLE
Get the project name from the distribution list

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DownloadController < ApplicationController
+class DownloadController < OBSController
   before_action :set_colors, :hide_search_box
 
   # display documentation
@@ -58,7 +58,7 @@ class DownloadController < ApplicationController
               repo: "https://download.opensuse.org/repositories/#{@project}/#{distro}/",
               package: {}
             }
-            data[distro][:flavor] = set_distro_flavor e.attributes['baseproject']
+            data[distro][:flavor] = set_distro_flavor get_project(distro, e.attributes['baseproject'])
             case e.attributes['baseproject']
             when /^(DISCONTINUED:)?openSUSE:/, /^(DISCONTINUED:)?SUSE:SLE-/
               data[distro][:ymp] = "https://software.opensuse.org/ymp/#{@project}/#{distro}/#{@package}.ymp"
@@ -102,7 +102,7 @@ class DownloadController < ApplicationController
             repo: "https://download.opensuse.org/repositories/#{@project}/#{distro}/",
             package: {}
           }
-          data[distro][:flavor] = set_distro_flavor e.attributes['baseproject']
+          data[distro][:flavor] = set_distro_flavor get_project(distro, e.attributes['baseproject'])
           case e.attributes['baseproject']
           when /^(DISCONTINUED:)?openSUSE:/, /^(DISCONTINUED:)?SUSE:SLE-/
             data[distro][:ymp] = "https://download.opensuse.org/repositories/#{e.attributes['filepath']}"
@@ -145,6 +145,17 @@ class DownloadController < ApplicationController
       # needed for rails < 3.0 to support JSONP
       format.json { render_json @data.to_json }
     end
+  end
+
+  def get_project(distro, baseproject)
+    project = baseproject
+    unless @distributions.nil?
+      distribution = @distributions.find { |d| d[:reponame] == distro }
+      unless distribution.nil?
+        project = distribution[:project]
+      end
+    end
+    project
   end
 
   def set_distro_flavor(distro)


### PR DESCRIPTION
Currently, Fedora 34 and Rawhide downloads are listed as `Unknown` as the baseproject is `OBS:DefaultKernel`. This patch lets `app/controllers/download_controller.rb` take the real project name from the distribution list. The common key is the `repository`, which can be used to map downloads to distribution projects.

Download object with `repository` set to "Fedora_34":

    <binary baseproject='OBS:DefaultKernel' filename='example.rpm' repository='Fedora_34' [...]>

Distribution object with matching `reponame` and project name:

    {:name=>"Fedora 34", :project=>"Fedora:34", :reponame=>"Fedora_34", :repository=>"standard", :dist_id=>"19131"}

---

Fixes #1035

- [x] I did not change the UI
