### PR TITLE
New dnf config-manager syntax

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -71,7 +71,9 @@ pacman -Sy <%= repo_name %>/<%= @package %></pre>
                          "zypper addrepo #{v[:repo]}#{@project}.repo\nzypper refresh\nzypper install #{@package}"
                      when 'Fedora'
                        version = k.split("_").last
-                       if version == "Rawhide" or Integer(version) >= 22
+                       if version == "Rawhide" or Integer(version) >= 41
+                         "dnf config-manager addrepo --from-repofile=#{v[:repo]}#{@project}.repo\ndnf install #{@package}"
+                       elsif Integer(version) >= 22
                          "dnf config-manager --add-repo #{v[:repo]}#{@project}.repo\ndnf install #{@package}"
                        else
                          "cd /etc/yum.repos.d/\nwget #{v[:repo]}#{@project}.repo\nyum install #{@package}"


### PR DESCRIPTION
Fedora 41 and Rawhide changed the package manager [from dnf to dnf5](https://fedoraproject.org/wiki/Changes/SwitchToDnf5). The `dnf config-manager` command's syntax changed. See  [dnf5-config-manager(8)](https://manpages.opensuse.org/Tumbleweed/dnf5-plugins/dnf5-config-manager.8.en.html) and [dnf-config-manager(8)](https://manpages.opensuse.org/Tumbleweed/man-pages-de/dnf-config-manager.8.de.html) for the differences.

This commit changes the download instructions for Fedora Rawhide, 41 and above. Here's a screenshot:

![grafik](https://github.com/user-attachments/assets/b10f0403-db9d-41ab-89ca-ff7546b1bf5c)

---

- [X] I've included before / after screenshots or did not change the UI
