### PR TITLE
download/doc: fixed syntax to allow page being rendered

### DIFF
--- a/app/views/download/doc.html.haml
+++ b/app/views/download/doc.html.haml
@@ -65,13 +65,13 @@
                    project: 'openSUSE:Tools', package: 'osc', only_path: false
   %h3= _('Theming')
   %p
-    = _('To customize the theming of the download page, you have multiple |
-        options to change the colors.') |
-    - params = _('Use the parameters **bcolor** (background), **fcolor** |
-                  (foreground), **acolor** (links) and **hcolor** (hover) to |
-                  set the different colors.') |
-    :markdown
-      #{params}
+    = _('To customize the theming of the download page, you have multiple options to change the colors.')
+    %span
+      - params = _('Use the parameters **bcolor** (background), **fcolor** |
+                    (foreground), **acolor** (links) and **hcolor** (hover) to |
+                    set the different colors.') |
+      :markdown
+        #{params}
   %p
     = _('Example:')
     - custom_iframe = url_for(controller: :download, action: :appliance,


### PR DESCRIPTION
currently https://<instance>/download/doc fails with the error:
    undefined method `-' for "To customize the theming of the download
    page, you have multiple options to change the colors.
    ":ActiveSupport::SafeBuffer Did you mean? -@
this commit addresses this flaw by putting the rendered markdown in its
own seperate span, because the parser has seemingly issues with
multiline-haml (avoiding multiline in the first string [To customize..]
is an alternative solution that would also fix it).




---

Fixes #

- [ ] I've included before / after screenshots or did not change the UI
