### PR TITLE
Remove one click install buttons from official packages

### DIFF
--- a/app/views/package/_download_rows.html.erb
+++ b/app/views/package/_download_rows.html.erb
@@ -43,11 +43,13 @@
         <%  archs << _("Source") if archs.delete(_("Source")) %>
 
         <!-- 1-click install button -->
-        <% if oneclick && distro[:project].match(/SUSE/) && !(archs.uniq == [_("Source")]) %>
-          <% url = url_for :controller => 'download', :action => 'ymp_without_arch_and_version',
-            :project => result.first, :repository => result.last.first.repository, :package => @pkgname,
-            :base => result.last.first.baseproject, :query => @pkgname%>
-          <a class="btn btn-sm btn-primary" href="<%= url %>"><%= icon "oci", "1.15em" %> <%= _("1 Click Install") %></a>
+        <% unless type.eql? 'official' %>
+          <% if oneclick && distro[:project].match(/SUSE/) && !(archs.uniq == [_("Source")]) %>
+            <% url = url_for :controller => 'download', :action => 'ymp_without_arch_and_version',
+              :project => result.first, :repository => result.last.first.repository, :package => @pkgname,
+              :base => result.last.first.baseproject, :query => @pkgname%>
+            <a class="btn btn-sm btn-primary" href="<%= url %>"><%= icon "oci", "1.15em" %> <%= _("1 Click Install") %></a>
+          <% end %>
         <% end %>
 
         <% project = result.last.first.fetch("realproject", result.first) %>

--- a/app/views/package/show.html.erb
+++ b/app/views/package/show.html.erb
@@ -51,15 +51,12 @@
             </ul>
             <% if @appid && @baseproject != "ALL" %>
             <div>
-                <a id="appstream-button" class="btn" href="appstream://<%= @appid %>">
-                    <img class="typcn" src="<%= image_path('appstream-button1.svg') %>" width="177" height="51" alt="AppStream" />
+                <a id="appstream-button" class="btn btn-lg btn-primary" href="appstream://<%= @appid %>">
+                  <%= icon "oci" %>
+                  <%= _("Appstream Install") %>
                 </a>
             </div>
             <% end %>
-            <a id="one-click-button" class="btn btn-lg btn-primary" href="<%= url %>">
-              <%= icon "oci" %>
-              <%= _("Direct Install") %>
-            </a>
 
             <%= link_to download_package_path(project: @default_package.project, package: @pkgname), class: 'btn btn-lg btn-secondary' do %>
               <%= icon "download" %>


### PR DESCRIPTION
Stops displaying one click install buttons on official packages, falling back to appstream and instructions in expert downloads.