### PR TITLE
Remove pattern support from download section

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,10 +93,6 @@ class ApplicationController < ActionController::Base
     name =~ /^[[:alnum:]][-+~\w.:@]*$/
   end
 
-  def valid_pattern_name?(name)
-    name =~ /^[[:alnum:]][-_+\w.:]*$/
-  end
-
   def valid_project_name?(name)
     name =~ /^[[:alnum:]][-+\w.:]+$/
   end

--- a/app/views/download/doc.erb
+++ b/app/views/download/doc.erb
@@ -26,12 +26,6 @@
 
 <iframe src="<%= url_for :controller => :download, :action => :package, :project => "openSUSE:Tools", :package => "osc", :format => "iframe", :protocol => "https" %>" width="100%" height="700px" frameBorder="0" ></iframe>
 
-<h3>Creating a download page for a pattern</h3>
-
-<p>Linking to a pattern is similar to the way described above for a package, just change the url to use <i>pattern</i>:</p>
-
-<pre>https://software.opensuse.org/download/pattern?project=<b>&lt;projectname&gt;</b>&amp;pattern=<b>&lt;patternname&gt;</b></pre>
-
 <h3>Creating a download page for an appliance</h3>
 
 <p>If your OBS project is building appliances, you can also link to those with: </p>

--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -3,12 +3,11 @@
 <div class="container" id="content">
 <div class="soo_download_#{@project}_#{@package}">
    <% if @data.blank? %>
-   <h1 class="my-5"><%= _("No data for %s / %s") % [ @project, @package.nil? ? @pattern : @package] %></h1>
+   <h1 class="my-5"><%= _("No data for %s / %s") % [ @project, @package] %></h1>
    <% else %>
    <% unless @flavors.blank? %>
      <h1 class="font-weight-normal">
-       <% package = @package.nil? ? @pattern : @package %>
-       <%= _("<b>#{package}</b> from <b>#{project_url(@project)}</b> project") %></h1>
+       <%= _("<b>#{@package}</b> from <b>#{project_url(@project)}</b> project") %></h1>
    <h2 class="my-4"><%= _("Select Your Operating System") %></h2>
    <div class="row py-3">
       <% @flavors.each do |flavor| %>
@@ -69,11 +68,7 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
                   <pre><%=
                      case v[:flavor]
                      when 'openSUSE', 'SLE'
-                       if @package.nil?
-                         "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install -t pattern #{@pattern}"
-                       else
                          "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install #{@package}"
-                       end
                      when 'Fedora'
                        version = k.split("_").last
                        if version == "Rawhide" or Integer(version) >= 22
@@ -128,7 +123,7 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
    </div>
 </div>
 <% else %>
-<p><%= _("No downloads found for %s in project %s") % [ @package.nil? ? @pattern : @package, @project] %>.</p>
+<p><%= _("No downloads found for %s in project %s") % [ @package, @project] %>.</p>
 <% end %>
 <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,9 @@ Rails.application.routes.draw  do
   namespace 'download' do
     get 'appliance', constraints: ->(request) { request.params[:project].present? }
     get 'package', constraints: ->(request) { request.params[:project].present? && request.params[:package].present? }
-    get 'pattern', constraints: ->(request) { request.params[:project].present? && request.params[:pattern].present? }
 
     # Show documentation if contraints are not met
-    %w(doc appliance package pattern).each do |path|
+    %w(doc appliance package).each do |path|
       get path, action: :doc
     end
   end


### PR DESCRIPTION
Probing osc, it seems pattern objects are no longer a type of binary OBS recognizes or it stopped being utilized. In any case, it seems we don't need this code anymore.

---

Fixes #1162

- [x] I've included before / after screenshots or did not change the UI
