### PR TITLE
Change OpenSUSE Leap 15.3 Distribution ID

### DIFF
--- a/config/initializers/distributions_projects.rb
+++ b/config/initializers/distributions_projects.rb
@@ -3,7 +3,7 @@
 # maps a distro_id to an Array of project names that could be the baseproject
 DISTRIBUTION_PROJECTS_OVERRIDE = {
   # Leap 15.3
-  '20043' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:GA',
+  '20452' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:GA',
               'SUSE:SLE-15-SP1:Update', 'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP2:Update',
               'SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP3:Update', 'openSUSE:Leap:15.3', 'openSUSE:Backports:SLE-15-SP3']
 }.freeze


### PR DESCRIPTION
Distro ID changed from 20043 to 20452, this has broken the OpenSUSE Leap 15.3 package browser again.

Look:

![Captura](https://user-images.githubusercontent.com/61781343/169255000-7fdd8df0-b555-4213-b777-14e91810e391.PNG)




---

Fixes #

- [x] I've included before / after screenshots or did not change the UI
