### PR TITLE
Use dependabot to keep github actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependabot - GitHub Actions"


### PR DESCRIPTION
It is easy to forget to keep our github actions up to date, like now where node.js 12 actions are going to be deprecated. Let Dependabot take care of this.

TODO: After this is merged create a label in the repo called `Dependabot - GitHub Actions`
