### PR TITLE
Add missing repositories to the download page

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -59,9 +59,11 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
                   <h5><%= (_("For <strong>%s</strong> run the following:") % k.gsub('_', '&nbsp;').html_safe).html_safe %></h5>
                   <h6><%= (_("Keep in mind that the owner of the key may distribute updates, packages and repositories that your system will trust (<a href=\"%s\">more information</a>).") % secure_apt_url).html_safe %></h6>
                   <pre><%=
+                     package_names = v.fetch(:package, {}).keys.collect { |name| name.slice(0, name.index('_')) }.sort.uniq
+                     install_cmds = package_names.collect { |name| "sudo apt install #{name}" }.join("\n")
                      # don't use apt-add-repository wrapper for Ubuntu for now, because it adds source repo which we don't provide
                      #        "apt-add-repository deb #{v[:repo]} /\napt-get update\napt-get install #{@package}"
-                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\ncurl -fsSL #{v[:repo]}Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/#{@project.gsub(':', '_')}.gpg > /dev/null\nsudo apt update\nsudo apt install #{@package}"
+                     "echo 'deb #{v[:repo].gsub(/(\w):(\w)/, '\1:/\2').gsub(/^https/, 'http')} /' | sudo tee /etc/apt/sources.list.d/#{@project}.list\ncurl -fsSL #{v[:repo]}Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/#{@project.gsub(':', '_')}.gpg > /dev/null\nsudo apt update\n#{install_cmds}"
                      %></pre>
                   <% else %>
                   <h5><%= (_("For <strong>%s</strong> run the following as <strong>root</strong>:") % k.gsub('_', '&nbsp;').html_safe).html_safe %></h5>


### PR DESCRIPTION
Repositories without a package whose name matches the OBS package name are currently not added to the download page. Debian package names sometimes differ from RPM package names. For example, perl-URI is named liburi-perl on Debian-based systems.

This pull request makes the following modifications:

1. The API request fetches all binaries as mentioned in #1036.
2. As before repositories with a package whose name matches the OBS package name are added to the download page. Nothing changes for these repositories. As before only the matching package is added.
3. Additionally, the repositories that weren't added in the previous step are added to the download page.
4. The Debian section in the ERB template outputs the Debian package name instead of the OBS package name.

### Screenshots

Source: https://software.opensuse.org//download.html?project=home%3Avoegelas&package=perl-CPANPLUS-Dist-Debora

#### Current download page _without_ Debian repositories

![grafik](https://user-images.githubusercontent.com/1150045/233337933-1f50d83d-c8cf-45fc-96b9-89f59af56e7e.png)

#### New download page _with_ Debian repositories

![grafik](https://user-images.githubusercontent.com/1150045/233338074-ae61aaa1-410e-45e3-a247-80deefbe05cb.png)

---

- [X] I've included before / after screenshots or did not change the UI


