### PR TITLE
Place AlmaLinux and Rocky Linux under RHEL

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -129,7 +129,7 @@ class DownloadController < ApplicationController
       'SLE'
     when /^(DISCONTINUED:)?Fedora:/
       'Fedora'
-    when /^(DISCONTINUED:)?RedHat:RHEL-/
+    when /^(DISCONTINUED:)?(RedHat:RHEL-|AlmaLinux:|RockyLinux:)/
       'RHEL'
     when /^(DISCONTINUED:)?ScientificLinux:/
       'SL'


### PR DESCRIPTION
This pull request puts Alma and Rocky Linux downloads under "RHEL". If you prefer new flavors, I could create pull requests similar to 2ab2b8ca69a8f5a8fb4e6f56f998568c3ff8468b for Raspbian, but that would add two new flavors to an ever-growing list of distributions in the user interface.

![grafik](https://user-images.githubusercontent.com/1150045/188913089-63136114-eccf-4ada-93f0-a4df3b920f24.png)

---

Fixes #1253

- [X] I've included before / after screenshots or did not change the UI
