### PR TITLE
Update openSUSE Leap distribution id prior to 15.6

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,13 +81,16 @@ class ApplicationController < ActionController::Base
         if repo
           package.realproject = package.project
           package.baseproject = repo[:project]
-        # one off exception for Leap 15.3, which switched it's default
-        # repository name from openSUSE_Leap_15.3 to 15.3
-        elsif package.repository == 'openSUSE_Leap_15.3'
-          leap153 = @distributions.find { |d| d[:dist_id] == '20043' }
-          next unless leap153
+        elsif package.repository == 'openSUSE_Leap_15.4'
+          leap154 = @distributions.find { |d| d[:dist_id] == '23178' }
+          next unless leap154
 
-          package.baseproject = leap153[:project]
+          package.baseproject = leap154[:project]
+        elsif package.repository == 'openSUSE_Leap_15.5'
+          leap155 = @distributions.find { |d| d[:dist_id] == '23175' }
+          next unless leap155
+
+          package.baseproject = leap155[:project]
         end
       end
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -74,6 +74,6 @@ class SearchController < ApplicationController
   private
 
   def baseproject_not_canonical?
-    ['SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP1:GA', 'openSUSE:Leap:15.3'].include?(@baseproject)
+    ['openSUSE:Leap:15.5', 'openSUSE:Leap:15.4'].include?(@baseproject)
   end
 end

--- a/config/initializers/distributions_projects.rb
+++ b/config/initializers/distributions_projects.rb
@@ -2,8 +2,19 @@
 
 # maps a distro_id to an Array of project names that could be the baseproject
 DISTRIBUTION_PROJECTS_OVERRIDE = {
-  # Leap 15.3
-  '20452' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:GA',
-              'SUSE:SLE-15-SP1:Update', 'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP2:Update',
-              'SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP3:Update', 'openSUSE:Leap:15.3', 'openSUSE:Backports:SLE-15-SP3']
+  # Leap 15.4
+  '23178' => ['SUSE:SLE-15:GA', 'SUSE:SLE-15:Update',
+              'SUSE:SLE-15-SP1:GA', 'SUSE:SLE-15-SP1:Update',
+              'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP2:Update',
+              'SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP3:Update',
+              'SUSE:SLE-15-SP4:GA', 'SUSE:SLE-15-SP4:Update',
+              'openSUSE:Backports:SLE-15-SP4', 'openSUSE:Leap:15.4'],
+  # Leap 15.5
+  '23175' => ['SUSE:SLE-15:GA','SUSE:SLE-15:Update',
+              'SUSE:SLE-15-SP1:GA','SUSE:SLE-15-SP1:Update',
+              'SUSE:SLE-15-SP2:GA', 'SUSE:SLE-15-SP2:Update',
+              'SUSE:SLE-15-SP3:GA', 'SUSE:SLE-15-SP3:Update',
+              'SUSE:SLE-15-SP4:GA', 'SUSE:SLE-15-SP4:Update',
+              'SUSE:SLE-15-SP5:GA', 'SUSE:SLE-15-SP5:Update',
+              'openSUSE:Backports:SLE-15-SP5', 'openSUSE:Leap:15.5']
 }.freeze


### PR DESCRIPTION
Add openSUSE Leap 15.4 and 15.5 distribution id, and removed EOL'ed Leap 15.3. This change also limits the canonical projects to Leap only as it was the only official distribution doesn't have a dedicated baseproject for providing the package.

With this change, Leap 15.4 and 15.5's package will be marked as **official release** package in the right distribution box, no longer be dispatch to **unsupported distribution**.

![scrnli_2023_11_7 下午10-09-05](https://github.com/openSUSE/software-o-o/assets/417859/d6784b4e-0def-426c-95e1-877fc5c220c1)
