### PR TITLE
Fix json output in download section

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,23 +90,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # special version of render json with JSONP capabilities (only needed for rails < 3.0)
-  def render_json(json, options = {})
-    callback = params[:callback]
-    variable = params[:variable]
-    response = if callback && variable
-                 "var #{variable} = #{json};\n#{callback}(#{variable});"
-               elsif variable
-                 "var #{variable} = #{json};"
-               elsif callback
-                 "#{callback}(#{json});"
-               else
-                 json
-               end
-
-    render({ content_type: 'application/javascript', body: response }.merge(options))
-  end
-
   def valid_package_name?(name)
     name =~ /^[[:alnum:]][-+~\w.:@]*$/
   end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -143,7 +143,7 @@ class DownloadController < ObsController
         render page_template, layout: 'iframe.html'
       end
       # needed for rails < 3.0 to support JSONP
-      format.json { render_json @data.to_json }
+      format.json { render json: @data.to_json }
     end
   end
 

--- a/test/integration/download_controller_test.rb
+++ b/test/integration/download_controller_test.rb
@@ -9,10 +9,13 @@ class DownloadControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       # Check if the schema is right
       json_item = JSON.parse(response.body).values.first
-      assert_match %r{https://download.opensuse.org/repositories/openSUSE:Tools/(.*)/}, json_item['repo']
+      repo_link = 'https://download.opensuse.org/repositories'
+      assert_match %r{#{repo_link}/openSUSE:Tools/(.*)/}, json_item['repo']
       # The key is filename, the value is link to that file on the server
-      assert_match /osc(.*)/, json_item['package'].keys.first
-      assert_match %r{https://download.opensuse.org/repositories/openSUSE:/Tools/(.*)/#{json_item['package'].keys.first}}, json_item['package'].values.first
+      package_name = json_item['package'].keys.first
+      package_link = json_item['package'].values.first
+      assert_match(/osc(.*)/, package_name)
+      assert_match %r{#{repo_link}/openSUSE:/Tools/(.*)/#{package_name}}, package_link
     end
   end
 end

--- a/test/integration/download_controller_test.rb
+++ b/test/integration/download_controller_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require File.expand_path('../test_helper', __dir__)
+
+class DownloadControllerTest < ActionDispatch::IntegrationTest
+  test 'download package returns a valid json document' do
+    VCR.use_cassette('download package returns a valid json document') do
+      get '/download/package.json?project=openSUSE%3ATools&package=osc'
+      assert_response :success
+      # Check if the schema is right
+      json_item = JSON.parse(response.body).values.first
+      assert_match %r{https://download.opensuse.org/repositories/openSUSE:Tools/(.*)/}, json_item['repo']
+      # The key is filename, the value is link to that file on the server
+      assert_match /osc(.*)/, json_item['package'].keys.first
+      assert_match %r{https://download.opensuse.org/repositories/openSUSE:/Tools/(.*)/#{json_item['package'].keys.first}}, json_item['package'].values.first
+    end
+  end
+end

--- a/test/support/vcr-cassettes/download_package_returns_a_valid_json_document.yml
+++ b/test/support/vcr-cassettes/download_package_returns_a_valid_json_document.yml
@@ -1,0 +1,1250 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opensuse.org/public/distributions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      X-Username:
+      - "<API USERNAME>"
+      X-Opensuse-Data:
+      - TEST
+      Authorization:
+      - Basic <API HTTP AUTH>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Mar 2022 21:27:13 GMT
+      Server:
+      - Apache/2.4.51 (Linux/SUSE)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept,Accept-Encoding
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Opensuse-Runtimes:
+      - '{"view":173.799886040797,"db":64.29544396087294,"backend":0}'
+      X-Request-Id:
+      - 9df15e93-b566-4c5c-939d-0f2d35ae3bcb
+      X-Opensuse-Apiversion:
+      - 2.11~alpha.20220325T134845.229514a0dc
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.249172'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.12
+      Etag:
+      - W/"29ac160026c03327e5336d50ce8b0806"
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <distributions>
+          <distribution vendor="openEuler" version="20.03" id="20031">
+            <name>openEuler 20.03</name>
+            <project>openEuler:20.03</project>
+            <reponame>openEuler_20.03</reponame>
+            <repository>standard</repository>
+            <link>http://www.openeuler.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openEuler" version="21.03" id="20034">
+            <name>openEuler 21.03</name>
+            <project>openEuler:21.03</project>
+            <reponame>openEuler_21.03</reponame>
+            <repository>standard</repository>
+            <link>http://www.openeuler.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="Tumbleweed" id="20037">
+            <name>openSUSE Tumbleweed</name>
+            <project>openSUSE:Factory</project>
+            <reponame>openSUSE_Tumbleweed</reponame>
+            <repository>snapshot</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.4" id="20040">
+            <name>openSUSE Leap 15.4</name>
+            <project>openSUSE:Leap:15.4</project>
+            <reponame>15.4</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.3" id="20043">
+            <name>openSUSE Leap 15.3</name>
+            <project>openSUSE:Leap:15.3</project>
+            <reponame>15.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2" id="20046">
+            <name>openSUSE Leap 15.2</name>
+            <project>openSUSE:Leap:15.2</project>
+            <reponame>openSUSE_Leap_15.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2 ARM" id="20049">
+            <name>openSUSE Leap 15.2 ARM</name>
+            <project>openSUSE:Leap:15.2:ARM</project>
+            <reponame>openSUSE_Leap_15.2_ARM</reponame>
+            <repository>ports</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2 PowerPC" id="20052">
+            <name>openSUSE Leap 15.2 PowerPC</name>
+            <project>openSUSE:Leap:15.2:PowerPC</project>
+            <reponame>openSUSE_Leap_15.2_PowerPC</reponame>
+            <repository>ports</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryRISCV" id="20055">
+            <name>openSUSE Factory RISCV</name>
+            <project>openSUSE:Factory:RISCV</project>
+            <reponame>openSUSE_Factory_RISCV</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>riscv64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryARM" id="20058">
+            <name>openSUSE Factory ARM</name>
+            <project>openSUSE:Factory:ARM</project>
+            <reponame>openSUSE_Factory_ARM</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryPPC" id="20061">
+            <name>openSUSE Factory PowerPC</name>
+            <project>openSUSE:Factory:PowerPC</project>
+            <reponame>openSUSE_Factory_PowerPC</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>ppc64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryzSystems" id="20064">
+            <name>openSUSE Factory zSystems</name>
+            <project>openSUSE:Factory:zSystems</project>
+            <reponame>openSUSE_Factory_zSystems</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>s390x</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP4_Backports" id="20067">
+            <name>openSUSE Backports for SLE 15 SP4</name>
+            <project>openSUSE:Backports:SLE-15-SP4</project>
+            <reponame>15.4</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP3_Backports" id="20070">
+            <name>openSUSE Backports for SLE 15 SP3</name>
+            <project>openSUSE:Backports:SLE-15-SP3</project>
+            <reponame>15.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP2_Backports" id="20073">
+            <name>openSUSE Backports for SLE 15 SP2</name>
+            <project>openSUSE:Backports:SLE-15-SP2</project>
+            <reponame>SLE_15_SP2_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP1_Backports" id="20076">
+            <name>openSUSE Backports for SLE 15 SP1</name>
+            <project>openSUSE:Backports:SLE-15-SP1</project>
+            <reponame>SLE_15_SP1_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP5" id="20079">
+            <name>openSUSE Backports for SLE 12 SP5</name>
+            <project>openSUSE:Backports:SLE-12-SP5</project>
+            <reponame>SLE_12_SP5_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP4" id="20082">
+            <name>openSUSE Backports for SLE 12 SP4</name>
+            <project>openSUSE:Backports:SLE-12-SP4</project>
+            <reponame>SLE_12_SP4_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP3" id="20085">
+            <name>openSUSE Backports for SLE 12 SP3</name>
+            <project>openSUSE:Backports:SLE-12-SP3</project>
+            <reponame>SLE_12_SP3_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP2" id="20088">
+            <name>openSUSE Backports for SLE 12 SP2</name>
+            <project>openSUSE:Backports:SLE-12-SP2</project>
+            <reponame>SLE_12_SP2_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP1" id="20091">
+            <name>openSUSE Backports for SLE 12 SP1</name>
+            <project>openSUSE:Backports:SLE-12-SP1</project>
+            <reponame>SLE_12_SP1_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12" id="20094">
+            <name>openSUSE Backports for SLE 12 SP0</name>
+            <project>openSUSE:Backports:SLE-12</project>
+            <reponame>SLE_12_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP4" id="20097">
+            <name>SUSE SLE-15-SP4</name>
+            <project>SUSE:SLE-15-SP4:GA</project>
+            <reponame>15.4</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP3" id="20100">
+            <name>SUSE SLE-15-SP3</name>
+            <project>SUSE:SLE-15-SP3:GA</project>
+            <reponame>15.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP2" id="20103">
+            <name>SUSE SLE-15-SP2</name>
+            <project>SUSE:SLE-15-SP2:GA</project>
+            <reponame>SLE_15_SP2</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP1" id="20106">
+            <name>SUSE SLE-15-SP1</name>
+            <project>SUSE:SLE-15-SP1:GA</project>
+            <reponame>SLE_15_SP1</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-12-SP5" id="20109">
+            <name>SUSE SLE-12-SP5</name>
+            <project>SUSE:SLE-12-SP5:GA</project>
+            <reponame>SLE_12_SP5</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-11-SP4" id="20112">
+            <name>SUSE SLE-11 SP 4</name>
+            <project>SUSE:SLE-11:SP4</project>
+            <reponame>SLE_11_SP4</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Arch" version="1.0" id="20115">
+            <name>Arch Extra</name>
+            <project>Arch:Extra</project>
+            <reponame>Arch</reponame>
+            <repository>standard</repository>
+            <link>http://www.archlinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Arch" version="1.0" id="20118">
+            <name>Arch Community</name>
+            <project>Arch:Community</project>
+            <reponame>Arch</reponame>
+            <repository>standard</repository>
+            <link>http://www.archlinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Raspbian" version="11" id="20121">
+            <name>Raspbian 11</name>
+            <project>Raspbian:11</project>
+            <reponame>Raspbian_11</reponame>
+            <repository>standard</repository>
+            <link>http://www.raspbian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="16" height="16"/>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="Raspbian" version="10" id="20124">
+            <name>Raspbian 10</name>
+            <project>Raspbian:10</project>
+            <reponame>Raspbian_10</reponame>
+            <repository>standard</repository>
+            <link>http://www.raspbian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="16" height="16"/>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="Unstable" id="20127">
+            <name>Debian Unstable</name>
+            <project>Debian:Next</project>
+            <reponame>Debian_Unstable</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="Testing" id="20130">
+            <name>Debian Testing</name>
+            <project>Debian:Testing</project>
+            <reponame>Debian_Testing</reponame>
+            <repository>update</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="11" id="20133">
+            <name>Debian 11</name>
+            <project>Debian:11</project>
+            <reponame>Debian_11</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="10" id="20136">
+            <name>Debian 10</name>
+            <project>Debian:10</project>
+            <reponame>Debian_10</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="9.0" id="20139">
+            <name>Debian 9.0</name>
+            <project>Debian:9.0</project>
+            <reponame>Debian_9.0</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="Rawhide" id="20142">
+            <name>Fedora Rawhide (unstable)</name>
+            <project>Fedora:Rawhide</project>
+            <reponame>Fedora_Rawhide</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="35" id="20145">
+            <name>Fedora 35</name>
+            <project>Fedora:35</project>
+            <reponame>Fedora_35</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>ppc64le</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="34" id="20148">
+            <name>Fedora 34</name>
+            <project>Fedora:34</project>
+            <reponame>Fedora_34</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>ppc64le</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="33" id="20151">
+            <name>Fedora 33</name>
+            <project>Fedora:33</project>
+            <reponame>Fedora_33</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>ppc64le</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="32" id="20154">
+            <name>Fedora 32</name>
+            <project>Fedora:32</project>
+            <reponame>Fedora_32</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>ppc64le</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="31" id="20157">
+            <name>Fedora 31</name>
+            <project>Fedora:31</project>
+            <reponame>Fedora_31</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>ppc64le</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="ScientificLinux" version="SL-7" id="20160">
+            <name>ScientificLinux 7</name>
+            <project>ScientificLinux:7</project>
+            <reponame>ScientificLinux_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.ScientificLinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="ScientificLinux" version="SL-6" id="20163">
+            <name>ScientificLinux 6</name>
+            <project>ScientificLinux:6</project>
+            <reponame>ScientificLinux_6</reponame>
+            <repository>standard</repository>
+            <link>http://www.ScientificLinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-7" id="20166">
+            <name>RedHat RHEL-7</name>
+            <project>RedHat:RHEL-7</project>
+            <reponame>RHEL_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>ppc64</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-6" id="20169">
+            <name>RedHat RHEL-6</name>
+            <project>RedHat:RHEL-6</project>
+            <reponame>RHEL_6</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-5" id="20172">
+            <name>RedHat RHEL-5</name>
+            <project>RedHat:RHEL-5</project>
+            <reponame>RHEL_5</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-8-Stream" id="20175">
+            <name>CentOS CentOS-8-Stream</name>
+            <project>CentOS:CentOS-8:Stream</project>
+            <reponame>CentOS_8_Stream</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-8" id="20178">
+            <name>CentOS CentOS-8</name>
+            <project>CentOS:CentOS-8</project>
+            <reponame>CentOS_8</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-7" id="20181">
+            <name>CentOS CentOS-7</name>
+            <project>CentOS:CentOS-7</project>
+            <reponame>CentOS_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="21.10" id="20184">
+            <name>Ubuntu 21.10</name>
+            <project>Ubuntu:21.10</project>
+            <reponame>xUbuntu_21.10</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="21.04" id="20187">
+            <name>Ubuntu 21.04</name>
+            <project>Ubuntu:21.04</project>
+            <reponame>xUbuntu_21.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="20.10" id="20190">
+            <name>Ubuntu 20.10</name>
+            <project>Ubuntu:20.10</project>
+            <reponame>xUbuntu_20.10</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="20.04" id="20193">
+            <name>Ubuntu 20.04</name>
+            <project>Ubuntu:20.04</project>
+            <reponame>xUbuntu_20.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="18.04" id="20196">
+            <name>Ubuntu 18.04</name>
+            <project>Ubuntu:18.04</project>
+            <reponame>xUbuntu_18.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="16.04" id="20199">
+            <name>Ubuntu 16.04</name>
+            <project>Ubuntu:16.04</project>
+            <reponame>xUbuntu_16.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="14.04" id="20202">
+            <name>Ubuntu 14.04</name>
+            <project>Ubuntu:14.04</project>
+            <reponame>xUbuntu_14.04</reponame>
+            <repository>standard</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.4" id="20205">
+            <name>Univention UCS 4.4</name>
+            <project>Univention:4.4</project>
+            <reponame>Univention_4.4</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.3" id="20208">
+            <name>Univention UCS 4.3</name>
+            <project>Univention:4.3</project>
+            <reponame>Univention_4.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.2" id="20211">
+            <name>Univention UCS 4.2</name>
+            <project>Univention:4.2</project>
+            <reponame>Univention_4.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.1" id="20214">
+            <name>Univention UCS 4.1</name>
+            <project>Univention:4.1</project>
+            <reponame>Univention_4.1</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.0" id="20217">
+            <name>Univention UCS 4.0</name>
+            <project>Univention:4.0</project>
+            <reponame>Univention_4.0</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Mageia" version="Cauldron" id="20220">
+            <name>Mageia Cauldron (unstable)</name>
+            <project>Mageia:Cauldron</project>
+            <reponame>Mageia_Cauldron</reponame>
+            <repository>standard</repository>
+            <link>http://www.mageia.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Mageia" version="8" id="20223">
+            <name>Mageia 8</name>
+            <project>Mageia:8</project>
+            <reponame>Mageia_8</reponame>
+            <repository>standard</repository>
+            <link>http://www.mageia.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="3.2" id="20226">
+            <name>Univention UCS 3.2</name>
+            <project>Univention:3.2</project>
+            <reponame>Univention_3.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="IBM" version="3.1" id="20229">
+            <name>IBM PowerKVM 3.1</name>
+            <project>IBM:PowerKVM:3.1</project>
+            <reponame>PowerKVM_3.1</reponame>
+            <repository>standard</repository>
+            <link>http://www-03.ibm.com/systems/power/software/linux/powerkvm/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/powerkvm.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/powerkvm.png" width="16" height="16"/>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="Many" version="42.3" id="20232">
+            <name>AppImage</name>
+            <project>OBS:AppImage</project>
+            <reponame>AppImage</reponame>
+            <repository>AppImage</repository>
+            <link>http://www.appimage.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+        </distributions>
+  recorded_at: Fri, 25 Mar 2022 21:27:13 GMT
+- request:
+    method: get
+    uri: https://get.opensuse.org/api/v0/distributions.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Mar 2022 21:27:13 GMT
+      Content-Type:
+      - application/json
+      Last-Modified:
+      - Fri, 25 Mar 2022 21:05:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - W/"623e2e7c-c96"
+      Expires:
+      - Fri, 22 Apr 2022 21:27:13 GMT
+      Cache-Control:
+      - max-age=2419200
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "Leap": [
+            {
+              "name": "openSUSE Leap",
+              "version": "15.4",
+              "state": "Beta",
+              "upgrade-weight": 7
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "15.3",
+              "state": "Stable",
+              "upgrade-weight": 6
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "15.2",
+              "state": "EOL",
+              "upgrade-weight": 5
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "15.1",
+              "state": "EOL",
+              "upgrade-weight": 4
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "15.0",
+              "state": "EOL",
+              "upgrade-weight": 3
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "42.3",
+              "state": "EOL",
+              "upgrade-weight": 2
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "42.2",
+              "state": "EOL",
+              "upgrade-weight": 1
+            },
+            {
+              "name": "openSUSE Leap",
+              "version": "42.1",
+              "state": "EOL",
+              "upgrade-weight": 0
+            }
+          ],
+          "Tumbleweed": [
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220323",
+              "upgrade-weight": 20220323
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220322",
+              "upgrade-weight": 20220322
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220321",
+              "upgrade-weight": 20220321
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220320",
+              "upgrade-weight": 20220320
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220319",
+              "upgrade-weight": 20220319
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220318",
+              "upgrade-weight": 20220318
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220317",
+              "upgrade-weight": 20220317
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220316",
+              "upgrade-weight": 20220316
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220314",
+              "upgrade-weight": 20220314
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220313",
+              "upgrade-weight": 20220313
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220312",
+              "upgrade-weight": 20220312
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220311",
+              "upgrade-weight": 20220311
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220310",
+              "upgrade-weight": 20220310
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220309",
+              "upgrade-weight": 20220309
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220308",
+              "upgrade-weight": 20220308
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220307",
+              "upgrade-weight": 20220307
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220306",
+              "upgrade-weight": 20220306
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220305",
+              "upgrade-weight": 20220305
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220304",
+              "upgrade-weight": 20220304
+            },
+            {
+              "name": "openSUSE Tumbleweed",
+              "version": "20220303",
+              "upgrade-weight": 20220303
+            }
+          ]
+        }
+
+  recorded_at: Fri, 25 Mar 2022 21:27:13 GMT
+- request:
+    method: get
+    uri: https://api.opensuse.org//search/published/binary/id?match=project=%27openSUSE:Tools%27%20and%20name=%27osc%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      X-Username:
+      - "<API USERNAME>"
+      X-Opensuse-Data:
+      - TEST
+      Authorization:
+      - Basic <API HTTP AUTH>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Mar 2022 21:27:14 GMT
+      Server:
+      - Apache/2.4.51 (Linux/SUSE)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - no-cache
+      - private, no-transform
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Opensuse-Runtimes:
+      - '{"view":null,"db":3.327533006086014,"backend":0}'
+      X-Request-Id:
+      - e043c2e6-534d-48f3-bc8a-c05b99df98ff
+      X-Opensuse-Apiversion:
+      - 2.11~alpha.20220325T134845.229514a0dc
+      X-Download-Options:
+      - noopen
+      X-Runtime:
+      - '0.011808'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.12
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '55246'
+      Set-Cookie:
+      - openSUSE_session=14ab39a11534269345bdb0afca22b63c; path=/; Max-Age=86400;
+        Secure; HttpOnly; domain=.opensuse.org
+    body:
+      encoding: UTF-8
+      string: |
+        <collection matches="197">
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Debian_10/all/osc_0.176.0-0_all.deb" baseproject="Debian:10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_11" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Debian_11/all/osc_0.176.0-0_all.deb" baseproject="Debian:11" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_9.0" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Debian_9.0/all/osc_0.176.0-0_all.deb" baseproject="Debian:9.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_Testing" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Debian_Testing/all/osc_0.176.0-0_all.deb" baseproject="Debian:Testing" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_Unstable" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Debian_Unstable/all/osc_0.176.0-0_all.deb" baseproject="Debian:Next" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Raspbian_10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Raspbian_10/all/osc_0.176.0-0_all.deb" baseproject="Debian:10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Raspbian_11" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Raspbian_11/all/osc_0.176.0-0_all.deb" baseproject="Debian:11" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Raspbian_9" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Raspbian_9/all/osc_0.176.0-0_all.deb" baseproject="Debian:9.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_4.3" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Univention_4.3/all/osc_0.176.0-0_all.deb" baseproject="Univention:4.3" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_4.4" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/Univention_4.4/all/osc_0.176.0-0_all.deb" baseproject="Univention:4.3" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_17.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_17.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:17.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_18.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_18.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:18.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_18.10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_18.10/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:18.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_19.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_19.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:19.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_19.10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_19.10/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:19.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_20.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_20.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:20.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_20.10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_20.10/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:20.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_21.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_21.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:21.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_21.10" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_21.10/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:21.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_22.04" version="0.176.0" release="0" arch="all" filename="osc_0.176.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_22.04/all/osc_0.176.0-0_all.deb" baseproject="Ubuntu:22.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="15.3" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/15.3/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="15.4" version="0.176.0" release="150400.324.2" arch="noarch" filename="osc-0.176.0-150400.324.2.noarch.rpm" filepath="openSUSE:/Tools/15.4/noarch/osc-0.176.0-150400.324.2.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_7" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/CentOS_7/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="CentOS:CentOS-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_8" version="0.176.0" release="324.4" arch="noarch" filename="osc-0.176.0-324.4.noarch.rpm" filepath="openSUSE:/Tools/CentOS_8/noarch/osc-0.176.0-324.4.noarch.rpm" baseproject="CentOS:CentOS-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_8_Stream" version="0.176.0" release="324.4" arch="noarch" filename="osc-0.176.0-324.4.noarch.rpm" filepath="openSUSE:/Tools/CentOS_8_Stream/noarch/osc-0.176.0-324.4.noarch.rpm" baseproject="CentOS:CentOS-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_22" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_22/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Fedora:22" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_30" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_30/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Fedora:30" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_32" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_32/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Fedora:32" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_33" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_33/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Fedora:33" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_34" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_34/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_35" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_35/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_Rawhide" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_Rawhide/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_5" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Mageia_5/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Mageia:5" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_6" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Mageia_6/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Mageia:6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_7" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Mageia_7/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Mageia:7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_8" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/Mageia_8/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="Mageia:8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_Cauldron" version="0.176.0" release="324.40" arch="noarch" filename="osc-0.176.0-324.40.noarch.rpm" filepath="openSUSE:/Tools/Mageia_Cauldron/noarch/osc-0.176.0-324.40.noarch.rpm" baseproject="Mageia:Cauldron" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_8" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/RHEL_8/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="RedHat:RHEL-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP1" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_12_SP1/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP3" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_12_SP3/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP4" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_12_SP4/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP5" version="0.176.0" release="324.6" arch="noarch" filename="osc-0.176.0-324.6.noarch.rpm" filepath="openSUSE:/Tools/SLE_12_SP5/noarch/osc-0.176.0-324.6.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_15/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP1" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_15_SP1/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP2" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_15_SP2/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP3" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/SLE_15_SP3/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="ScientificLinux_7" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/ScientificLinux_7/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="RedHat:RHEL-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_11.4" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_11.4/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:11.4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.1" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_12.1/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:12.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.2" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_12.2/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:12.2:ARM" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.2_ARM" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_12.2_ARM/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:12.2:ARM" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.3" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_12.3/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:12.3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_13.1" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_13.1/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:13.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_13.2" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_13.2/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:13.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.0" version="0.176.0" release="lp150.324.1" arch="noarch" filename="osc-0.176.0-lp150.324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_15.0/noarch/osc-0.176.0-lp150.324.1.noarch.rpm" baseproject="openSUSE:Leap:15.0" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.1" version="0.176.0" release="lp151.324.1" arch="noarch" filename="osc-0.176.0-lp151.324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_15.1/noarch/osc-0.176.0-lp151.324.1.noarch.rpm" baseproject="openSUSE:Leap:15.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.1_ports" version="0.176.0" release="lp151.324.1" arch="noarch" filename="osc-0.176.0-lp151.324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_15.1_ports/noarch/osc-0.176.0-lp151.324.1.noarch.rpm" baseproject="openSUSE:Leap:15.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.2" version="0.176.0" release="lp152.324.1" arch="noarch" filename="osc-0.176.0-lp152.324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_15.2/noarch/osc-0.176.0-lp152.324.1.noarch.rpm" baseproject="openSUSE:Leap:15.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.3" version="0.176.0" release="lp153.324.1" arch="noarch" filename="osc-0.176.0-lp153.324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_15.3/noarch/osc-0.176.0-lp153.324.1.noarch.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.1" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_42.1/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:Leap:42.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.2" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_42.2/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:Leap:42.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.3" version="0.176.0" release="324.1" arch="noarch" filename="osc-0.176.0-324.1.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_42.3/noarch/osc-0.176.0-324.1.noarch.rpm" baseproject="openSUSE:Leap:42.3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_Factory/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_ARM" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_ARM/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_PPC" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_PPC/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_zSystems" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_zSystems/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Tumbleweed" version="0.176.0" release="324.2" arch="noarch" filename="osc-0.176.0-324.2.noarch.rpm" filepath="openSUSE:/Tools/openSUSE_Tumbleweed/noarch/osc-0.176.0-324.2.noarch.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="15.3" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/15.3/src/osc-0.176.0-324.2.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="15.4" version="0.176.0" release="150400.324.2" arch="src" filename="osc-0.176.0-150400.324.2.src.rpm" filepath="openSUSE:/Tools/15.4/src/osc-0.176.0-150400.324.2.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_7" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/CentOS_7/src/osc-0.176.0-324.1.src.rpm" baseproject="CentOS:CentOS-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_8" version="0.176.0" release="324.4" arch="src" filename="osc-0.176.0-324.4.src.rpm" filepath="openSUSE:/Tools/CentOS_8/src/osc-0.176.0-324.4.src.rpm" baseproject="CentOS:CentOS-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_8_Stream" version="0.176.0" release="324.4" arch="src" filename="osc-0.176.0-324.4.src.rpm" filepath="openSUSE:/Tools/CentOS_8_Stream/src/osc-0.176.0-324.4.src.rpm" baseproject="CentOS:CentOS-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_22" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_22/src/osc-0.176.0-324.1.src.rpm" baseproject="Fedora:22" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_30" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_30/src/osc-0.176.0-324.1.src.rpm" baseproject="Fedora:30" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_32" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_32/src/osc-0.176.0-324.1.src.rpm" baseproject="Fedora:32" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_33" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_33/src/osc-0.176.0-324.1.src.rpm" baseproject="Fedora:33" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_34" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_34/src/osc-0.176.0-324.1.src.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_35" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_35/src/osc-0.176.0-324.1.src.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_Rawhide" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Fedora_Rawhide/src/osc-0.176.0-324.1.src.rpm" baseproject="OBS:DefaultKernel" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_5" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Mageia_5/src/osc-0.176.0-324.1.src.rpm" baseproject="Mageia:5" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_6" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Mageia_6/src/osc-0.176.0-324.1.src.rpm" baseproject="Mageia:6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_7" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Mageia_7/src/osc-0.176.0-324.1.src.rpm" baseproject="Mageia:7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_8" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Mageia_8/src/osc-0.176.0-324.1.src.rpm" baseproject="Mageia:8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_Cauldron" version="0.176.0" release="324.40" arch="src" filename="osc-0.176.0-324.40.src.rpm" filepath="openSUSE:/Tools/Mageia_Cauldron/src/osc-0.176.0-324.40.src.rpm" baseproject="Mageia:Cauldron" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mandriva_2011" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/Mandriva_2011/src/osc-0.176.0-324.1.src.rpm" baseproject="Mandriva:2011" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_8" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/RHEL_8/src/osc-0.176.0-324.2.src.rpm" baseproject="RedHat:RHEL-8" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP1" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_12_SP1/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP3" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_12_SP3/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP4" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_12_SP4/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP5" version="0.176.0" release="324.6" arch="src" filename="osc-0.176.0-324.6.src.rpm" filepath="openSUSE:/Tools/SLE_12_SP5/src/osc-0.176.0-324.6.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Adv-Systems-Management" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_15/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP1" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_15_SP1/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP2" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/SLE_15_SP2/src/osc-0.176.0-324.1.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_15_SP3" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/SLE_15_SP3/src/osc-0.176.0-324.2.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="ScientificLinux_7" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/ScientificLinux_7/src/osc-0.176.0-324.1.src.rpm" baseproject="RedHat:RHEL-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_11.4" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_11.4/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:11.4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.1" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_12.1/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:12.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.2" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_12.2/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:12.2:ARM" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.2_ARM" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_12.2_ARM/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:12.2:ARM" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_12.3" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_12.3/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:12.3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_13.1" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_13.1/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:13.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_13.2" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_13.2/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:13.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.0" version="0.176.0" release="lp150.324.1" arch="src" filename="osc-0.176.0-lp150.324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_15.0/src/osc-0.176.0-lp150.324.1.src.rpm" baseproject="openSUSE:Leap:15.0" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.1" version="0.176.0" release="lp151.324.1" arch="src" filename="osc-0.176.0-lp151.324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_15.1/src/osc-0.176.0-lp151.324.1.src.rpm" baseproject="openSUSE:Leap:15.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.1_ports" version="0.176.0" release="lp151.324.1" arch="src" filename="osc-0.176.0-lp151.324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_15.1_ports/src/osc-0.176.0-lp151.324.1.src.rpm" baseproject="openSUSE:Leap:15.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.2" version="0.176.0" release="lp152.324.1" arch="src" filename="osc-0.176.0-lp152.324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_15.2/src/osc-0.176.0-lp152.324.1.src.rpm" baseproject="openSUSE:Leap:15.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_15.3" version="0.176.0" release="lp153.324.1" arch="src" filename="osc-0.176.0-lp153.324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_15.3/src/osc-0.176.0-lp153.324.1.src.rpm" baseproject="SUSE:SLE-15:GA" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.1" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_42.1/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:Leap:42.1" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.2" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_42.2/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:Leap:42.2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_42.3" version="0.176.0" release="324.1" arch="src" filename="osc-0.176.0-324.1.src.rpm" filepath="openSUSE:/Tools/openSUSE_42.3/src/osc-0.176.0-324.1.src.rpm" baseproject="openSUSE:Leap:42.3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/openSUSE_Factory/src/osc-0.176.0-324.2.src.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_ARM" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_ARM/src/osc-0.176.0-324.2.src.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_PPC" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_PPC/src/osc-0.176.0-324.2.src.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Factory_zSystems" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/openSUSE_Factory_zSystems/src/osc-0.176.0-324.2.src.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="openSUSE_Tumbleweed" version="0.176.0" release="324.2" arch="src" filename="osc-0.176.0-324.2.src.rpm" filepath="openSUSE:/Tools/openSUSE_Tumbleweed/src/osc-0.176.0-324.2.src.rpm" baseproject="openSUSE:Factory" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Arch" version="0.176.0" release="0" arch="x86_64" filename="osc-0.176.0-0-x86_64.pkg.tar.zst" filepath="openSUSE:/Tools/Arch/x86_64/osc-0.176.0-0-x86_64.pkg.tar.zst" baseproject="Arch:Core" type="arch"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_7" version="0.175.0" release="322.1" arch="noarch" filename="osc-0.175.0-322.1.noarch.rpm" filepath="openSUSE:/Tools/CentOS_7/noarch/osc-0.175.0-322.1.noarch.rpm" baseproject="CentOS:CentOS-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_7" version="0.175.0" release="322.1" arch="noarch" filename="osc-0.175.0-322.1.noarch.rpm" filepath="openSUSE:/Tools/RHEL_7/noarch/osc-0.175.0-322.1.noarch.rpm" baseproject="RedHat:RHEL-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_7" version="0.175.0" release="322.1" arch="src" filename="osc-0.175.0-322.1.src.rpm" filepath="openSUSE:/Tools/CentOS_7/src/osc-0.175.0-322.1.src.rpm" baseproject="CentOS:CentOS-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_7" version="0.175.0" release="322.1" arch="src" filename="osc-0.175.0-322.1.src.rpm" filepath="openSUSE:/Tools/RHEL_7/src/osc-0.175.0-322.1.src.rpm" baseproject="RedHat:RHEL-7" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Raspbian_Next" version="0.174.0" release="0" arch="all" filename="osc_0.174.0-0_all.deb" filepath="openSUSE:/Tools/Raspbian_Next/all/osc_0.174.0-0_all.deb" baseproject="Raspbian:Next" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_19.10" version="0.174.0" release="0" arch="all" filename="osc_0.174.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_19.10/all/osc_0.174.0-0_all.deb" baseproject="Ubuntu:19.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_31" version="0.174.0" release="321.1" arch="noarch" filename="osc-0.174.0-321.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_31/noarch/osc-0.174.0-321.1.noarch.rpm" baseproject="Fedora:31" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_31" version="0.174.0" release="321.1" arch="src" filename="osc-0.174.0-321.1.src.rpm" filepath="openSUSE:/Tools/Fedora_31/src/osc-0.174.0-321.1.src.rpm" baseproject="Fedora:31" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_6" version="0.173.0" release="318.1" arch="noarch" filename="osc-0.173.0-318.1.noarch.rpm" filepath="openSUSE:/Tools/Mageia_6/noarch/osc-0.173.0-318.1.noarch.rpm" baseproject="Mageia:6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Mageia_6" version="0.173.0" release="318.1" arch="src" filename="osc-0.173.0-318.1.src.rpm" filepath="openSUSE:/Tools/Mageia_6/src/osc-0.173.0-318.1.src.rpm" baseproject="Mageia:6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_19.04" version="0.172.0" release="0" arch="all" filename="osc_0.172.0-0_all.deb" filepath="openSUSE:/Tools/xUbuntu_19.04/all/osc_0.172.0-0_all.deb" baseproject="Ubuntu:19.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_8.0" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/Debian_8.0/all/osc_0.171.0_all.deb" baseproject="Debian:8.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_4.2" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/Univention_4.2/all/osc_0.171.0_all.deb" baseproject="Univention:4.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_14.04" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_14.04/all/osc_0.171.0_all.deb" baseproject="Ubuntu:14.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_14.10" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_14.10/all/osc_0.171.0_all.deb" baseproject="Ubuntu:14.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_15.04" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_15.04/all/osc_0.171.0_all.deb" baseproject="Ubuntu:15.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_15.10" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_15.10/all/osc_0.171.0_all.deb" baseproject="Ubuntu:15.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_16.04" version="0.171.0" arch="all" filename="osc_0.171.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_16.04/all/osc_0.171.0_all.deb" baseproject="Ubuntu:16.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_23" version="0.171.0" release="311.1" arch="noarch" filename="osc-0.171.0-311.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_23/noarch/osc-0.171.0-311.1.noarch.rpm" baseproject="Fedora:23" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.171.0" release="311.1" arch="noarch" filename="osc-0.171.0-311.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_29/noarch/osc-0.171.0-311.1.noarch.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_31" version="0.171.0" release="311.1" arch="noarch" filename="osc-0.171.0-311.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_31/noarch/osc-0.171.0-311.1.noarch.rpm" baseproject="Fedora:31" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_23" version="0.171.0" release="311.1" arch="src" filename="osc-0.171.0-311.1.src.rpm" filepath="openSUSE:/Tools/Fedora_23/src/osc-0.171.0-311.1.src.rpm" baseproject="Fedora:23" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.171.0" release="311.1" arch="src" filename="osc-0.171.0-311.1.src.rpm" filepath="openSUSE:/Tools/Fedora_29/src/osc-0.171.0-311.1.src.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_31" version="0.171.0" release="311.1" arch="src" filename="osc-0.171.0-311.1.src.rpm" filepath="openSUSE:/Tools/Fedora_31/src/osc-0.171.0-311.1.src.rpm" baseproject="Fedora:31" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_27" version="0.170.0" release="307.1" arch="noarch" filename="osc-0.170.0-307.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_27/noarch/osc-0.170.0-307.1.noarch.rpm" baseproject="Fedora:27" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.170.0" release="307.1" arch="noarch" filename="osc-0.170.0-307.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_28/noarch/osc-0.170.0-307.1.noarch.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.170.0" release="307.1" arch="noarch" filename="osc-0.170.0-307.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_29/noarch/osc-0.170.0-307.1.noarch.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12" version="0.170.0" release="307.1" arch="noarch" filename="osc-0.170.0-307.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_12/noarch/osc-0.170.0-307.1.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP2" version="0.170.0" release="307.1" arch="noarch" filename="osc-0.170.0-307.1.noarch.rpm" filepath="openSUSE:/Tools/SLE_12_SP2/noarch/osc-0.170.0-307.1.noarch.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_27" version="0.170.0" release="307.1" arch="src" filename="osc-0.170.0-307.1.src.rpm" filepath="openSUSE:/Tools/Fedora_27/src/osc-0.170.0-307.1.src.rpm" baseproject="Fedora:27" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.170.0" release="307.1" arch="src" filename="osc-0.170.0-307.1.src.rpm" filepath="openSUSE:/Tools/Fedora_28/src/osc-0.170.0-307.1.src.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.170.0" release="307.1" arch="src" filename="osc-0.170.0-307.1.src.rpm" filepath="openSUSE:/Tools/Fedora_29/src/osc-0.170.0-307.1.src.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12" version="0.170.0" release="307.1" arch="src" filename="osc-0.170.0-307.1.src.rpm" filepath="openSUSE:/Tools/SLE_12/src/osc-0.170.0-307.1.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_12_SP2" version="0.170.0" release="307.1" arch="src" filename="osc-0.170.0-307.1.src.rpm" filepath="openSUSE:/Tools/SLE_12_SP2/src/osc-0.170.0-307.1.src.rpm" baseproject="SUSE:SLE-12:SLE-Module-Toolchain" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.169.1" release="303.1" arch="noarch" filename="osc-0.169.1-303.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_28/noarch/osc-0.169.1-303.1.noarch.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.169.1" release="303.1" arch="noarch" filename="osc-0.169.1-303.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_29/noarch/osc-0.169.1-303.1.noarch.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.169.1" release="303.1" arch="src" filename="osc-0.169.1-303.1.src.rpm" filepath="openSUSE:/Tools/Fedora_28/src/osc-0.169.1-303.1.src.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_29" version="0.169.1" release="303.1" arch="src" filename="osc-0.169.1-303.1.src.rpm" filepath="openSUSE:/Tools/Fedora_29/src/osc-0.169.1-303.1.src.rpm" baseproject="Fedora:29" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP2" version="0.169.0" release="302.1" arch="i586" filename="osc-0.169.0-302.1.i586.rpm" filepath="openSUSE:/Tools/SLE_11_SP2/i586/osc-0.169.0-302.1.i586.rpm" baseproject="SUSE:SLE-11:SP2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP3" version="0.169.0" release="302.1" arch="i586" filename="osc-0.169.0-302.1.i586.rpm" filepath="openSUSE:/Tools/SLE_11_SP3/i586/osc-0.169.0-302.1.i586.rpm" baseproject="SUSE:SLE-11:SP3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP4" version="0.169.0" release="302.1" arch="i586" filename="osc-0.169.0-302.1.i586.rpm" filepath="openSUSE:/Tools/SLE_11_SP4/i586/osc-0.169.0-302.1.i586.rpm" baseproject="SUSE:SLE-11:SP4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_6" version="0.169.0" release="302.1" arch="noarch" filename="osc-0.169.0-302.1.noarch.rpm" filepath="openSUSE:/Tools/CentOS_6/noarch/osc-0.169.0-302.1.noarch.rpm" baseproject="CentOS:CentOS-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_6" version="0.169.0" release="302.1" arch="noarch" filename="osc-0.169.0-302.1.noarch.rpm" filepath="openSUSE:/Tools/RHEL_6/noarch/osc-0.169.0-302.1.noarch.rpm" baseproject="RedHat:RHEL-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="ScientificLinux_6" version="0.169.0" release="302.1" arch="noarch" filename="osc-0.169.0-302.1.noarch.rpm" filepath="openSUSE:/Tools/ScientificLinux_6/noarch/osc-0.169.0-302.1.noarch.rpm" baseproject="RedHat:RHEL-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP2" version="0.169.0" release="302.1" arch="ppc64" filename="osc-0.169.0-302.1.ppc64.rpm" filepath="openSUSE:/Tools/SLE_11_SP2/ppc64/osc-0.169.0-302.1.ppc64.rpm" baseproject="SUSE:SLE-11:SP2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP3" version="0.169.0" release="302.1" arch="ppc64" filename="osc-0.169.0-302.1.ppc64.rpm" filepath="openSUSE:/Tools/SLE_11_SP3/ppc64/osc-0.169.0-302.1.ppc64.rpm" baseproject="SUSE:SLE-11:SP3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP4" version="0.169.0" release="302.1" arch="ppc64" filename="osc-0.169.0-302.1.ppc64.rpm" filepath="openSUSE:/Tools/SLE_11_SP4/ppc64/osc-0.169.0-302.1.ppc64.rpm" baseproject="SUSE:SLE-11:SP4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="CentOS_6" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/CentOS_6/src/osc-0.169.0-302.1.src.rpm" baseproject="CentOS:CentOS-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="RHEL_6" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/RHEL_6/src/osc-0.169.0-302.1.src.rpm" baseproject="RedHat:RHEL-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP2" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/SLE_11_SP2/src/osc-0.169.0-302.1.src.rpm" baseproject="SUSE:SLE-11:SP2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP3" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/SLE_11_SP3/src/osc-0.169.0-302.1.src.rpm" baseproject="SUSE:SLE-11:SP3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP4" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/SLE_11_SP4/src/osc-0.169.0-302.1.src.rpm" baseproject="SUSE:SLE-11:SP4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="ScientificLinux_6" version="0.169.0" release="302.1" arch="src" filename="osc-0.169.0-302.1.src.rpm" filepath="openSUSE:/Tools/ScientificLinux_6/src/osc-0.169.0-302.1.src.rpm" baseproject="RedHat:RHEL-6" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP2" version="0.169.0" release="302.1" arch="x86_64" filename="osc-0.169.0-302.1.x86_64.rpm" filepath="openSUSE:/Tools/SLE_11_SP2/x86_64/osc-0.169.0-302.1.x86_64.rpm" baseproject="SUSE:SLE-11:SP2" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP3" version="0.169.0" release="302.1" arch="x86_64" filename="osc-0.169.0-302.1.x86_64.rpm" filepath="openSUSE:/Tools/SLE_11_SP3/x86_64/osc-0.169.0-302.1.x86_64.rpm" baseproject="SUSE:SLE-11:SP3" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="SLE_11_SP4" version="0.169.0" release="302.1" arch="x86_64" filename="osc-0.169.0-302.1.x86_64.rpm" filepath="openSUSE:/Tools/SLE_11_SP4/x86_64/osc-0.169.0-302.1.x86_64.rpm" baseproject="SUSE:SLE-11:SP4" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_7.0" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/Debian_7.0/all/osc_0.167.2_all.deb" baseproject="Debian:7.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_4.0" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/Univention_4.0/all/osc_0.167.2_all.deb" baseproject="Univention:4.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_4.1" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/Univention_4.1/all/osc_0.167.2_all.deb" baseproject="Univention:4.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_12.04" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/xUbuntu_12.04/all/osc_0.167.2_all.deb" baseproject="Ubuntu:12.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_12.10" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/xUbuntu_12.10/all/osc_0.167.2_all.deb" baseproject="Ubuntu:12.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_13.04" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/xUbuntu_13.04/all/osc_0.167.2_all.deb" baseproject="Ubuntu:13.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_Next" version="0.167.2" arch="all" filename="osc_0.167.2_all.deb" filepath="openSUSE:/Tools/xUbuntu_Next/all/osc_0.167.2_all.deb" baseproject="Ubuntu:Next" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.167.2" release="282.1" arch="noarch" filename="osc-0.167.2-282.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_28/noarch/osc-0.167.2-282.1.noarch.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_28" version="0.167.2" release="282.1" arch="src" filename="osc-0.167.2-282.1.src.rpm" filepath="openSUSE:/Tools/Fedora_28/src/osc-0.167.2-282.1.src.rpm" baseproject="Fedora:28" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Debian_6.0" version="0.165.4" arch="all" filename="osc_0.165.4_all.deb" filepath="openSUSE:/Tools/Debian_6.0/all/osc_0.165.4_all.deb" baseproject="Debian:6.0" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Univention_3.1" version="0.165.4" arch="all" filename="osc_0.165.4_all.deb" filepath="openSUSE:/Tools/Univention_3.1/all/osc_0.165.4_all.deb" baseproject="Univention:3.1" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_Next" version="0.165.0" arch="all" filename="osc_0.165.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_Next/all/osc_0.165.0_all.deb" baseproject="Ubuntu:Next" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_27" version="0.164.2" release="245.1" arch="noarch" filename="osc-0.164.2-245.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_27/noarch/osc-0.164.2-245.1.noarch.rpm" baseproject="Fedora:27" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_27" version="0.164.2" release="245.1" arch="src" filename="osc-0.164.2-245.1.src.rpm" filepath="openSUSE:/Tools/Fedora_27/src/osc-0.164.2-245.1.src.rpm" baseproject="Fedora:27" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_25" version="0.164.0" release="241.1" arch="noarch" filename="osc-0.164.0-241.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_25/noarch/osc-0.164.0-241.1.noarch.rpm" baseproject="Fedora:25" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_26" version="0.164.0" release="241.1" arch="noarch" filename="osc-0.164.0-241.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_26/noarch/osc-0.164.0-241.1.noarch.rpm" baseproject="Fedora:26" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_25" version="0.164.0" release="241.1" arch="src" filename="osc-0.164.0-241.1.src.rpm" filepath="openSUSE:/Tools/Fedora_25/src/osc-0.164.0-241.1.src.rpm" baseproject="Fedora:25" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_26" version="0.164.0" release="241.1" arch="src" filename="osc-0.164.0-241.1.src.rpm" filepath="openSUSE:/Tools/Fedora_26/src/osc-0.164.0-241.1.src.rpm" baseproject="Fedora:26" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_16.10" version="0.162.1" arch="all" filename="osc_0.162.1_all.deb" filepath="openSUSE:/Tools/xUbuntu_16.10/all/osc_0.162.1_all.deb" baseproject="Ubuntu:16.10" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_23" version="0.162.1" release="230.1" arch="noarch" filename="osc-0.162.1-230.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_23/noarch/osc-0.162.1-230.1.noarch.rpm" baseproject="Fedora:23" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_24" version="0.162.1" release="230.1" arch="noarch" filename="osc-0.162.1-230.1.noarch.rpm" filepath="openSUSE:/Tools/Fedora_24/noarch/osc-0.162.1-230.1.noarch.rpm" baseproject="Fedora:24" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_23" version="0.162.1" release="230.1" arch="src" filename="osc-0.162.1-230.1.src.rpm" filepath="openSUSE:/Tools/Fedora_23/src/osc-0.162.1-230.1.src.rpm" baseproject="Fedora:23" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="Fedora_24" version="0.162.1" release="230.1" arch="src" filename="osc-0.162.1-230.1.src.rpm" filepath="openSUSE:/Tools/Fedora_24/src/osc-0.162.1-230.1.src.rpm" baseproject="Fedora:24" type="rpm"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_10.04" version="0.155.1" arch="all" filename="osc_0.155.1_all.deb" filepath="openSUSE:/Tools/xUbuntu_10.04/all/osc_0.155.1_all.deb" baseproject="Ubuntu:10.04" type="deb"/>
+          <binary name="osc" project="openSUSE:Tools" package="osc" repository="xUbuntu_13.10" version="0.154.0" arch="all" filename="osc_0.154.0_all.deb" filepath="openSUSE:/Tools/xUbuntu_13.10/all/osc_0.154.0_all.deb" baseproject="Ubuntu:13.10" type="deb"/>
+        </collection>
+  recorded_at: Fri, 25 Mar 2022 21:27:14 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
We broke the json output of for example `/download/package.json?package=osc&project=openSUSE%3ATools`, this fixes it.