### PR TITLE
Remove `pacman-key --init` from the instructions

### DIFF
--- a/app/views/download/package.erb
+++ b/app/views/download/package.erb
@@ -50,7 +50,6 @@ Server = <%= v[:repo].gsub(/(\w):(\w)/, '\1:/\2') %>$arch
 key=$(curl -fsSL <%= "#{v[:repo]}$(uname -m)/#{repo_name}.key" %>)
 fingerprint=$(gpg --quiet --with-colons --import-options show-only --import --fingerprint &lt;&lt;&lt; "${key}" | awk -F: '$1 == "fpr" { print $10 }')
 
-pacman-key --init
 pacman-key --add - &lt;&lt;&lt; "${key}"
 pacman-key --lsign-key "${fingerprint}"
 


### PR DESCRIPTION
Removing this instruction is crucial because it wrongly resets the archlinux pacman database.
If one resets the database via `pacman --init` they have to repopulate again all the keys used to sign all packages (this is done only once at installation). Those instructions are missing here and since it is unnecessary, the line should be removed.





---

- [x] I've included before / after screenshots or **did not change the UI**
