### PR TITLE
Use the correct ruby version in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from: .rubocop_todo.yml
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - 'bin/*'


### PR DESCRIPTION
We were using 2.5, while we are on 3.1