### PR TITLE
download: map x<distro> to <distro>

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -113,7 +113,8 @@ class DownloadController < ApplicationController
   def get_project(distro, baseproject)
     project = baseproject
     unless @distributions.nil?
-      distribution = @distributions.find { |d| d[:reponame] == distro }
+      # On OBS "Ubuntu" is sometimes recorded as "xUbuntu"
+      distribution = @distributions.find { |d| [distro, "x#{distro}"].include?(d[:reponame]) }
       unless distribution.nil?
         project = distribution[:project]
       end


### PR DESCRIPTION
Ubuntu base repositories on OBS are called xUbuntu for some reason. If a project uses the normal Ubuntu name to avoid confusion, the download.o.o page fails to associate it and shows a question mark instead of the instructions to set up the repository.

e.g.:

https://software.opensuse.org/download.html?project=system%3Asystemd&package=systemd https://build.opensuse.org/projects/system:systemd/meta

```
$ osc api "/public/distributions"
<...>
  <distribution vendor="Ubuntu" version="26.04" id="28990">
    <name>Ubuntu 26.04</name>
    <project>Ubuntu:26.04</project>
    <reponame>xUbuntu_26.04</reponame>
    <repository>universe</repository>
    <link>http://www.ubuntu.com/</link>
    <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
    <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
    <architecture>x86_64</architecture>
  </distribution>
<...>
```

<img width="1069" height="227" alt="image" src="https://github.com/user-attachments/assets/ee0c5423-e751-403a-92b6-c998d0ca50c5" />
