### PR TITLE
Update openSUSE Leap 15.3 distibution ID

### DIFF
--- a/app/controllers/obs_controller.rb
+++ b/app/controllers/obs_controller.rb
@@ -87,7 +87,7 @@ class ObsController < ApplicationController
         # one off exception for Leap 15.3, which switched it's default
         # repository name from openSUSE_Leap_15.3 to 15.3
         elsif package.repository == 'openSUSE_Leap_15.3'
-          leap153 = @distributions.find { |d| d[:dist_id] == '19032' }
+          leap153 = @distributions.find { |d| d[:dist_id] == '20043' }
           next unless leap153
 
           package.baseproject = leap153[:project]

--- a/config/initializers/distributions_projects.rb
+++ b/config/initializers/distributions_projects.rb
@@ -3,7 +3,7 @@
 # maps a distro_id to an Array of project names that could be the baseproject
 DISTRIBUTION_PROJECTS_OVERRIDE = {
   # Leap 15.3
-  '19032' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:GA',
+  '20043' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:GA',
               'SUSE:SLE-15-SP1:Update', 'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP2:Update',
               'SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP3:Update', 'openSUSE:Leap:15.3', 'openSUSE:Backports:SLE-15-SP3']
 }.freeze


### PR DESCRIPTION
Distribution ID changed from 19032 to 20043. I do not know why, may be
due to respin. This broke search for Leap 15.3 packages.

$ osc api -X GET /public/distributions | grep -FA 9 'distribution vendor="openSUSE" version="15.3"'
  <distribution vendor="openSUSE" version="15.3" id="20043">
    <name>openSUSE Leap 15.3</name>
    <project>openSUSE:Leap:15.3</project>
    <reponame>15.3</reponame>
    <repository>standard</repository>
    <link>http://www.opensuse.org/</link>
    <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
    <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
    <architecture>x86_64</architecture>
  </distribution>
$

---

Fixes #1101

- [ ] I've included before / after screenshots or did not change the UI
